### PR TITLE
Fixes for touch interface on push-to-talk button

### DIFF
--- a/src/room/PTTButton.tsx
+++ b/src/room/PTTButton.tsx
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState, createRef } from "react";
 import classNames from "classnames";
 
 import styles from "./PTTButton.module.css";
@@ -48,7 +48,7 @@ export const PTTButton: React.FC<Props> = ({
   startTalking,
   stopTalking,
 }) => {
-  const buttonRef = React.createRef<HTMLButtonElement>();
+  const buttonRef = createRef<HTMLButtonElement>();
 
   const [{ isHeld, activeTouchID }, setState] = useState<State>({
     isHeld: false,


### PR DESCRIPTION
 * Avoid also getting a 'mousedown' event by making the event listener
   non-passive so the preventDefault() works
 * Remember the touch that pressed the button so we only un-press
   when that touch ends, otherwise the button gets released if the
   user taps the screen anywhere else.