### PR TITLE
Bump js-sdk dependency to encrypt to-device messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "color-hash": "^2.0.1",
     "events": "^3.3.0",
     "lodash-move": "^1.1.1",
-    "matrix-js-sdk": "github:matrix-org/matrix-js-sdk#acef1d7dd0b915368730efabee94deb42b2e4058",
+    "matrix-js-sdk": "github:matrix-org/matrix-js-sdk#942a28ddf69ec25e1af9075be53f355c222597b3",
     "mermaid": "^8.13.8",
     "normalize.css": "^8.0.1",
     "pako": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "color-hash": "^2.0.1",
     "events": "^3.3.0",
     "lodash-move": "^1.1.1",
-    "matrix-js-sdk": "github:matrix-org/matrix-js-sdk#942a28ddf69ec25e1af9075be53f355c222597b3",
+    "matrix-js-sdk": "github:matrix-org/matrix-js-sdk#aa0d3bd1f5a006d151f826e6b8c5f286abb6e960",
     "mermaid": "^8.13.8",
     "normalize.css": "^8.0.1",
     "pako": "^2.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8599,9 +8599,9 @@ matrix-events-sdk@^0.0.1-beta.7:
   resolved "https://registry.yarnpkg.com/matrix-events-sdk/-/matrix-events-sdk-0.0.1-beta.7.tgz#5ffe45eba1f67cc8d7c2377736c728b322524934"
   integrity sha512-9jl4wtWanUFSy2sr2lCjErN/oC8KTAtaeaozJtrgot1JiQcEI4Rda9OLgQ7nLKaqb4Z/QUx/fR3XpDzm5Jy1JA==
 
-"matrix-js-sdk@github:matrix-org/matrix-js-sdk#acef1d7dd0b915368730efabee94deb42b2e4058":
+"matrix-js-sdk@github:matrix-org/matrix-js-sdk#942a28ddf69ec25e1af9075be53f355c222597b3":
   version "17.2.0"
-  resolved "https://codeload.github.com/matrix-org/matrix-js-sdk/tar.gz/acef1d7dd0b915368730efabee94deb42b2e4058"
+  resolved "https://codeload.github.com/matrix-org/matrix-js-sdk/tar.gz/942a28ddf69ec25e1af9075be53f355c222597b3"
   dependencies:
     "@babel/runtime" "^7.12.5"
     another-json "^0.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8599,9 +8599,9 @@ matrix-events-sdk@^0.0.1-beta.7:
   resolved "https://registry.yarnpkg.com/matrix-events-sdk/-/matrix-events-sdk-0.0.1-beta.7.tgz#5ffe45eba1f67cc8d7c2377736c728b322524934"
   integrity sha512-9jl4wtWanUFSy2sr2lCjErN/oC8KTAtaeaozJtrgot1JiQcEI4Rda9OLgQ7nLKaqb4Z/QUx/fR3XpDzm5Jy1JA==
 
-"matrix-js-sdk@github:matrix-org/matrix-js-sdk#942a28ddf69ec25e1af9075be53f355c222597b3":
+"matrix-js-sdk@github:matrix-org/matrix-js-sdk#aa0d3bd1f5a006d151f826e6b8c5f286abb6e960":
   version "17.2.0"
-  resolved "https://codeload.github.com/matrix-org/matrix-js-sdk/tar.gz/942a28ddf69ec25e1af9075be53f355c222597b3"
+  resolved "https://codeload.github.com/matrix-org/matrix-js-sdk/tar.gz/aa0d3bd1f5a006d151f826e6b8c5f286abb6e960"
   dependencies:
     "@babel/runtime" "^7.12.5"
     another-json "^0.2.0"


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-call/issues/257