### PR TITLE
Fix soft crash when opening invite modal in lobby

### DIFF
--- a/src/room/LobbyView.jsx
+++ b/src/room/LobbyView.jsx
@@ -95,6 +95,7 @@ export function LobbyView({
             <VideoPreview
               state={state}
               client={client}
+              roomId={roomId}
               microphoneMuted={microphoneMuted}
               localVideoMuted={localVideoMuted}
               toggleLocalVideoMuted={toggleLocalVideoMuted}


### PR DESCRIPTION
It was exploding on `roomId` being `undefined`.