### PR TITLE
Fix crash when setting audio output on Chrome for Android

### DIFF
--- a/src/video-grid/useMediaStream.js
+++ b/src/video-grid/useMediaStream.js
@@ -55,7 +55,8 @@ export function useMediaStream(stream, audioOutputDevice, mute = false) {
       mediaRef.current !== undefined
     ) {
       console.log(`useMediaStream setSinkId ${audioOutputDevice}`);
-      mediaRef.current.setSinkId(audioOutputDevice);
+      // Chrome for Android doesn't support this
+      mediaRef.current.setSinkId?.(audioOutputDevice);
     }
   }, [audioOutputDevice]);
 


### PR DESCRIPTION
According to https://github.com/vector-im/element-call/issues/364 Chrome only offers a single choice of audio output, so it's probably still fine to lie to the user and show the dropdown?

Closes https://github.com/vector-im/element-call/issues/364