### PR TITLE
'Webcam' → 'Camera'

### DIFF
--- a/src/room/VideoPreview.jsx
+++ b/src/room/VideoPreview.jsx
@@ -50,13 +50,13 @@ export function VideoPreview({
     <div className={styles.preview} ref={previewRef}>
       <video ref={videoRef} muted playsInline disablePictureInPicture />
       {state === GroupCallState.LocalCallFeedUninitialized && (
-        <Body fontWeight="semiBold" className={styles.webcamPermissions}>
-          Webcam/microphone permissions needed to join the call.
+        <Body fontWeight="semiBold" className={styles.cameraPermissions}>
+          Camera/microphone permissions needed to join the call.
         </Body>
       )}
       {state === GroupCallState.InitializingLocalCallFeed && (
-        <Body fontWeight="semiBold" className={styles.webcamPermissions}>
-          Accept webcam/microphone permissions to join the call.
+        <Body fontWeight="semiBold" className={styles.cameraPermissions}>
+          Accept camera/microphone permissions to join the call.
         </Body>
       )}
       {state === GroupCallState.LocalCallFeedInitialized && (

--- a/src/room/VideoPreview.module.css
+++ b/src/room/VideoPreview.module.css
@@ -29,7 +29,7 @@
   background-color: var(--bgColor3);
 }
 
-.webcamPermissions {
+.cameraPermissions {
   position: absolute;
   top: 50%;
   left: 50%;

--- a/src/settings/SettingsModal.jsx
+++ b/src/settings/SettingsModal.jsx
@@ -103,7 +103,7 @@ export const SettingsModal = (props) => {
           }
         >
           <SelectInput
-            label="Webcam"
+            label="Camera"
             selectedKey={videoInput}
             onSelectionChange={setVideoInput}
           >


### PR DESCRIPTION
I'm pretty sure this is a design call we can just make, since the well-defined parts of the designs only ever use the word 'camera', never 'webcam'.

Closes https://github.com/vector-im/element-call/issues/344