### PR TITLE
Add config param to disable e2e for signalling

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "classnames": "^2.3.1",
     "color-hash": "^2.0.1",
     "events": "^3.3.0",
-    "matrix-js-sdk": "github:matrix-org/matrix-js-sdk#e980c889016b48268031b22735e70b7f618e219c",
+    "matrix-js-sdk": "github:matrix-org/matrix-js-sdk#9a15094374f52053ca9f833269d2b1c6c7f964d2",
     "mermaid": "^8.13.8",
     "normalize.css": "^8.0.1",
     "pako": "^2.0.4",

--- a/src/matrix-utils.ts
+++ b/src/matrix-utils.ts
@@ -14,6 +14,7 @@ import {
   GroupCallType,
 } from "matrix-js-sdk/src/webrtc/groupCall";
 import { ISyncStateData, SyncState } from "matrix-js-sdk/src/sync";
+import { logger } from "matrix-js-sdk/src/logger";
 
 import IndexedDBWorker from "./IndexedDBWorker?worker";
 
@@ -79,6 +80,19 @@ export async function initClient(
     storeOpts.cryptoStore = new MemoryCryptoStore();
   }
 
+  // XXX: we read from the URL search params in RoomPage too:
+  // it would be much better to read them in one place and pass
+  // the values around, but we initialise the matrix client in
+  // many different places so we'd have to pass it into all of
+  // them.
+  const params = new URLSearchParams(window.location.search);
+  // disable e2e only if enableE2e=false is given
+  const enableE2e = !(params.get("enableE2e") === "false");
+
+  if (!enableE2e) {
+    logger.info("Disabling E2E: group call signalling will NOT be encrypted.");
+  }
+
   const client = createClient({
     ...storeOpts,
     ...clientOptions,
@@ -86,6 +100,7 @@ export async function initClient(
     // Use a relatively low timeout for API calls: this is a realtime application
     // so we don't want API calls taking ages, we'd rather they just fail.
     localTimeoutMs: 5000,
+    useE2eForGroupCall: enableE2e,
   });
 
   try {

--- a/src/matrix-utils.ts
+++ b/src/matrix-utils.ts
@@ -87,7 +87,7 @@ export async function initClient(
   // them.
   const params = new URLSearchParams(window.location.search);
   // disable e2e only if enableE2e=false is given
-  const enableE2e = !(params.get("enableE2e") === "false");
+  const enableE2e = params.get("enableE2e") !== "false";
 
   if (!enableE2e) {
     logger.info("Disabling E2E: group call signalling will NOT be encrypted.");

--- a/yarn.lock
+++ b/yarn.lock
@@ -8602,9 +8602,9 @@ matrix-events-sdk@^0.0.1-beta.7:
   resolved "https://registry.yarnpkg.com/matrix-events-sdk/-/matrix-events-sdk-0.0.1-beta.7.tgz#5ffe45eba1f67cc8d7c2377736c728b322524934"
   integrity sha512-9jl4wtWanUFSy2sr2lCjErN/oC8KTAtaeaozJtrgot1JiQcEI4Rda9OLgQ7nLKaqb4Z/QUx/fR3XpDzm5Jy1JA==
 
-"matrix-js-sdk@github:matrix-org/matrix-js-sdk#e980c889016b48268031b22735e70b7f618e219c":
+"matrix-js-sdk@github:matrix-org/matrix-js-sdk#9a15094374f52053ca9f833269d2b1c6c7f964d2":
   version "18.1.0"
-  resolved "https://codeload.github.com/matrix-org/matrix-js-sdk/tar.gz/e980c889016b48268031b22735e70b7f618e219c"
+  resolved "https://codeload.github.com/matrix-org/matrix-js-sdk/tar.gz/9a15094374f52053ca9f833269d2b1c6c7f964d2"
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@types/sdp-transform" "^2.4.5"


### PR DESCRIPTION
Deliberately not making it an option on the room since then we'd have to worry about server doing downgrade attacks.

Requires https://github.com/matrix-org/matrix-js-sdk/pull/2492