### PR TITLE
Fix the PTT button on mobile

### DIFF
--- a/src/room/PTTButton.tsx
+++ b/src/room/PTTButton.tsx
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React, { useCallback, useState, createRef } from "react";
+import React, { useCallback, useState, useRef } from "react";
 import classNames from "classnames";
 import { useSpring, animated } from "@react-spring/web";
 
@@ -54,7 +54,7 @@ export const PTTButton: React.FC<Props> = ({
   enqueueNetworkWaiting,
   setNetworkWaiting,
 }) => {
-  const buttonRef = createRef<HTMLButtonElement>();
+  const buttonRef = useRef<HTMLButtonElement>();
 
   const [activeTouchId, setActiveTouchId] = useState<number | null>(null);
 


### PR DESCRIPTION
We were using createRef() instead of useRef() in the hook, which
meant we were always creating a new ref object and never actually
getting the ref. This must have been working before the useEventTarget
stuff due to some quirk of React / hooks...

Fixes https://github.com/vector-im/element-call/issues/439