### PR TITLE
Fix view when another person is talking

### DIFF
--- a/src/room/PTTButton.module.css
+++ b/src/room/PTTButton.module.css
@@ -19,8 +19,8 @@
 
 .avatar {
   /* Remove explicit size to allow avatar to scale with the button */
-  width: unset !important;
-  height: unset !important;
+  width: 100% !important;
+  height: 100% !important;
 }
 
 .talking {


### PR DESCRIPTION
Hopefully this matches what was intended (leaving it unset meant it didn't fill the whole height of the button.

Fixes https://github.com/vector-im/element-call/issues/445