### PR TITLE
Prevent empty device labels

### DIFF
--- a/src/settings/SettingsModal.tsx
+++ b/src/settings/SettingsModal.tsx
@@ -78,7 +78,11 @@ export const SettingsModal = (props: Props) => {
             onSelectionChange={setAudioInput}
           >
             {audioInputs.map(({ deviceId, label }) => (
-              <Item key={deviceId}>{!!label && label.trim().length > 0 ? label : "Default microphone"}</Item>
+              <Item key={deviceId}>
+                {!!label && label.trim().length > 0
+                  ? label
+                  : "Default microphone"}
+              </Item>
             ))}
           </SelectInput>
           {audioOutputs.length > 0 && (
@@ -88,7 +92,11 @@ export const SettingsModal = (props: Props) => {
               onSelectionChange={setAudioOutput}
             >
               {audioOutputs.map(({ deviceId, label }) => (
-                <Item key={deviceId}>{!!label && label.trim().length > 0 ? label : "Default speaker"}</Item>
+                <Item key={deviceId}>
+                  {!!label && label.trim().length > 0
+                    ? label
+                    : "Default speaker"}
+                </Item>
               ))}
             </SelectInput>
           )}
@@ -119,7 +127,9 @@ export const SettingsModal = (props: Props) => {
             onSelectionChange={setVideoInput}
           >
             {videoInputs.map(({ deviceId, label }) => (
-              <Item key={deviceId}>{!!label && label.trim().length > 0 ? label : "Default camera"}</Item>
+              <Item key={deviceId}>
+                {!!label && label.trim().length > 0 ? label : "Default camera"}
+              </Item>
             ))}
           </SelectInput>
         </TabItem>

--- a/src/settings/SettingsModal.tsx
+++ b/src/settings/SettingsModal.tsx
@@ -77,11 +77,11 @@ export const SettingsModal = (props: Props) => {
             selectedKey={audioInput}
             onSelectionChange={setAudioInput}
           >
-            {audioInputs.map(({ deviceId, label }) => (
+            {audioInputs.map(({ deviceId, label }, index) => (
               <Item key={deviceId}>
                 {!!label && label.trim().length > 0
                   ? label
-                  : "Default microphone"}
+                  : `Microphone ${index + 1}`}
               </Item>
             ))}
           </SelectInput>
@@ -91,11 +91,11 @@ export const SettingsModal = (props: Props) => {
               selectedKey={audioOutput}
               onSelectionChange={setAudioOutput}
             >
-              {audioOutputs.map(({ deviceId, label }) => (
+              {audioOutputs.map(({ deviceId, label }, index) => (
                 <Item key={deviceId}>
                   {!!label && label.trim().length > 0
                     ? label
-                    : "Default speaker"}
+                    : `Speaker ${index + 1}`}
                 </Item>
               ))}
             </SelectInput>
@@ -126,9 +126,11 @@ export const SettingsModal = (props: Props) => {
             selectedKey={videoInput}
             onSelectionChange={setVideoInput}
           >
-            {videoInputs.map(({ deviceId, label }) => (
+            {videoInputs.map(({ deviceId, label }, index) => (
               <Item key={deviceId}>
-                {!!label && label.trim().length > 0 ? label : "Default camera"}
+                {!!label && label.trim().length > 0
+                  ? label
+                  : `Camera ${index + 1}`}
               </Item>
             ))}
           </SelectInput>

--- a/src/settings/SettingsModal.tsx
+++ b/src/settings/SettingsModal.tsx
@@ -78,7 +78,7 @@ export const SettingsModal = (props: Props) => {
             onSelectionChange={setAudioInput}
           >
             {audioInputs.map(({ deviceId, label }) => (
-              <Item key={deviceId}>{label}</Item>
+              <Item key={deviceId}>{!!label && label.trim().length > 0 ? label : "Default microphone"}</Item>
             ))}
           </SelectInput>
           {audioOutputs.length > 0 && (
@@ -88,7 +88,7 @@ export const SettingsModal = (props: Props) => {
               onSelectionChange={setAudioOutput}
             >
               {audioOutputs.map(({ deviceId, label }) => (
-                <Item key={deviceId}>{label}</Item>
+                <Item key={deviceId}>{!!label && label.trim().length > 0 ? label : "Default speaker"}</Item>
               ))}
             </SelectInput>
           )}
@@ -119,7 +119,7 @@ export const SettingsModal = (props: Props) => {
             onSelectionChange={setVideoInput}
           >
             {videoInputs.map(({ deviceId, label }) => (
-              <Item key={deviceId}>{label}</Item>
+              <Item key={deviceId}>{!!label && label.trim().length > 0 ? label : "Default camera"}</Item>
             ))}
           </SelectInput>
         </TabItem>


### PR DESCRIPTION
Fixes: #324

This isn't very elegant but at least prevents the empty dropdowns on Android. Possibly should move into `MediaHandlerProvider`? Open to feedback. 🙂