### PR TITLE
Fix 'waiting for network' after reaching time limit

### DIFF
--- a/src/room/PTTButton.tsx
+++ b/src/room/PTTButton.tsx
@@ -57,13 +57,17 @@ export const PTTButton: React.FC<Props> = ({
   const buttonRef = useRef<HTMLButtonElement>();
 
   const [activeTouchId, setActiveTouchId] = useState<number | null>(null);
+  const [buttonHeld, setButtonHeld] = useState(false);
 
   const hold = useCallback(() => {
     // This update is delayed so the user only sees it if latency is significant
+    if (buttonHeld) return;
+    setButtonHeld(true);
     enqueueNetworkWaiting(true, 100);
     startTalking();
-  }, [enqueueNetworkWaiting, startTalking]);
+  }, [enqueueNetworkWaiting, startTalking, buttonHeld]);
   const unhold = useCallback(() => {
+    setButtonHeld(false);
     setNetworkWaiting(false);
     stopTalking();
   }, [setNetworkWaiting, stopTalking]);


### PR DESCRIPTION
If you spoke for the maximum amount of time and got cut off, the
next time you tried to speak you'd just get the 'waiting for network'
state. Key repeats would cause more delayed state timeouts to queue
up.