### PR TITLE
Fix a crash

### DIFF
--- a/src/room/GroupCallInspector.tsx
+++ b/src/room/GroupCallInspector.tsx
@@ -231,7 +231,7 @@ function reducer(
   action: {
     type?: CallEvent | ClientEvent | RoomStateEvent;
     event?: MatrixEvent;
-    rawEvent?: object;
+    rawEvent?: Record<string, unknown>;
     callStateEvent?: MatrixEvent;
     memberStateEvents?: MatrixEvent[];
   }
@@ -321,7 +321,7 @@ function reducer(
       const event = action.rawEvent;
       const eventsByUserId = { ...state.eventsByUserId };
       const fromId = state.localUserId;
-      const toId = event.userId;
+      const toId = event.userId as string;
 
       const remoteUserIds = eventsByUserId[toId]
         ? state.remoteUserIds
@@ -332,8 +332,8 @@ function reducer(
         {
           from: fromId,
           to: toId,
-          type: event.eventType,
-          content: event.content,
+          type: event.eventType as string,
+          content: event.content as CallEventContent,
           timestamp: Date.now(),
           ignored: false,
         },
@@ -383,7 +383,7 @@ function useGroupCallState(
       dispatch({ type: ClientEvent.ReceivedVoipEvent, event });
     }
 
-    function onSendVoipEvent(event: object) {
+    function onSendVoipEvent(event: Record<string, unknown>) {
       dispatch({ type: CallEvent.SendVoipEvent, rawEvent: event });
     }
     client.on(RoomStateEvent.Events, onUpdateRoomState);

--- a/src/room/GroupCallInspector.tsx
+++ b/src/room/GroupCallInspector.tsx
@@ -230,7 +230,8 @@ function reducer(
   state: InspectorContextState,
   action: {
     type?: CallEvent | ClientEvent | RoomStateEvent;
-    event: MatrixEvent;
+    event?: MatrixEvent;
+    rawEvent?: object;
     callStateEvent?: MatrixEvent;
     memberStateEvents?: MatrixEvent[];
   }
@@ -317,10 +318,10 @@ function reducer(
       return { ...state, eventsByUserId, remoteUserIds };
     }
     case CallEvent.SendVoipEvent: {
-      const event = action.event;
+      const event = action.rawEvent;
       const eventsByUserId = { ...state.eventsByUserId };
       const fromId = state.localUserId;
-      const toId = event.target.userId; // was .user
+      const toId = event.userId;
 
       const remoteUserIds = eventsByUserId[toId]
         ? state.remoteUserIds
@@ -331,8 +332,8 @@ function reducer(
         {
           from: fromId,
           to: toId,
-          type: event.getType(),
-          content: event.getContent(),
+          type: event.eventType,
+          content: event.content,
           timestamp: Date.now(),
           ignored: false,
         },
@@ -382,8 +383,8 @@ function useGroupCallState(
       dispatch({ type: ClientEvent.ReceivedVoipEvent, event });
     }
 
-    function onSendVoipEvent(event: MatrixEvent) {
-      dispatch({ type: CallEvent.SendVoipEvent, event });
+    function onSendVoipEvent(event: object) {
+      dispatch({ type: CallEvent.SendVoipEvent, rawEvent: event });
     }
     client.on(RoomStateEvent.Events, onUpdateRoomState);
     //groupCall.on("calls_changed", onCallsChanged);


### PR DESCRIPTION
`CallEvent.SendVoipEvent` is sent with a raw dictionary, not an actual `MatrixEvent`.

Closes https://github.com/matrix-org/matrix-video-chat-rageshakes/issues/1074
Closes https://github.com/matrix-org/matrix-video-chat-rageshakes/issues/1073
Closes https://github.com/matrix-org/matrix-video-chat-rageshakes/issues/1072
Closes https://github.com/matrix-org/matrix-video-chat-rageshakes/issues/1071
Closes https://github.com/matrix-org/matrix-video-chat-rageshakes/issues/1070