### PR TITLE
fix mirror text on FF by reverting weird css hack.

### DIFF
--- a/src/room/VideoPreview.module.css
+++ b/src/room/VideoPreview.module.css
@@ -9,12 +9,11 @@
 }
 
 .preview video {
-  width: calc(100% + 1px);
+  width: 100%;
   height: 100%;
   object-fit: contain;
   background-color: black;
-  /* transform scale doesn't perfectly match width, so make -1.01 border issues */
-  transform: scaleX(-1.01);
+  transform: scaleX(-1);
 }
 
 .avatarContainer {


### PR DESCRIPTION
this reverts some of https://github.com/vector-im/element-call/commit/d1368f46220d36e6f76da24e0f08f78951f507de
it's very unclear why the width of the preview was pushed out to 100%+1px (and the transform then flipped to 1.01)
but i see no ill effects on having reverted it.

should fix https://github.com/vector-im/element-call/issues/392 and https://github.com/vector-im/element-call/issues/498