### PR TITLE
Fix a case where someone's audio could be missing if the audio track arrived late

### DIFF
--- a/src/video-grid/useMediaStream.ts
+++ b/src/video-grid/useMediaStream.ts
@@ -213,12 +213,7 @@ export const useSpatialMediaStream = (
   const sourceRef = useRef<MediaStreamAudioSourceNode>();
 
   useEffect(() => {
-    if (
-      spatialAudio &&
-      tileRef.current &&
-      !mute &&
-      stream.getAudioTracks().length > 0
-    ) {
+    if (spatialAudio && tileRef.current && !mute) {
       if (!pannerNodeRef.current) {
         pannerNodeRef.current = new PannerNode(audioContext, {
           panningModel: "HRTF",


### PR DESCRIPTION
The addition of an audio track wouldn't cause this hook to re-run. However, I don't think we should worry about optimizing for the case of 0 audio tracks at all, since that could only conceivably happen with screensharing feeds.