### PR TITLE
Fix groupcall debug info in rageshakes

### DIFF
--- a/src/room/GroupCallInspector.tsx
+++ b/src/room/GroupCallInspector.tsx
@@ -121,8 +121,11 @@ export function InspectorContextProvider({
 }: {
   children: React.ReactNode;
 }) {
-  // The context will be initialized empty.
-  // It is then set from within GroupCallInspector.
+  // We take the tuple of [currentState, setter] and stick
+  // it straight into the context for other things to call
+  // the setState method... this feels like a fairly severe
+  // contortion of the hooks API - is this really the best way
+  // to do this?
   const context = useState<InspectorContextState>({});
   return (
     <InspectorContext.Provider value={context}>

--- a/src/settings/submit-rageshake.ts
+++ b/src/settings/submit-rageshake.ts
@@ -40,7 +40,9 @@ export function useSubmitRageshake(): {
   error: Error;
 } {
   const client: MatrixClient = useClient().client;
-  const json = useContext(InspectorContext);
+  // The value of the context is the whole tuple returned from setState,
+  // so we just want the current state.
+  const [inspectorState] = useContext(InspectorContext);
 
   const [{ sending, sent, error }, setState] = useState({
     sending: false,
@@ -231,10 +233,12 @@ export function useSubmitRageshake(): {
             body.append("compressed-log", new Blob([buf]), entry.id);
           }
 
-          if (json) {
+          if (inspectorState) {
             body.append(
               "file",
-              new Blob([JSON.stringify(json)], { type: "text/plain" }),
+              new Blob([JSON.stringify(inspectorState)], {
+                type: "text/plain",
+              }),
               "groupcall.txt"
             );
           }
@@ -262,7 +266,7 @@ export function useSubmitRageshake(): {
         console.error(error);
       }
     },
-    [client, json, sending]
+    [client, inspectorState, sending]
   );
 
   return {


### PR DESCRIPTION
We were putting the whole array from setState in, so the debug info
was wrapped in an array when it shouldn't be.

Also comment the groupCallInspector setState/context dance which I
now *finally* understand.