### PR TITLE
Fix bug where additional group calls could be created

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "classnames": "^2.3.1",
     "color-hash": "^2.0.1",
     "events": "^3.3.0",
-    "matrix-js-sdk": "github:matrix-org/matrix-js-sdk#965f4fb13b4b36b26a3f4d7214cc7630d9f579a5",
+    "matrix-js-sdk": "github:matrix-org/matrix-js-sdk#da5bc358f40e1e9de39d28aea072a9c38e356bda",
     "matrix-widget-api": "^1.0.0",
     "mermaid": "^8.13.8",
     "normalize.css": "^8.0.1",

--- a/src/room/useLoadGroupCall.ts
+++ b/src/room/useLoadGroupCall.ts
@@ -58,7 +58,7 @@ export const useLoadGroupCall = (
             resolve(room);
           }
         };
-        client.on(ClientEvent.Room, onRoomEvent);
+        client.on(GroupCallEventHandlerEvent.Room, onRoomEvent);
       });
 
       // race the promise with a timeout so we don't

--- a/src/room/useLoadGroupCall.ts
+++ b/src/room/useLoadGroupCall.ts
@@ -21,7 +21,6 @@ import {
   GroupCallIntent,
 } from "matrix-js-sdk/src/webrtc/groupCall";
 import { GroupCallEventHandlerEvent } from "matrix-js-sdk/src/webrtc/groupCallEventHandler";
-import { ClientEvent } from "matrix-js-sdk/src/client";
 import { logger } from "matrix-js-sdk/src/logger";
 
 import type { MatrixClient } from "matrix-js-sdk/src/client";

--- a/yarn.lock
+++ b/yarn.lock
@@ -8390,9 +8390,9 @@ matrix-events-sdk@^0.0.1-beta.7:
   resolved "https://registry.yarnpkg.com/matrix-events-sdk/-/matrix-events-sdk-0.0.1-beta.7.tgz#5ffe45eba1f67cc8d7c2377736c728b322524934"
   integrity sha512-9jl4wtWanUFSy2sr2lCjErN/oC8KTAtaeaozJtrgot1JiQcEI4Rda9OLgQ7nLKaqb4Z/QUx/fR3XpDzm5Jy1JA==
 
-"matrix-js-sdk@github:matrix-org/matrix-js-sdk#965f4fb13b4b36b26a3f4d7214cc7630d9f579a5":
+"matrix-js-sdk@github:matrix-org/matrix-js-sdk#da5bc358f40e1e9de39d28aea072a9c38e356bda":
   version "19.3.0"
-  resolved "https://codeload.github.com/matrix-org/matrix-js-sdk/tar.gz/965f4fb13b4b36b26a3f4d7214cc7630d9f579a5"
+  resolved "https://codeload.github.com/matrix-org/matrix-js-sdk/tar.gz/da5bc358f40e1e9de39d28aea072a9c38e356bda"
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@types/sdp-transform" "^2.4.5"


### PR DESCRIPTION
This (hopefully) fixes the remaining bug where extra group calls
could be created when entering a room.

We waited for the Room event to arrive, but didn't wait for the
group call event handler to actually process the event, so it would
have depended what order the event handlers were run in.

If this doesn't fix it, it at least adds logging so we'll have more
to go on next time.

Fixes https://github.com/vector-im/element-call/issues/563