### PR TITLE
Use new method to wait until a room is ready for group calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "classnames": "^2.3.1",
     "color-hash": "^2.0.1",
     "events": "^3.3.0",
-    "matrix-js-sdk": "github:matrix-org/matrix-js-sdk#da5bc358f40e1e9de39d28aea072a9c38e356bda",
+    "matrix-js-sdk": "github:matrix-org/matrix-js-sdk#3e8607a77b363e162358995ad6c4c7ce6c7fb168",
     "matrix-widget-api": "^1.0.0",
     "mermaid": "^8.13.8",
     "normalize.css": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "classnames": "^2.3.1",
     "color-hash": "^2.0.1",
     "events": "^3.3.0",
-    "matrix-js-sdk": "github:matrix-org/matrix-js-sdk#3e8607a77b363e162358995ad6c4c7ce6c7fb168",
+    "matrix-js-sdk": "github:matrix-org/matrix-js-sdk#98d119d6e1d39f1c5b01b36e7fda133e9f12f50c",
     "matrix-widget-api": "^1.0.0",
     "mermaid": "^8.13.8",
     "normalize.css": "^8.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8390,9 +8390,9 @@ matrix-events-sdk@^0.0.1-beta.7:
   resolved "https://registry.yarnpkg.com/matrix-events-sdk/-/matrix-events-sdk-0.0.1-beta.7.tgz#5ffe45eba1f67cc8d7c2377736c728b322524934"
   integrity sha512-9jl4wtWanUFSy2sr2lCjErN/oC8KTAtaeaozJtrgot1JiQcEI4Rda9OLgQ7nLKaqb4Z/QUx/fR3XpDzm5Jy1JA==
 
-"matrix-js-sdk@github:matrix-org/matrix-js-sdk#3e8607a77b363e162358995ad6c4c7ce6c7fb168":
+"matrix-js-sdk@github:matrix-org/matrix-js-sdk#98d119d6e1d39f1c5b01b36e7fda133e9f12f50c":
   version "19.3.0"
-  resolved "https://codeload.github.com/matrix-org/matrix-js-sdk/tar.gz/3e8607a77b363e162358995ad6c4c7ce6c7fb168"
+  resolved "https://codeload.github.com/matrix-org/matrix-js-sdk/tar.gz/98d119d6e1d39f1c5b01b36e7fda133e9f12f50c"
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@types/sdp-transform" "^2.4.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8390,9 +8390,9 @@ matrix-events-sdk@^0.0.1-beta.7:
   resolved "https://registry.yarnpkg.com/matrix-events-sdk/-/matrix-events-sdk-0.0.1-beta.7.tgz#5ffe45eba1f67cc8d7c2377736c728b322524934"
   integrity sha512-9jl4wtWanUFSy2sr2lCjErN/oC8KTAtaeaozJtrgot1JiQcEI4Rda9OLgQ7nLKaqb4Z/QUx/fR3XpDzm5Jy1JA==
 
-"matrix-js-sdk@github:matrix-org/matrix-js-sdk#da5bc358f40e1e9de39d28aea072a9c38e356bda":
+"matrix-js-sdk@github:matrix-org/matrix-js-sdk#3e8607a77b363e162358995ad6c4c7ce6c7fb168":
   version "19.3.0"
-  resolved "https://codeload.github.com/matrix-org/matrix-js-sdk/tar.gz/da5bc358f40e1e9de39d28aea072a9c38e356bda"
+  resolved "https://codeload.github.com/matrix-org/matrix-js-sdk/tar.gz/3e8607a77b363e162358995ad6c4c7ce6c7fb168"
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@types/sdp-transform" "^2.4.5"


### PR DESCRIPTION
We were waiting for the group call event handler to process the room,
but only if we couldn't get the room from the client - if getRoom returned
a room, we just wouldn't wait. This just uses promises rather than
an event to wait for the room to be ready.

Looks like the failure was that we were getting a room from the store
and therefore not waiting for the event at all, but the fact that the room
was in the store doesn't mean it's been processed. We can't wait for
the event even if we got the room from the store because it may have
already happened in that case, so we'd be waiting forever for an event
that's already fired. Using promises fixes the race.

Requires https://github.com/matrix-org/matrix-js-sdk/pull/2641