### PR TITLE
Log ID instead of object

### DIFF
--- a/src/room/useLoadGroupCall.ts
+++ b/src/room/useLoadGroupCall.ts
@@ -80,7 +80,7 @@ export const useLoadGroupCall = (
       const room = await fetchOrCreateRoom();
       logger.debug(`Fetched / joined room ${roomIdOrAlias}`);
       const groupCall = client.getGroupCallForRoom(room.roomId);
-      logger.debug("Got group call", groupCall);
+      logger.debug("Got group call", groupCall.groupCallId);
 
       if (groupCall) return groupCall;
 

--- a/src/room/useLoadGroupCall.ts
+++ b/src/room/useLoadGroupCall.ts
@@ -80,7 +80,7 @@ export const useLoadGroupCall = (
       const room = await fetchOrCreateRoom();
       logger.debug(`Fetched / joined room ${roomIdOrAlias}`);
       const groupCall = client.getGroupCallForRoom(room.roomId);
-      logger.debug("Got group call", groupCall.groupCallId);
+      logger.debug("Got group call", groupCall?.groupCallId);
 
       if (groupCall) return groupCall;
 


### PR DESCRIPTION
as otherwise it recurses and logs the entire client + store