### PR TITLE
Don't kill other sessions when running as a widget

### DIFF
--- a/src/ClientContext.tsx
+++ b/src/ClientContext.tsx
@@ -258,7 +258,11 @@ export const ClientProvider: FC<Props> = ({ children }) => {
   }, [history]);
 
   useEffect(() => {
-    if (client) {
+    // To protect against multiple sessions writing to the same storage
+    // simultaneously, we send a to-device message that shuts down all other
+    // running instances of the app. This isn't necessary if the app is running
+    // in a widget though, since then it'll be mostly stateless.
+    if (!widget && client) {
       const loadTime = Date.now();
 
       const onToDeviceEvent = (event: MatrixEvent) => {

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -106,7 +106,6 @@ export const widget: WidgetHelpers | null = (() => {
         EventType.CallSDPStreamMetadataChanged,
         EventType.CallSDPStreamMetadataChangedPrefix,
         EventType.CallReplaces,
-        "org.matrix.call_duplicate_session",
       ];
 
       const client = createRoomWidgetClient(


### PR DESCRIPTION
Element Web wants to keep two Element Call iframes in the DOM when switching between video rooms, and we have no reason to kill other sessions if the app is just a stateless widget (I think).