### PR TITLE
Unpersist widget after hanging up

### DIFF
--- a/src/room/GroupCallView.tsx
+++ b/src/room/GroupCallView.tsx
@@ -150,6 +150,7 @@ export function GroupCallView({
       const onHangup = async (ev: CustomEvent<IWidgetApiRequest>) => {
         leave();
         await widget.api.transport.reply(ev.detail, {});
+        widget.api.setAlwaysOnScreen(false);
       };
       widget.lazyActions.once(ElementWidgetActions.HangupCall, onHangup);
       return () => {


### PR DESCRIPTION
Otherwise it can get stuck on screen in Element Web.