### PR TITLE
Further simplify the maximised speaker view

### DIFF
--- a/src/video-grid/VideoTile.tsx
+++ b/src/video-grid/VideoTile.tsx
@@ -78,7 +78,7 @@ export const VideoTile = forwardRef<HTMLDivElement, Props>(
         ref={ref}
         {...rest}
       >
-        {(!isLocal || screenshare) && (
+        {(!isLocal || screenshare) && !maximised && (
           <div className={classNames(styles.toolbar)}>
             {!isLocal && (
               <AudioButton

--- a/src/video-grid/VideoTileContainer.tsx
+++ b/src/video-grid/VideoTileContainer.tsx
@@ -109,7 +109,7 @@ export function VideoTileContainer({
         onFullscreen={onFullscreenCallback}
         {...rest}
       />
-      {videoTileSettingsModalState.isOpen && (
+      {videoTileSettingsModalState.isOpen && !maximised && (
         <VideoTileSettingsModal
           {...videoTileSettingsModalProps}
           feed={item.callFeed}


### PR DESCRIPTION
This hides the toolbar and video tile settings modal as long as the active speaker is [maximised](https://github.com/vector-im/element-call/pull/581).