### PR TITLE
Make tooltips look more like Element Web's

### DIFF
--- a/src/Tooltip.module.css
+++ b/src/Tooltip.module.css
@@ -3,10 +3,12 @@
   flex-direction: row;
   justify-content: center;
   align-items: center;
-  padding: 8px 10px;
+  padding: 10px;
   color: var(--primary-content);
   border-radius: 8px;
   max-width: 135px;
   width: max-content;
+  font-size: 12px;
+  font-weight: 500;
   text-align: center;
 }

--- a/src/Tooltip.tsx
+++ b/src/Tooltip.tsx
@@ -86,7 +86,7 @@ export const TooltipTrigger = forwardRef<HTMLElement, TooltipTriggerProps>(
       targetRef: triggerRef,
       overlayRef,
       isOpen: tooltipState.isOpen,
-      offset: 5,
+      offset: 12,
     });
 
     return (


### PR DESCRIPTION
The only thing they're missing now is animated fading.

https://user-images.githubusercontent.com/48614497/192403117-90d9efab-78cb-4460-b4a1-3d35412254ed.mp4

Closes https://github.com/vector-im/element-call/issues/571