### PR TITLE
Show a reduced set of controls when the window is narrow

### DIFF
--- a/src/room/InCallView.tsx
+++ b/src/room/InCallView.tsx
@@ -215,13 +215,15 @@ export function InCallView({
   // window is too small to show everyone
   const maximisedParticipant = useMemo(
     () =>
-      fullscreenParticipant ?? (bounds.height <= 500 && bounds.width <= 500)
+      fullscreenParticipant ?? (bounds.height <= 400 && bounds.width <= 400)
         ? items.find((item) => item.focused) ??
           items.find((item) => item.callFeed) ??
           null
         : null,
     [fullscreenParticipant, bounds, items]
   );
+
+  const reducedControls = bounds.width <= 400;
 
   const renderAvatar = useCallback(
     (roomMember: RoomMember, width: number, height: number) => {
@@ -325,13 +327,13 @@ export function InCallView({
       <div className={styles.footer}>
         <MicButton muted={microphoneMuted} onPress={toggleMicrophoneMuted} />
         <VideoButton muted={localVideoMuted} onPress={toggleLocalVideoMuted} />
-        {canScreenshare && !isSafari && !maximisedParticipant && (
+        {canScreenshare && !isSafari && !reducedControls && (
           <ScreenshareButton
             enabled={isScreensharing}
             onPress={toggleScreensharing}
           />
         )}
-        {!maximisedParticipant && (
+        {!reducedControls && (
           <OverflowMenu
             inCall
             roomIdOrAlias={roomIdOrAlias}


### PR DESCRIPTION
![Screenshot 2022-09-26 at 20-32-51 Element 3 Native video room 1](https://user-images.githubusercontent.com/48614497/192404618-fca89ad6-440d-4b15-add8-113cc9431a7a.png)

Closes https://github.com/vector-im/element-call/issues/591