### PR TITLE
Use device labels rather than IDs in widget API

### DIFF
--- a/src/media-utils.ts
+++ b/src/media-utils.ts
@@ -1,0 +1,23 @@
+/*
+Copyright 2022 Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export async function findDeviceByName(
+  deviceName: string
+): Promise<string | undefined> {
+  const devices = await navigator.mediaDevices.enumerateDevices();
+  const deviceInfo = devices.find((d) => d.label === deviceName);
+  return deviceInfo?.deviceId;
+}

--- a/src/media-utils.ts
+++ b/src/media-utils.ts
@@ -48,7 +48,7 @@ export async function findDeviceByName(
  * @return The available media devices
  */
 export async function getDevices(): Promise<MediaDeviceInfo[]> {
-  let stream;
+  let stream: MediaStream;
   try {
     stream = await navigator.mediaDevices.getUserMedia({
       audio: true,

--- a/src/media-utils.ts
+++ b/src/media-utils.ts
@@ -24,9 +24,12 @@ import { logger } from "matrix-js-sdk/src/logger";
  */
 export async function findDeviceByName(
   deviceName: string,
+  kind: MediaDeviceKind,
   devices: MediaDeviceInfo[]
 ): Promise<string | undefined> {
-  const deviceInfo = devices.find((d) => d.label === deviceName);
+  const deviceInfo = devices.find(
+    (d) => d.kind === kind && d.label === deviceName
+  );
   return deviceInfo?.deviceId;
 }
 

--- a/src/room/GroupCallView.tsx
+++ b/src/room/GroupCallView.tsx
@@ -105,7 +105,11 @@ export function GroupCallView({
           .data as unknown as JoinCallData;
 
         if (audioInput !== null) {
-          const deviceId = await findDeviceByName(audioInput, devices);
+          const deviceId = await findDeviceByName(
+            audioInput,
+            "audioinput",
+            devices
+          );
           if (!deviceId) {
             logger.warn("Unknown audio input: " + audioInput);
           } else {
@@ -117,7 +121,11 @@ export function GroupCallView({
         }
 
         if (videoInput !== null) {
-          const deviceId = await findDeviceByName(videoInput, devices);
+          const deviceId = await findDeviceByName(
+            videoInput,
+            "videoinput",
+            devices
+          );
           if (!deviceId) {
             logger.warn("Unknown video input: " + videoInput);
           } else {

--- a/src/room/GroupCallView.tsx
+++ b/src/room/GroupCallView.tsx
@@ -32,7 +32,7 @@ import { useRoomAvatar } from "./useRoomAvatar";
 import { useSentryGroupCallHandler } from "./useSentryGroupCallHandler";
 import { useLocationNavigation } from "../useLocationNavigation";
 import { useMediaHandler } from "../settings/useMediaHandler";
-import { findDeviceByName } from "../media-utils";
+import { findDeviceByName, getDevices } from "../media-utils";
 
 declare global {
   interface Window {
@@ -96,11 +96,16 @@ export function GroupCallView({
     if (widget && preload) {
       // In preload mode, wait for a join action before entering
       const onJoin = async (ev: CustomEvent<IWidgetApiRequest>) => {
+        // Get the available devices so we can match the selected device
+        // to its ID. This involves getting a media stream (see docs on
+        // the function) so we only do it once and re-use the result.
+        const devices = await getDevices();
+
         const { audioInput, videoInput } = ev.detail
           .data as unknown as JoinCallData;
 
         if (audioInput !== null) {
-          const deviceId = await findDeviceByName(audioInput);
+          const deviceId = await findDeviceByName(audioInput, devices);
           if (!deviceId) {
             logger.warn("Unknown audio input: " + audioInput);
           } else {
@@ -112,7 +117,7 @@ export function GroupCallView({
         }
 
         if (videoInput !== null) {
-          const deviceId = await findDeviceByName(videoInput);
+          const deviceId = await findDeviceByName(videoInput, devices);
           if (!deviceId) {
             logger.warn("Unknown video input: " + videoInput);
           } else {


### PR DESCRIPTION
device IDs are different for each origin, so won't match up when passed in & out of widgets. Use the label instead.

For https://github.com/vector-im/element-web/issues/23331