### PR TITLE
Leave audio elements unmuted regardless of mute state

### DIFF
--- a/src/video-grid/AudioContainer.tsx
+++ b/src/video-grid/AudioContainer.tsx
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React, { useEffect, useRef } from "react";
+import React, { FC, useEffect, useRef } from "react";
 
 import { Participant } from "../room/InCallView";
 import { useCallFeed } from "./useCallFeed";
@@ -29,19 +29,22 @@ interface AudioForParticipantProps {
   audioDestination: AudioNode;
 }
 
-export function AudioForParticipant({
+export const AudioForParticipant: FC<AudioForParticipantProps> = ({
   item,
   audioContext,
   audioDestination,
-}: AudioForParticipantProps): JSX.Element {
-  const { stream, localVolume, audioMuted } = useCallFeed(item.callFeed);
+}) => {
+  const { stream, localVolume } = useCallFeed(item.callFeed);
   const [audioTrackCount] = useMediaStreamTrackCount(stream);
 
   const gainNodeRef = useRef<GainNode>();
   const sourceRef = useRef<MediaStreamAudioSourceNode>();
 
   useEffect(() => {
-    if (!item.isLocal && audioContext && !audioMuted && audioTrackCount > 0) {
+    // We don't compare the audioMuted flag of useCallFeed here, since unmuting
+    // depends on to-device messages which may lag behind the audio actually
+    // starting to flow over the network
+    if (!item.isLocal && audioContext && audioTrackCount > 0) {
       if (!gainNodeRef.current) {
         gainNodeRef.current = new GainNode(audioContext, {
           gain: localVolume,
@@ -68,12 +71,11 @@ export function AudioForParticipant({
     audioDestination,
     stream,
     localVolume,
-    audioMuted,
     audioTrackCount,
   ]);
 
   return null;
-}
+};
 
 interface AudioContainerProps {
   items: Participant[];
@@ -81,10 +83,7 @@ interface AudioContainerProps {
   audioDestination: AudioNode;
 }
 
-export function AudioContainer({
-  items,
-  ...rest
-}: AudioContainerProps): JSX.Element {
+export const AudioContainer: FC<AudioContainerProps> = ({ items, ...rest }) => {
   return (
     <>
       {items
@@ -94,4 +93,4 @@ export function AudioContainer({
         ))}
     </>
   );
-}
+};


### PR DESCRIPTION
Because to-device signaling can lag behind a user's actual audio, when you combine this with federation latency, you might end up cutting off the first few words of a user's sentence after they unmute.

I'd like to get this reviewed by @dbkr specifically before merging, to make sure this doesn't conflict with any walkie-talkie logic. (We did ultimately decide to leave feeds in walkie-talkie mode unmuted anyways, right?)

Closes https://github.com/vector-im/voip-internal/issues/63