### PR TITLE
Prevent screenshare feeds from collapsing when you're alone in freedom mode

### DIFF
--- a/src/video-grid/VideoGrid.tsx
+++ b/src/video-grid/VideoGrid.tsx
@@ -316,11 +316,7 @@ function getFreedomLayoutTilePositions(
     columnCount: focusedColumnCount,
     rowCount: focusedRowCount,
     tileAspectRatio: focusedTileAspectRatio,
-  } = getSubGridLayout(
-    focusedTileCount,
-    focusedGridWidth,
-    focusedGridHeight
-  );
+  } = getSubGridLayout(focusedTileCount, focusedGridWidth, focusedGridHeight);
 
   const focusedGridPositions = getSubGridPositions(
     focusedTileCount,
@@ -333,13 +329,7 @@ function getFreedomLayoutTilePositions(
 
   const tilePositions = [...focusedGridPositions, ...itemGridPositions];
 
-  centerTiles(
-    focusedGridPositions,
-    focusedGridWidth,
-    focusedGridHeight,
-    0,
-    0
-  );
+  centerTiles(focusedGridPositions, focusedGridWidth, focusedGridHeight, 0, 0);
 
   if (layoutDirection === "vertical") {
     centerTiles(
@@ -664,7 +654,11 @@ function getSubGridPositions(
 // Sets the 'order' property on tiles based on the layout param and
 // other properties of the tiles, eg. 'focused' and 'presenter'
 function reorderTiles(tiles: Tile[], layout: Layout) {
-  if (layout === "freedom" && tiles.length === 2 && !tiles.some(t => t.presenter)) {
+  if (
+    layout === "freedom" &&
+    tiles.length === 2 &&
+    !tiles.some((t) => t.presenter)
+  ) {
     // 1:1 layout
     tiles.forEach((tile) => (tile.order = tile.item.isLocal ? 0 : 1));
   } else {
@@ -678,9 +672,7 @@ function reorderTiles(tiles: Tile[], layout: Layout) {
       (tile.focused ? focusedTiles : otherTiles).push(tile)
     );
 
-    [...focusedTiles, ...otherTiles].forEach(
-      (tile, i) => (tile.order = i)
-    );
+    [...focusedTiles, ...otherTiles].forEach((tile, i) => (tile.order = i));
   }
 }
 
@@ -824,7 +816,7 @@ export function VideoGrid({
               tilePositions: getTilePositions(
                 newTiles.length,
                 focusedTileCount,
-                newTiles.some(t => t.presenter),
+                newTiles.some((t) => t.presenter),
                 gridBounds.width,
                 gridBounds.height,
                 pipXRatio,
@@ -849,7 +841,7 @@ export function VideoGrid({
         tilePositions: getTilePositions(
           newTiles.length,
           focusedTileCount,
-          newTiles.some(t => t.presenter),
+          newTiles.some((t) => t.presenter),
           gridBounds.width,
           gridBounds.height,
           pipXRatio,
@@ -975,7 +967,7 @@ export function VideoGrid({
           tilePositions: getTilePositions(
             newTiles.length,
             focusedTileCount,
-            newTiles.some(t => t.presenter),
+            newTiles.some((t) => t.presenter),
             gridBounds.width,
             gridBounds.height,
             pipXRatio,
@@ -1007,7 +999,7 @@ export function VideoGrid({
 
       let newTiles = tiles;
 
-      if (tiles.length === 2 && !tiles.some(t => t.presenter)) {
+      if (tiles.length === 2 && !tiles.some((t) => t.presenter)) {
         // We're in 1:1 mode, so only the local tile should be draggable
         if (!dragTile.item.isLocal) return;
 


### PR DESCRIPTION
The code was previously confusing focused and presenter tiles quite a bit, and also had a couple different spots that would mistakenly engage 1:1 layout behavior when you're alone with your own screensharing feed.

This is a bit more easily explained with a video:

**Before**

https://user-images.githubusercontent.com/48614497/196336480-3005100d-b39a-4a79-91cc-5afe45a43c08.mp4

**After**

https://user-images.githubusercontent.com/48614497/196336477-4a159ca3-2237-445c-a73b-080afd112f25.mp4