### PR TITLE
Fix a soft crash when exiting fullscreen

### DIFF
--- a/src/video-grid/useFullscreen.tsx
+++ b/src/video-grid/useFullscreen.tsx
@@ -32,7 +32,7 @@ export function useFullscreen(ref: React.RefObject<HTMLElement>): {
   const toggleFullscreen = useCallback(
     (participant: Participant) => {
       if (fullscreenParticipant) {
-        document.exitFullscreen();
+        document.exitFullscreen().catch((e) => console.error(e));
         setFullscreenParticipant(null);
       } else {
         try {
@@ -56,7 +56,7 @@ export function useFullscreen(ref: React.RefObject<HTMLElement>): {
 
   useEffect(() => {
     if (disposed) {
-      document.exitFullscreen();
+      document.exitFullscreen().catch((e) => console.error(e));
       setFullscreenParticipant(null);
     }
   }, [disposed]);


### PR DESCRIPTION
I can't quite remember how I triggered this, but it's apparently possible for exitFullscreen to be called while you're not in fullscreen, which throws an error. As a quick fix, this catches the errors.