### PR TITLE
Don't log AbortErrors from videos that are never played

### DIFF
--- a/src/video-grid/useMediaStream.ts
+++ b/src/video-grid/useMediaStream.ts
@@ -86,7 +86,9 @@ export const useMediaStream = (
       if (stream) {
         mediaEl.muted = mute;
         mediaEl.srcObject = stream;
-        mediaEl.play();
+        mediaEl.play().catch((e) => {
+          if (e.name !== "AbortError") throw e;
+        });
 
         // Unmuting the tab in Safari causes all video elements to be individually
         // unmuted, so we need to reset the mute state here to prevent audio loops


### PR DESCRIPTION
It's normal for the `play` operation on video feeds to be cancelled due to tiles unmounting quickly (especially with React 18's strict mode), but it logs a scary error which can be misleading during debugging.