### PR TITLE
Add an underline to blue (external) links on hover

### DIFF
--- a/src/typography/Typography.module.css
+++ b/src/typography/Typography.module.css
@@ -24,6 +24,11 @@
   color: var(--links);
 }
 
+.link:hover {
+  text-decoration: underline;
+  opacity: initial;
+}
+
 .primary {
   color: var(--accent);
 }


### PR DESCRIPTION
This is in line with Element Web's behavior, and is a [WCAG accessibility requirement](https://webaim.org/techniques/hypertext/link_text#underlining).