### PR TITLE
Fix Walkie-Talkie mode in Safari

### DIFF
--- a/src/settings/useMediaHandler.tsx
+++ b/src/settings/useMediaHandler.tsx
@@ -160,7 +160,7 @@ export function MediaHandlerProvider({ client, children }: Props): JSX.Element {
 
         if (
           // @ts-ignore
-          mediaHandler.videoInput !== videoInput ||
+          (mediaHandler.videoInput && mediaHandler.videoInput !== videoInput) ||
           // @ts-ignore
           mediaHandler.audioInput !== audioInput
         ) {


### PR DESCRIPTION
We didn't check whether we actually had a video device when seeing if the current video devices was in the list of devices, so this caused loops which confused Safari.

Seems this was actually regressed by the latest Safari rather than any of our changes (it appears to emit a `devicechange` event after you get a stream to reflect the fact that you'll now get IDs and labels on your devices).