### PR TITLE
Improve the visual experience of joining a call

### DIFF
--- a/src/room/InCallView.tsx
+++ b/src/room/InCallView.tsx
@@ -126,6 +126,7 @@ export function InCallView({
 
   const containerRef1 = useRef<HTMLDivElement | null>(null);
   const [containerRef2, bounds] = useMeasure({ polyfill: ResizeObserver });
+  const boundsValid = bounds.height > 0;
   // Merge the refs so they can attach to the same element
   const containerRef = useCallback(
     (el: HTMLDivElement) => {
@@ -238,15 +239,15 @@ export function InCallView({
   const maximisedParticipant = useMemo(
     () =>
       fullscreenParticipant ??
-      (bounds.height <= 400 && bounds.width <= 400
+      (boundsValid && bounds.height <= 400 && bounds.width <= 400
         ? items.find((item) => item.focused) ??
           items.find((item) => item.callFeed) ??
           null
         : null),
-    [fullscreenParticipant, bounds, items]
+    [fullscreenParticipant, boundsValid, bounds, items]
   );
 
-  const reducedControls = bounds.width <= 400;
+  const reducedControls = boundsValid && bounds.width <= 400;
 
   const renderAvatar = useCallback(
     (roomMember: RoomMember, width: number, height: number) => {


### PR DESCRIPTION
Because `useMeasure` always returns a width and height of zero on the first render, various call UI elements would flash in and out of existence or animate in from the wrong place when joining a call. This poses an accessibility issue, and is generally unpleasant.

Closes https://github.com/vector-im/element-call/issues/569

**Before**

https://user-images.githubusercontent.com/48614497/199638100-9ddd84e6-488c-46b0-8c4b-d98945ce0f78.mp4

**After**

https://user-images.githubusercontent.com/48614497/199638119-35acd0fa-b5c6-4cc3-86b6-e6cad0df9889.mp4