### PR TITLE
Enable fullscreen button for all tiles

### DIFF
--- a/src/video-grid/VideoTile.tsx
+++ b/src/video-grid/VideoTile.tsx
@@ -82,16 +82,14 @@ export const VideoTile = forwardRef<HTMLDivElement, Props>(
         />
       );
 
-      if (screenshare) {
-        toolbarButtons.push(
-          <FullscreenButton
-            key="fullscreen"
-            className={styles.button}
-            fullscreen={fullscreen}
-            onPress={onFullscreen}
-          />
-        );
-      }
+      toolbarButtons.push(
+        <FullscreenButton
+          key="fullscreen"
+          className={styles.button}
+          fullscreen={fullscreen}
+          onPress={onFullscreen}
+        />
+      );
     }
 
     const caption = hasFeed ? name : t("{{name}} (Connecting...)", { name });


### PR DESCRIPTION
Currently, the fullscreen button in the top right corner of the video tile is only shown for screenshare.
This PR enables it for every video feed.

It is a useful feature, and it doesn't bring any considerable disadvantages.

Closes https://github.com/vector-im/element-call/issues/566

Signed-off-by: notramo <notramo@protonmail.com>