### PR TITLE
Preserve aspect ratio for fullscreen video

### DIFF
--- a/src/video-grid/VideoTile.module.css
+++ b/src/video-grid/VideoTile.module.css
@@ -47,6 +47,7 @@
   width: 100%;
 }
 
+.videoTile.maximised > video,
 .videoTile.screenshare > video {
   object-fit: contain;
 }


### PR DESCRIPTION
Current behavior: crop fullscreen video to 16:9
This PR: preserve aspect ratio when video is fullscreen.

Note that screensharing already preserves the aspect ratio, so this is only relevant for regular streams in fullscreen (#715).