### PR TITLE
Don't check out group-call branch in build script

### DIFF
--- a/scripts/dockerbuild.sh
+++ b/scripts/dockerbuild.sh
@@ -7,7 +7,6 @@ export VITE_PRODUCT_NAME="Element Call"
 
 git clone https://github.com/matrix-org/matrix-js-sdk.git
 cd matrix-js-sdk
-git checkout robertlong/group-call
 yarn install
 yarn run build
 yarn link


### PR DESCRIPTION
This build script might change more soon (we shouldn't really need to checkout & link the js-sdk at all) but for now let's just switch the branch now group-call is merged.