### PR TITLE
Add 'm' and 'space' shortcuts for mute/unmuting during a call

### DIFF
--- a/public/locales/en-GB/app.json
+++ b/public/locales/en-GB/app.json
@@ -134,6 +134,7 @@
   "Walkie-talkie call": "Walkie-talkie call",
   "Walkie-talkie call name": "Walkie-talkie call name",
   "WebRTC is not supported or is being blocked in this browser.": "WebRTC is not supported or is being blocked in this browser.",
+  "Whether to enable the keyboard shortcuts to e.g. mute/unmute the local microphone.": "Whether to enable the keyboard shortcuts to e.g. mute/unmute the local microphone.",
   "Yes, join call": "Yes, join call",
   "You can't talk at the same time": "You can't talk at the same time",
   "Your recent calls": "Your recent calls"

--- a/public/locales/en-GB/app.json
+++ b/public/locales/en-GB/app.json
@@ -42,6 +42,7 @@
   "Display name": "Display name",
   "Download debug logs": "Download debug logs",
   "Element Call Home": "Element Call Home",
+  "Enable keyboard shortcuts": "Enable keyboard shortcuts",
   "Entering room…": "Entering room…",
   "Exit full screen": "Exit full screen",
   "Fetching group call timed out.": "Fetching group call timed out.",

--- a/public/locales/en-GB/app.json
+++ b/public/locales/en-GB/app.json
@@ -134,7 +134,7 @@
   "Walkie-talkie call": "Walkie-talkie call",
   "Walkie-talkie call name": "Walkie-talkie call name",
   "WebRTC is not supported or is being blocked in this browser.": "WebRTC is not supported or is being blocked in this browser.",
-  "Whether to enable the keyboard shortcuts to e.g. mute/unmute the local microphone.": "Whether to enable the keyboard shortcuts to e.g. mute/unmute the local microphone.",
+  "Whether to enable the keyboard shortcuts, e.g. 'm' to mute/unmute the mic.": "Whether to enable the keyboard shortcuts, e.g. 'm' to mute/unmute the mic.",
   "Yes, join call": "Yes, join call",
   "You can't talk at the same time": "You can't talk at the same time",
   "Your recent calls": "Your recent calls"

--- a/public/locales/en-GB/app.json
+++ b/public/locales/en-GB/app.json
@@ -42,7 +42,7 @@
   "Display name": "Display name",
   "Download debug logs": "Download debug logs",
   "Element Call Home": "Element Call Home",
-  "Enable keyboard shortcuts": "Enable keyboard shortcuts",
+  "Single-key keyboard shortcuts": "Single-key keyboard shortcuts",
   "Entering room…": "Entering room…",
   "Exit full screen": "Exit full screen",
   "Fetching group call timed out.": "Fetching group call timed out.",
@@ -134,7 +134,7 @@
   "Walkie-talkie call": "Walkie-talkie call",
   "Walkie-talkie call name": "Walkie-talkie call name",
   "WebRTC is not supported or is being blocked in this browser.": "WebRTC is not supported or is being blocked in this browser.",
-  "Whether to enable the keyboard shortcuts, e.g. 'm' to mute/unmute the mic.": "Whether to enable the keyboard shortcuts, e.g. 'm' to mute/unmute the mic.",
+  "Whether to enable single-key keyboard shortcuts, e.g. 'm' to mute/unmute the mic.": "Whether to enable single-key keyboard shortcuts, e.g. 'm' to mute/unmute the mic.",
   "Yes, join call": "Yes, join call",
   "You can't talk at the same time": "You can't talk at the same time",
   "Your recent calls": "Your recent calls"

--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -14,7 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { DEFAULT_CONFIG, ConfigOptions, ResolvedConfigOptions } from "./ConfigOptions";
+import {
+  DEFAULT_CONFIG,
+  ConfigOptions,
+  ResolvedConfigOptions,
+} from "./ConfigOptions";
 
 export class Config {
   private static internalInstance: Config;

--- a/src/room/PTTButton.tsx
+++ b/src/room/PTTButton.tsx
@@ -23,6 +23,7 @@ import { ReactComponent as MicIcon } from "../icons/Mic.svg";
 import { useEventTarget } from "../useEvents";
 import { Avatar } from "../Avatar";
 import { usePrefersReducedMotion } from "../usePrefersReducedMotion";
+import { getSetting } from "../settings/useSetting";
 
 interface Props {
   enabled: boolean;
@@ -134,6 +135,12 @@ export const PTTButton: React.FC<Props> = ({
       (e: KeyboardEvent) => {
         if (e.code === "Space") {
           if (!enabled) return;
+          // Check if keyboard shortcuts are enabled
+          const keyboardShortcuts = getSetting("keyboard-shortcuts", true);
+          if (!keyboardShortcuts) {
+            return;
+          }
+
           e.preventDefault();
 
           hold();
@@ -148,6 +155,12 @@ export const PTTButton: React.FC<Props> = ({
     useCallback(
       (e: KeyboardEvent) => {
         if (e.code === "Space") {
+          // Check if keyboard shortcuts are enabled
+          const keyboardShortcuts = getSetting("keyboard-shortcuts", true);
+          if (!keyboardShortcuts) {
+            return;
+          }
+
           e.preventDefault();
 
           unhold();

--- a/src/room/useGroupCall.ts
+++ b/src/room/useGroupCall.ts
@@ -33,6 +33,7 @@ import { usePageUnload } from "./usePageUnload";
 import { PosthogAnalytics } from "../PosthogAnalytics";
 import { TranslatedError, translatedError } from "../TranslatedError";
 import { ElementWidgetActions, ScreenshareStartData, widget } from "../widget";
+import { getSetting } from "../settings/useSetting";
 
 export interface UseGroupCallReturnType {
   state: GroupCallState;
@@ -404,6 +405,12 @@ export function useGroupCall(groupCall: GroupCall): UseGroupCallReturnType {
 
   useEffect(() => {
     const keyDownListener = (event) => {
+      // Check if keyboard shortcuts are enabled
+      const keyboardShortcuts = getSetting("keyboard-shortcuts", true);
+      if (!keyboardShortcuts) {
+        return;
+      }
+
       if (event.key === "m") {
         toggleMicrophoneMuted();
       }
@@ -413,6 +420,12 @@ export function useGroupCall(groupCall: GroupCall): UseGroupCallReturnType {
     };
 
     const keyUpListener = (event) => {
+      // Check if keyboard shortcuts are enabled
+      const keyboardShortcuts = getSetting("keyboard-shortcuts", true);
+      if (!keyboardShortcuts) {
+        return;
+      }
+
       if (event.key === " ") {
         setMicrophoneMuted(true);
       }

--- a/src/room/useGroupCall.ts
+++ b/src/room/useGroupCall.ts
@@ -298,10 +298,14 @@ export function useGroupCall(groupCall: GroupCall): UseGroupCallReturnType {
     PosthogAnalytics.instance.eventMuteCamera.track(toggleToMute);
   }, [groupCall]);
 
+  const setMicrophoneMuted = useCallback((setMuted) => {
+    groupCall.setMicrophoneMuted(setMuted);
+    PosthogAnalytics.instance.eventMuteMicrophone.track(setMuted);
+  }, [groupCall]);
+
   const toggleMicrophoneMuted = useCallback(() => {
     const toggleToMute = !groupCall.isMicrophoneMuted();
-    groupCall.setMicrophoneMuted(toggleToMute);
-    PosthogAnalytics.instance.eventMuteMicrophone.track(toggleToMute);
+    setMicrophoneMuted(toggleToMute);
   }, [groupCall]);
 
   const toggleScreensharing = useCallback(async () => {
@@ -394,6 +398,33 @@ export function useGroupCall(groupCall: GroupCall): UseGroupCallReturnType {
       updateState({ error });
     }
   }, [t]);
+
+
+  useEffect(() => {
+    const keyDownListener = (event) => {
+      if (event.key === "m") {
+        toggleMicrophoneMuted();
+      }
+      if (event.key === " ") {
+        setMicrophoneMuted(false);
+      }
+    };
+
+    const keyUpListener = (event) => {
+      if (event.key === " ") {
+        setMicrophoneMuted(true);
+      }
+    };
+
+    window.addEventListener("keydown", keyDownListener, true);
+    window.addEventListener("keyup", keyUpListener, true);
+
+    return () => {
+      window.removeEventListener("keydown", keyDownListener, true);
+      window.removeEventListener("keyup", keyUpListener, true);
+    }
+  }, [toggleMicrophoneMuted, setMicrophoneMuted]);
+
 
   return {
     state,

--- a/src/room/useGroupCall.ts
+++ b/src/room/useGroupCall.ts
@@ -404,6 +404,8 @@ export function useGroupCall(groupCall: GroupCall): UseGroupCallReturnType {
     }
   }, [t]);
 
+  const [spacebarHeld, setSpacebarHeld] = useState(false);
+
   useEventTarget(
     window,
     "keydown",
@@ -420,10 +422,16 @@ export function useGroupCall(groupCall: GroupCall): UseGroupCallReturnType {
         } else if (event.key == "v") {
           toggleLocalVideoMuted();
         } else if (event.key === " ") {
+          setSpacebarHeld(true);
           setMicrophoneMuted(false);
         }
       },
-      [toggleLocalVideoMuted, toggleMicrophoneMuted, setMicrophoneMuted]
+      [
+        toggleLocalVideoMuted,
+        toggleMicrophoneMuted,
+        setMicrophoneMuted,
+        setSpacebarHeld,
+      ]
     )
   );
 
@@ -439,11 +447,23 @@ export function useGroupCall(groupCall: GroupCall): UseGroupCallReturnType {
         }
 
         if (event.key === " ") {
+          setSpacebarHeld(false);
           setMicrophoneMuted(true);
         }
       },
-      [setMicrophoneMuted]
+      [setMicrophoneMuted, setSpacebarHeld]
     )
+  );
+
+  useEventTarget(
+    window,
+    "blur",
+    useCallback(() => {
+      if (spacebarHeld) {
+        setSpacebarHeld(false);
+        setMicrophoneMuted(true);
+      }
+    }, [setMicrophoneMuted, setSpacebarHeld, spacebarHeld])
   );
 
   return {

--- a/src/room/useGroupCall.ts
+++ b/src/room/useGroupCall.ts
@@ -417,12 +417,13 @@ export function useGroupCall(groupCall: GroupCall): UseGroupCallReturnType {
 
         if (event.key === "m") {
           toggleMicrophoneMuted();
-        }
-        if (event.key === " ") {
+        } else if (event.key == "v") {
+          toggleLocalVideoMuted();
+        } else if (event.key === " ") {
           setMicrophoneMuted(false);
         }
       },
-      [toggleMicrophoneMuted, setMicrophoneMuted]
+      [toggleLocalVideoMuted, toggleMicrophoneMuted, setMicrophoneMuted]
     )
   );
 

--- a/src/room/useGroupCall.ts
+++ b/src/room/useGroupCall.ts
@@ -298,10 +298,13 @@ export function useGroupCall(groupCall: GroupCall): UseGroupCallReturnType {
     PosthogAnalytics.instance.eventMuteCamera.track(toggleToMute);
   }, [groupCall]);
 
-  const setMicrophoneMuted = useCallback((setMuted) => {
-    groupCall.setMicrophoneMuted(setMuted);
-    PosthogAnalytics.instance.eventMuteMicrophone.track(setMuted);
-  }, [groupCall]);
+  const setMicrophoneMuted = useCallback(
+    (setMuted) => {
+      groupCall.setMicrophoneMuted(setMuted);
+      PosthogAnalytics.instance.eventMuteMicrophone.track(setMuted);
+    },
+    [groupCall]
+  );
 
   const toggleMicrophoneMuted = useCallback(() => {
     const toggleToMute = !groupCall.isMicrophoneMuted();
@@ -399,7 +402,6 @@ export function useGroupCall(groupCall: GroupCall): UseGroupCallReturnType {
     }
   }, [t]);
 
-
   useEffect(() => {
     const keyDownListener = (event) => {
       if (event.key === "m") {
@@ -422,9 +424,8 @@ export function useGroupCall(groupCall: GroupCall): UseGroupCallReturnType {
     return () => {
       window.removeEventListener("keydown", keyDownListener, true);
       window.removeEventListener("keyup", keyUpListener, true);
-    }
+    };
   }, [toggleMicrophoneMuted, setMicrophoneMuted]);
-
 
   return {
     state,

--- a/src/room/useGroupCall.ts
+++ b/src/room/useGroupCall.ts
@@ -34,6 +34,7 @@ import { PosthogAnalytics } from "../PosthogAnalytics";
 import { TranslatedError, translatedError } from "../TranslatedError";
 import { ElementWidgetActions, ScreenshareStartData, widget } from "../widget";
 import { getSetting } from "../settings/useSetting";
+import { useEventTarget } from "../useEvents";
 
 export interface UseGroupCallReturnType {
   state: GroupCallState;
@@ -403,42 +404,46 @@ export function useGroupCall(groupCall: GroupCall): UseGroupCallReturnType {
     }
   }, [t]);
 
-  useEffect(() => {
-    const keyDownListener = (event) => {
-      // Check if keyboard shortcuts are enabled
-      const keyboardShortcuts = getSetting("keyboard-shortcuts", true);
-      if (!keyboardShortcuts) {
-        return;
-      }
+  useEventTarget(
+    window,
+    "keydown",
+    useCallback(
+      (event: KeyboardEvent) => {
+        // Check if keyboard shortcuts are enabled
+        const keyboardShortcuts = getSetting("keyboard-shortcuts", true);
+        if (!keyboardShortcuts) {
+          return;
+        }
 
-      if (event.key === "m") {
-        toggleMicrophoneMuted();
-      }
-      if (event.key === " ") {
-        setMicrophoneMuted(false);
-      }
-    };
+        if (event.key === "m") {
+          toggleMicrophoneMuted();
+        }
+        if (event.key === " ") {
+          setMicrophoneMuted(false);
+        }
+      },
+      [toggleMicrophoneMuted, setMicrophoneMuted]
+    )
+  );
 
-    const keyUpListener = (event) => {
-      // Check if keyboard shortcuts are enabled
-      const keyboardShortcuts = getSetting("keyboard-shortcuts", true);
-      if (!keyboardShortcuts) {
-        return;
-      }
+  useEventTarget(
+    window,
+    "keyup",
+    useCallback(
+      (event: KeyboardEvent) => {
+        // Check if keyboard shortcuts are enabled
+        const keyboardShortcuts = getSetting("keyboard-shortcuts", true);
+        if (!keyboardShortcuts) {
+          return;
+        }
 
-      if (event.key === " ") {
-        setMicrophoneMuted(true);
-      }
-    };
-
-    window.addEventListener("keydown", keyDownListener, true);
-    window.addEventListener("keyup", keyUpListener, true);
-
-    return () => {
-      window.removeEventListener("keydown", keyDownListener, true);
-      window.removeEventListener("keyup", keyUpListener, true);
-    };
-  }, [toggleMicrophoneMuted, setMicrophoneMuted]);
+        if (event.key === " ") {
+          setMicrophoneMuted(true);
+        }
+      },
+      [setMicrophoneMuted]
+    )
+  );
 
   return {
     state,

--- a/src/room/useGroupCall.ts
+++ b/src/room/useGroupCall.ts
@@ -309,7 +309,7 @@ export function useGroupCall(groupCall: GroupCall): UseGroupCallReturnType {
   const toggleMicrophoneMuted = useCallback(() => {
     const toggleToMute = !groupCall.isMicrophoneMuted();
     setMicrophoneMuted(toggleToMute);
-  }, [groupCall]);
+  }, [groupCall, setMicrophoneMuted]);
 
   const toggleScreensharing = useCallback(async () => {
     if (!groupCall.isScreensharing()) {

--- a/src/settings/SettingsModal.tsx
+++ b/src/settings/SettingsModal.tsx
@@ -175,7 +175,7 @@ export const SettingsModal = (props: Props) => {
               type="checkbox"
               checked={keyboardShortcuts}
               description={t(
-                "Whether to enable the keyboard shortcuts to e.g. mute/unmute the local microphone."
+                "Whether to enable the keyboard shortcuts, e.g. 'm' to mute/unmute the mic."
               )}
               onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
                 setKeyboardShortcuts(event.target.checked)

--- a/src/settings/SettingsModal.tsx
+++ b/src/settings/SettingsModal.tsx
@@ -28,6 +28,7 @@ import { ReactComponent as OverflowIcon } from "../icons/Overflow.svg";
 import { SelectInput } from "../input/SelectInput";
 import { useMediaHandler } from "./useMediaHandler";
 import {
+  useKeyboardShortcuts,
   useSpatialAudio,
   useShowInspector,
   useOptInAnalytics,
@@ -59,6 +60,7 @@ export const SettingsModal = (props: Props) => {
   const [spatialAudio, setSpatialAudio] = useSpatialAudio();
   const [showInspector, setShowInspector] = useShowInspector();
   const [optInAnalytics, setOptInAnalytics] = useOptInAnalytics();
+  const [keyboardShortcuts, setKeyboardShortcuts] = useKeyboardShortcuts();
 
   const downloadDebugLog = useDownloadDebugLog();
 
@@ -163,6 +165,17 @@ export const SettingsModal = (props: Props) => {
               )}
               onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
                 setOptInAnalytics(event.target.checked)
+              }
+            />
+          </FieldRow>
+          <FieldRow>
+            <InputField
+              id="keyboardShortcuts"
+              label={t("Enable keyboard shortcuts")}
+              type="checkbox"
+              checked={keyboardShortcuts}
+              onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
+                setKeyboardShortcuts(event.target.checked)
               }
             />
           </FieldRow>

--- a/src/settings/SettingsModal.tsx
+++ b/src/settings/SettingsModal.tsx
@@ -171,11 +171,11 @@ export const SettingsModal = (props: Props) => {
           <FieldRow>
             <InputField
               id="keyboardShortcuts"
-              label={t("Enable keyboard shortcuts")}
+              label={t("Single-key keyboard shortcuts")}
               type="checkbox"
               checked={keyboardShortcuts}
               description={t(
-                "Whether to enable the keyboard shortcuts, e.g. 'm' to mute/unmute the mic."
+                "Whether to enable single-key keyboard shortcuts, e.g. 'm' to mute/unmute the mic."
               )}
               onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
                 setKeyboardShortcuts(event.target.checked)

--- a/src/settings/SettingsModal.tsx
+++ b/src/settings/SettingsModal.tsx
@@ -174,6 +174,9 @@ export const SettingsModal = (props: Props) => {
               label={t("Enable keyboard shortcuts")}
               type="checkbox"
               checked={keyboardShortcuts}
+              description={t(
+                "Whether to enable the keyboard shortcuts to e.g. mute/unmute the local microphone."
+              )}
               onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
                 setKeyboardShortcuts(event.target.checked)
               }

--- a/src/settings/useSetting.ts
+++ b/src/settings/useSetting.ts
@@ -61,3 +61,5 @@ export const getSetting = <T>(name: string, defaultValue: T): T => {
 export const useSpatialAudio = () => useSetting("spatial-audio", false);
 export const useShowInspector = () => useSetting("show-inspector", false);
 export const useOptInAnalytics = () => useSetting("opt-in-analytics", false);
+export const useKeyboardShortcuts = () =>
+  useSetting("keyboard-shortcuts", true);


### PR DESCRIPTION
I rely on using the `m` and `space` shortcuts to toggle mute in Jitsi all the time, and I *really* miss it.

I have *no* idea what I'm doing when it comes to react and javascript or whatever language I have just written, but it seems to work when I test it :shrug: 

Related issue: https://github.com/vector-im/element-call/issues/218