### PR TITLE
Don't start new calls in widget mode

### DIFF
--- a/src/room/useLoadGroupCall.ts
+++ b/src/room/useLoadGroupCall.ts
@@ -30,6 +30,7 @@ import type { Room } from "matrix-js-sdk/src/models/room";
 import type { GroupCall } from "matrix-js-sdk/src/webrtc/groupCall";
 import { isLocalRoomId, createRoom, roomNameFromRoomId } from "../matrix-utils";
 import { translatedError } from "../TranslatedError";
+import { widget } from "../widget";
 
 export interface GroupCallLoadState {
   loading: boolean;
@@ -89,6 +90,7 @@ export const useLoadGroupCall = (
       if (groupCall) return groupCall;
 
       if (
+        !widget &&
         room.currentState.mayClientSendStateEvent(
           EventType.GroupCallPrefix,
           client

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -110,7 +110,6 @@ export const widget: WidgetHelpers | null = (() => {
       // These are all the event types the app uses
       const sendRecvEvent = ["org.matrix.rageshake_request"];
       const sendState = [
-        { eventType: EventType.GroupCallPrefix },
         { eventType: EventType.GroupCallMemberPrefix, stateKey: userId },
       ];
       const receiveState = [


### PR DESCRIPTION
In widget mode, it's the client's duty to start the call.