### PR TITLE
Simplify build process

### DIFF
--- a/scripts/dockerbuild.sh
+++ b/scripts/dockerbuild.sh
@@ -2,19 +2,7 @@
 
 set -ex
 
-export VITE_DEFAULT_HOMESERVER=https://call.ems.host
-export VITE_PRODUCT_NAME="Element Call"
-
-git clone https://github.com/matrix-org/matrix-js-sdk.git
-cd matrix-js-sdk
-yarn install
-yarn run build
-yarn link
-
-cd ../element-call
-
 export VITE_APP_VERSION=$(git describe --tags --abbrev=0)
 
-yarn link matrix-js-sdk
 yarn install
 yarn run build

--- a/vite.config.js
+++ b/vite.config.js
@@ -35,11 +35,6 @@ export default defineConfig(({ mode }) => {
         },
       }),
     ],
-    server: {
-      proxy: {
-        "/_matrix": env.VITE_DEFAULT_HOMESERVER || "http://localhost:8008",
-      },
-    },
     resolve: {
       alias: {
         // matrix-widget-api has its transpiled lib/index.js as its entry point,


### PR DESCRIPTION
 * We don't need to check out the js-sdk separately anymore
 * Remove the vite proxying: there's no need since Matrix HSes allow cross origin requests. This will let us move the default homeserver config to the config file (in a separate PR...)
 * Remove the product name variable which just set it to the default anyway