### PR TITLE
Fix docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,13 @@ FROM --platform=$BUILDPLATFORM node:16-buster as builder
 
 WORKDIR /src
 
-COPY . /src/element-call
-RUN element-call/scripts/dockerbuild.sh
+COPY . /src
+RUN scripts/dockerbuild.sh
 
 # App
 FROM nginxinc/nginx-unprivileged:alpine
 
-COPY --from=builder /src/element-call/dist /app
+COPY --from=builder /src/dist /app
 COPY config/default.conf /etc/nginx/conf.d/
 
 USER root


### PR DESCRIPTION
Remove the element-call directory level which isn't necessary any more (accidentally removed the `cd element-call` in #794).