### PR TITLE
Remove Olm from devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
   },
   "devDependencies": {
     "@babel/core": "^7.16.5",
-    "@matrix-org/olm": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.8.tgz",
     "@storybook/react": "^6.5.0-alpha.5",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",


### PR DESCRIPTION
It was in devDependencies as well as dependencies for some reason