### PR TITLE
Remove the overflow menu button in fullscreen mode

### DIFF
--- a/src/room/InCallView.tsx
+++ b/src/room/InCallView.tsx
@@ -377,14 +377,16 @@ export function InCallView({
             onPress={toggleScreensharing}
           />
         )}
-        <OverflowMenu
-          inCall
-          roomIdOrAlias={roomIdOrAlias}
-          groupCall={groupCall}
-          showInvite={joinRule === JoinRule.Public}
-          feedbackModalState={feedbackModalState}
-          feedbackModalProps={feedbackModalProps}
-        />
+        {!maximisedParticipant && (
+          <OverflowMenu
+            inCall
+            roomIdOrAlias={roomIdOrAlias}
+            groupCall={groupCall}
+            showInvite={joinRule === JoinRule.Public}
+            feedbackModalState={feedbackModalState}
+            feedbackModalProps={feedbackModalProps}
+          />
+        )}
         <HangupButton onPress={onLeave} />
       </div>
     );


### PR DESCRIPTION
It didn't work and fixing it is a bit of a project: see comment

https://github.com/vector-im/element-call/issues/807