### PR TITLE
Upload source maps to sentry

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Build
         run: "yarn run build"
         env:
-          SENTRY_ORG: ${{ secrets.SENTRY_SENTRY_ORG }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       - name: Upload Artifact

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,6 +18,10 @@ jobs:
         run: "yarn install"
       - name: Build
         run: "yarn run build"
+        env:
+          SENTRY_ORG: ${{ secrets.SENTRY_SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       - name: Upload Artifact
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,6 +21,7 @@ jobs:
         env:
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+          SENTRY_URL: ${{ secrets.SENTRY_URL }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       - name: Upload Artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -45,10 +45,10 @@ jobs:
         run: |
           tar --numeric-owner --transform "s/dist/element-call-foo/" -cvzf element-call-${{ github.event.release.tag_name }}.tar.gz dist
       - name: Upload
-        uses: djn24/add-asset-to-release@v1
+        uses: AButler/upload-release-assets@v2.0
         with:
-          token: ${{secrets.GITHUB_TOKEN}}
-          path: "element-call-${{ github.event.release.tag_name }}.tar.gz"
+          repo-token: ${{secrets.GITHUB_TOKEN}}
+          files: "element-call-${{ github.event.release.tag_name }}.tar.gz"
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Create Tarball
         run: |
-          tar --numeric-owner --transform "s/dist/element-call-$GITHUB_TAG_NAME/" -cvzf element-call-$GITHUB_TAG_NAME.tar.gz dist
+          tar --numeric-owner --transform "s/dist/element-call-${GITHUB_TAG_NAME}/" -cvzf element-call-${GITHUB_TAG_NAME}.tar.gz dist
       - name: Upload
         uses: alexellis/upload-assets@0.4.0
         env:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -43,11 +43,12 @@ jobs:
 
       - name: Create Tarball
         run: |
-          tar --numeric-owner --transform "s/dist/element-call-"${{ github.event.release.tag_name }}"/" -cvzf element-call-${{ github.event.release.tag_name }}.tar.gz dist
+          tar --numeric-owner --transform "s/dist/element-call-$GITHUB_TAG_NAME/" -cvzf element-call-$GITHUB_TAG_NAME.tar.gz dist
       - name: Upload
         uses: alexellis/upload-assets@0.4.0
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TAG_NAME: ${{ github.event.release.tag_name }}
         with:
           asset_paths: '["element-call-${{ github.event.release.tag_name }}.tar.gz"]'
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -42,13 +42,14 @@ jobs:
           VITE_APP_VERSION: ${{ github.event.release.tag_name }}
 
       - name: Create Tarball
+        env:
+          GITHUB_TAG_NAME: ${{ github.event.release.tag_name }}
         run: |
           tar --numeric-owner --transform "s/dist/element-call-${GITHUB_TAG_NAME}/" -cvzf element-call-${GITHUB_TAG_NAME}.tar.gz dist
       - name: Upload
         uses: alexellis/upload-assets@0.4.0
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          GITHUB_TAG_NAME: ${{ github.event.release.tag_name }}
         with:
           asset_paths: '["element-call-${{ github.event.release.tag_name }}.tar.gz"]'
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Build
         run: "yarn run build"
         env:
-          SENTRY_ORG: ${{ secrets.SENTRY_SENTRY_ORG }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           VITE_APP_VERSION: ${{ github.ref }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -26,6 +26,24 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Yarn cache
+        uses: actions/setup-node@v3
+        with:
+          cache: "yarn"
+      - name: Install dependencies
+        run: "yarn install"
+      - name: Build
+        run: "yarn run build"
+
+      - name: Create Tarball
+        run: -
+          tar --numeric-owner --transform "/dist/element-call-foo/" -cvzf element-call-${{ github.ref }}.tar.gz dist
+      - name: Upload
+        uses: djn24/add-asset-to-release@v1
+        with:
+          token: ${{secrets.GITHUB_TOKEN}}
+          path: "element-call-${{ github.ref }}.tar.gz"
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -33,7 +33,12 @@ jobs:
       - name: Install dependencies
         run: "yarn install"
       - name: Build
-        run: "VITE_APP_VERSION={{ github.ref }} yarn run build"
+        run: "yarn run build"
+        env:
+          SENTRY_ORG: ${{ secrets.SENTRY_SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          VITE_APP_VERSION: ${{ github.ref }}
 
       - name: Create Tarball
         run: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Install dependencies
         run: "yarn install"
       - name: Build
-        run: "yarn run build"
+        run: "VITE_APP_VERSION={{ github.ref }} yarn run build"
 
       - name: Create Tarball
         run: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,7 +13,7 @@ jobs:
     name: Build & publish
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: write # required to upload release asset
       packages: write
     steps:
       - name: Check it out
@@ -43,7 +43,7 @@ jobs:
 
       - name: Create Tarball
         run: |
-          tar --numeric-owner --transform "s/dist/element-call-foo/" -cvzf element-call-${{ github.event.release.tag_name }}.tar.gz dist
+          tar --numeric-owner --transform "s/dist/element-call-"${{ github.event.release.tag_name }}"/" -cvzf element-call-${{ github.event.release.tag_name }}.tar.gz dist
       - name: Upload
         uses: alexellis/upload-assets@0.4.0
         env:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Create Tarball
         run: |
-          tar --numeric-owner --transform "/dist/element-call-foo/" -cvzf element-call-${{ github.ref }}.tar.gz dist
+          tar --numeric-owner --transform "s/dist/element-call-foo/" -cvzf element-call-${{ github.ref }}.tar.gz dist
       - name: Upload
         uses: djn24/add-asset-to-release@v1
         with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -37,17 +37,18 @@ jobs:
         env:
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+          SENTRY_URL: ${{ secrets.SENTRY_URL }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          VITE_APP_VERSION: ${{ github.ref }}
+          VITE_APP_VERSION: ${{ github.event.release.tag_name }}
 
       - name: Create Tarball
         run: |
-          tar --numeric-owner --transform "s/dist/element-call-foo/" -cvzf element-call-${{ github.ref }}.tar.gz dist
+          tar --numeric-owner --transform "s/dist/element-call-foo/" -cvzf element-call-${{ github.event.release.tag_name }}.tar.gz dist
       - name: Upload
         uses: djn24/add-asset-to-release@v1
         with:
           token: ${{secrets.GITHUB_TOKEN}}
-          path: "element-call-${{ github.ref }}.tar.gz"
+          path: "element-call-${{ github.event.release.tag_name }}.tar.gz"
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,7 +13,7 @@ jobs:
     name: Build & publish
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       packages: write
     steps:
       - name: Check it out
@@ -45,10 +45,11 @@ jobs:
         run: |
           tar --numeric-owner --transform "s/dist/element-call-foo/" -cvzf element-call-${{ github.event.release.tag_name }}.tar.gz dist
       - name: Upload
-        uses: AButler/upload-release-assets@v2.0
+        uses: alexellis/upload-assets@0.4.0
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         with:
-          repo-token: ${{secrets.GITHUB_TOKEN}}
-          files: "element-call-${{ github.event.release.tag_name }}.tar.gz"
+          asset_paths: '["element-call-${{ github.event.release.tag_name }}.tar.gz"]'
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -36,7 +36,7 @@ jobs:
         run: "yarn run build"
 
       - name: Create Tarball
-        run: -
+        run: |
           tar --numeric-owner --transform "/dist/element-call-foo/" -cvzf element-call-${{ github.ref }}.tar.gz dist
       - name: Upload
         uses: djn24/add-asset-to-release@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,6 @@
-FROM --platform=$BUILDPLATFORM node:16-buster as builder
-
-WORKDIR /src
-
-COPY . /src
-RUN scripts/dockerbuild.sh
-
-# App
 FROM nginxinc/nginx-unprivileged:alpine
 
-COPY --from=builder /src/dist /app
+COPY ./dist /app
 COPY config/nginx.conf /etc/nginx/conf.d/
 
 USER root

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM nginxinc/nginx-unprivileged:alpine
 
 COPY ./dist /app
-COPY config/nginx.conf /etc/nginx/conf.d/
+COPY config/nginx.conf /etc/nginx/conf.d/default.conf
 
 USER root
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "VITE_APP_VERSION=$(git describe --tags --abbrev=0) && vite build",
     "serve": "vite preview",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.16.5",
+    "@sentry/vite-plugin": "^0.3.0",
     "@storybook/react": "^6.5.0-alpha.5",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "VITE_APP_VERSION=$(git describe --tags --abbrev=0) && vite build",
+    "build": "vite build",
     "serve": "vite preview",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",

--- a/vite.config.js
+++ b/vite.config.js
@@ -36,7 +36,7 @@ export default defineConfig(({ mode }) => {
 
   if (
     process.env.SENTRY_ORG &&
-    process.ev.SENTRY_PROJECT &&
+    process.env.SENTRY_PROJECT &&
     process.env.SENTRY_AUTH_TOKEN &&
     process.env.SENTRY_URL
   ) {

--- a/vite.config.js
+++ b/vite.config.js
@@ -36,12 +36,12 @@ export default defineConfig(({ mode }) => {
 
   plugins.push(sentryVitePlugin({  
     include: "./dist",  
+    release: process.env.VITE_APP_VERSION,
   }));
 
   return {
     build: {
       sourcemap: true,
-      dist: process.env.VITE_APP_VERSION,
     },
     plugins,
     resolve: {

--- a/vite.config.js
+++ b/vite.config.js
@@ -34,12 +34,19 @@ export default defineConfig(({ mode }) => {
     }),
   ];
 
-  plugins.push(
-    sentryVitePlugin({
-      include: "./dist",
-      release: process.env.VITE_APP_VERSION,
-    })
-  );
+  if (
+    process.env.SENTRY_ORG &&
+    process.ev.SENTRY_PROJECT &&
+    process.env.SENTRY_AUTH_TOKEN &&
+    process.env.SENTRY_URL
+  ) {
+    plugins.push(
+      sentryVitePlugin({
+        include: "./dist",
+        release: process.env.VITE_APP_VERSION,
+      })
+    );
+  }
 
   return {
     build: {

--- a/vite.config.js
+++ b/vite.config.js
@@ -17,24 +17,32 @@ limitations under the License.
 import { defineConfig, loadEnv } from "vite";
 import svgrPlugin from "vite-plugin-svgr";
 import htmlTemplate from "vite-plugin-html-template";
+import sentryVitePlugin from "@sentry/vite-plugin";
+
 import path from "path";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd());
 
+  const plugins = [
+    svgrPlugin(),
+    htmlTemplate.default({
+      data: {
+        title: env.VITE_PRODUCT_NAME || "Element Call",
+      },
+    }),
+  ];
+
+  plugins.push(sentryVitePlugin({  
+    include: "./dist",  
+  }));
+
   return {
     build: {
       sourcemap: true,
     },
-    plugins: [
-      svgrPlugin(),
-      htmlTemplate.default({
-        data: {
-          title: env.VITE_PRODUCT_NAME || "Element Call",
-        },
-      }),
-    ],
+    plugins,
     resolve: {
       alias: {
         // matrix-widget-api has its transpiled lib/index.js as its entry point,

--- a/vite.config.js
+++ b/vite.config.js
@@ -34,10 +34,12 @@ export default defineConfig(({ mode }) => {
     }),
   ];
 
-  plugins.push(sentryVitePlugin({  
-    include: "./dist",  
-    release: process.env.VITE_APP_VERSION,
-  }));
+  plugins.push(
+    sentryVitePlugin({
+      include: "./dist",
+      release: process.env.VITE_APP_VERSION,
+    })
+  );
 
   return {
     build: {

--- a/vite.config.js
+++ b/vite.config.js
@@ -41,6 +41,7 @@ export default defineConfig(({ mode }) => {
   return {
     build: {
       sourcemap: true,
+      dist: process.env.VITE_APP_VERSION,
     },
     plugins,
     resolve: {


### PR DESCRIPTION
Uses the vite sentry plugin which should also embed the release (in theory).

Also builds separately in the publish stage, as uploading source maps as part building the docker image is weird. This also means we can publish a tarball of just the built app.

Also fix the docker image again because I forgot to specify the destination file for the config file.

Secrets are added and should be ready to go.