### PR TITLE
send posthog events instantly for callEnded in embedded mode

### DIFF
--- a/src/PosthogAnalytics.ts
+++ b/src/PosthogAnalytics.ts
@@ -54,10 +54,6 @@ export interface IPosthogEvent {
   $set_once?: void;
 }
 
-export interface IPostHogEventOptions {
-  timestamp?: Date;
-}
-
 export enum Anonymity {
   Disabled,
   Anonymous,
@@ -373,7 +369,7 @@ export class PosthogAnalytics {
 
   public async trackEvent<E extends IPosthogEvent>(
     { eventName, ...properties }: E,
-    options?: IPostHogEventOptions
+    options?: CaptureOptions
   ): Promise<void> {
     if (this.identificationPromise) {
       // only make calls to posthog after the identificaion is done

--- a/src/PosthogEvents.ts
+++ b/src/PosthogEvents.ts
@@ -45,14 +45,17 @@ export class CallEndedTracker {
     );
   }
 
-  track(callId: string, callParticipantsNow: number) {
-    PosthogAnalytics.instance.trackEvent<CallEnded>({
-      eventName: "CallEnded",
-      callId: callId,
-      callParticipantsMax: this.cache.maxParticipantsCount,
-      callParticipantsOnLeave: callParticipantsNow,
-      callDuration: (Date.now() - this.cache.startTime.getTime()) / 1000,
-    });
+  track(callId: string, callParticipantsNow: number, sendInstantly: boolean) {
+    PosthogAnalytics.instance.trackEvent<CallEnded>(
+      {
+        eventName: "CallEnded",
+        callId: callId,
+        callParticipantsMax: this.cache.maxParticipantsCount,
+        callParticipantsOnLeave: callParticipantsNow,
+        callDuration: (Date.now() - this.cache.startTime.getTime()) / 1000,
+      },
+      { send_instantly: sendInstantly }
+    );
   }
 }
 

--- a/src/room/GroupCallView.tsx
+++ b/src/room/GroupCallView.tsx
@@ -195,7 +195,6 @@ export function GroupCallView({
     leave();
     if (widget) {
       // we need to wait until the callEnded event is tracked. Otherwise the iFrame gets killed before tracking the event
-      // This blocks for 500ms;
       await new Promise((resolve) => window.setTimeout(resolve, 500)); // 500ms
       PosthogAnalytics.instance.logout();
       widget.api.transport.send(ElementWidgetActions.HangupCall, {});

--- a/src/room/GroupCallView.tsx
+++ b/src/room/GroupCallView.tsx
@@ -184,7 +184,8 @@ export function GroupCallView({
       participantCount += deviceMap.size;
     }
 
-    // In widget mode we want the event to be sent instantly so it is not queued
+    // In embedded/widget mode the iFrame will be killed right after the call ended prohibiting the posthog event from getting sent,
+    // therefore we want the event to be sent instantly without getting queued/batched.
     const sendInstantly = !!widget;
     PosthogAnalytics.instance.eventCallEnded.track(
       groupCall.groupCallId,
@@ -194,7 +195,7 @@ export function GroupCallView({
 
     leave();
     if (widget) {
-      // we need to wait until the callEnded event is tracked. Otherwise the iFrame gets killed before tracking the event
+      // we need to wait until the callEnded event is tracked. Otherwise the iFrame gets killed before tracking the event.
       await new Promise((resolve) => window.setTimeout(resolve, 500)); // 500ms
       PosthogAnalytics.instance.logout();
       widget.api.transport.send(ElementWidgetActions.HangupCall, {});


### PR DESCRIPTION
In embedded mode the iFrame will be killed right after the call ended. This prohibits the event from beeing sent. With the send_instantly flag we skip the posthog batching queue to send the event before the iFrame closes.