### PR TITLE
Use IndexedDB storage in dev mode, just without the worker

### DIFF
--- a/src/matrix-utils.ts
+++ b/src/matrix-utils.ts
@@ -94,12 +94,17 @@ export async function initClient(
 
   const storeOpts = {} as ICreateClientOpts;
 
-  if (indexedDB && localStorage && !import.meta.env.DEV) {
+  if (indexedDB && localStorage) {
     storeOpts.store = new IndexedDBStore({
       indexedDB: window.indexedDB,
       localStorage,
       dbName: SYNC_STORE_NAME,
-      workerFactory: () => new IndexedDBWorker(),
+      // We can't use the worker in dev mode because Vite simply doesn't bundle workers
+      // in dev mode: it expects them to use native modules. Ours don't, and even then only
+      // Chrome supports it. (It bundles them fine in production mode.)
+      workerFactory: import.meta.env.DEV
+        ? undefined
+        : () => new IndexedDBWorker(),
     });
   } else if (localStorage) {
     storeOpts.store = new MemoryStore({ localStorage });


### PR DESCRIPTION
As per comment, we can't use workers in Vite dev mode. We previously fell back to the memory store but this ends up with it working significantly differently in dev mode to production, eg. dev mode would always start by doing an initial sync, so old to-device messages would arrive again.

There's no need to fall all the way back to the memory store though, we can use the IndexedDB store without the worker.