### PR TITLE
Fix caching headers on Docker image

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -2,9 +2,24 @@ server {
     listen       8080;
     server_name  localhost;
 
+    root   /app;
+
     location / {
-        root   /app;
+        # disable cache entriely by default (apart from Etag which is accurate enough)
+        add_header Cache-Control 'private no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0';
+        if_modified_since off;
+        expires off;
+        # also turn off last-modified since they are just the timestamps of the file in the docker image
+        # and may or may not bear any resemblance to when the resource changed
+        add_header Last-Modified "";
+
         try_files $uri /$uri /index.html;
+    }
+
+    # assets can be cached because they have hashed filenames
+    location /assets {
+        expires 1w;
+        add_header Cache-Control "public, no-transform";
     }
 }
 


### PR DESCRIPTION
Disable any caching other than etag based for everything other than the assets which have hash-based filenames.

Fixes https://github.com/vector-im/element-call/issues/840 (ie. this will avoid people being on different versions, unless they are super unlucky and different participants actually loaded the page before & after a deploy).