### PR TITLE
Log undecryptable to-device events

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "i18next": "^21.10.0",
     "i18next-browser-languagedetector": "^6.1.8",
     "i18next-http-backend": "^1.4.4",
-    "matrix-js-sdk": "github:matrix-org/matrix-js-sdk#79faee7a67f2cefa2a605aad1fad785b75e459c5",
+    "matrix-js-sdk": "github:matrix-org/matrix-js-sdk#7b10fa367df357b51c2e78e220d39e5e7967f9e3",
     "matrix-widget-api": "^1.0.0",
     "mermaid": "^8.13.8",
     "normalize.css": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "i18next": "^21.10.0",
     "i18next-browser-languagedetector": "^6.1.8",
     "i18next-http-backend": "^1.4.4",
-    "matrix-js-sdk": "github:matrix-org/matrix-js-sdk#c3d422f5fb1efac400da4c4ade592db3831445f9",
+    "matrix-js-sdk": "github:matrix-org/matrix-js-sdk#79faee7a67f2cefa2a605aad1fad785b75e459c5",
     "matrix-widget-api": "^1.0.0",
     "mermaid": "^8.13.8",
     "normalize.css": "^8.0.1",

--- a/src/PosthogAnalytics.ts
+++ b/src/PosthogAnalytics.ts
@@ -28,6 +28,7 @@ import {
   SignupTracker,
   MuteCameraTracker,
   MuteMicrophoneTracker,
+  UndecryptableToDeviceEventTracker,
 } from "./PosthogEvents";
 import { Config } from "./config/Config";
 import { getUrlParams } from "./UrlParams";
@@ -415,4 +416,5 @@ export class PosthogAnalytics {
   public eventLogin = new LoginTracker();
   public eventMuteMicrophone = new MuteMicrophoneTracker();
   public eventMuteCamera = new MuteCameraTracker();
+  public eventUndecryptableToDevice = new UndecryptableToDeviceEventTracker();
 }

--- a/src/PosthogEvents.ts
+++ b/src/PosthogEvents.ts
@@ -149,3 +149,17 @@ export class MuteCameraTracker {
     });
   }
 }
+
+interface UndecryptableToDeviceEvent {
+  eventName: "UndecryptableToDeviceEvent";
+  callId: string;
+}
+
+export class UndecryptableToDeviceEventTracker {
+  track(callId: string) {
+    PosthogAnalytics.instance.trackEvent<UndecryptableToDeviceEvent>({
+      eventName: "UndecryptableToDeviceEvent",
+      callId,
+    });
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -10362,9 +10362,9 @@ matrix-events-sdk@0.0.1:
   resolved "https://registry.yarnpkg.com/matrix-events-sdk/-/matrix-events-sdk-0.0.1.tgz#c8c38911e2cb29023b0bbac8d6f32e0de2c957dd"
   integrity sha512-1QEOsXO+bhyCroIe2/A5OwaxHvBm7EsSQ46DEDn8RBIfQwN5HWBpFvyWWR4QY0KHPPnnJdI99wgRiAl7Ad5qaA==
 
-"matrix-js-sdk@github:matrix-org/matrix-js-sdk#c3d422f5fb1efac400da4c4ade592db3831445f9":
+"matrix-js-sdk@github:matrix-org/matrix-js-sdk#79faee7a67f2cefa2a605aad1fad785b75e459c5":
   version "23.0.0"
-  resolved "https://codeload.github.com/matrix-org/matrix-js-sdk/tar.gz/c3d422f5fb1efac400da4c4ade592db3831445f9"
+  resolved "https://codeload.github.com/matrix-org/matrix-js-sdk/tar.gz/79faee7a67f2cefa2a605aad1fad785b75e459c5"
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@matrix-org/matrix-sdk-crypto-js" "^0.1.0-alpha.2"
@@ -10375,7 +10375,6 @@ matrix-events-sdk@0.0.1:
     matrix-events-sdk "0.0.1"
     matrix-widget-api "^1.0.0"
     p-retry "4"
-    qs "^6.9.6"
     sdp-transform "^2.14.1"
     unhomoglyph "^1.0.6"
     uuid "9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10362,9 +10362,9 @@ matrix-events-sdk@0.0.1:
   resolved "https://registry.yarnpkg.com/matrix-events-sdk/-/matrix-events-sdk-0.0.1.tgz#c8c38911e2cb29023b0bbac8d6f32e0de2c957dd"
   integrity sha512-1QEOsXO+bhyCroIe2/A5OwaxHvBm7EsSQ46DEDn8RBIfQwN5HWBpFvyWWR4QY0KHPPnnJdI99wgRiAl7Ad5qaA==
 
-"matrix-js-sdk@github:matrix-org/matrix-js-sdk#79faee7a67f2cefa2a605aad1fad785b75e459c5":
+"matrix-js-sdk@github:matrix-org/matrix-js-sdk#7b10fa367df357b51c2e78e220d39e5e7967f9e3":
   version "23.0.0"
-  resolved "https://codeload.github.com/matrix-org/matrix-js-sdk/tar.gz/79faee7a67f2cefa2a605aad1fad785b75e459c5"
+  resolved "https://codeload.github.com/matrix-org/matrix-js-sdk/tar.gz/7b10fa367df357b51c2e78e220d39e5e7967f9e3"
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@matrix-org/matrix-sdk-crypto-js" "^0.1.0-alpha.2"


### PR DESCRIPTION
Listen for the new undecryptable to-device event event and log events for it in Posthog & Sentry, and make it visible in the call flow diagram.

Requires https://github.com/matrix-org/matrix-js-sdk/pull/3066