### PR TITLE
Lowercase room alias before joining

### DIFF
--- a/src/matrix-utils.ts
+++ b/src/matrix-utils.ts
@@ -212,7 +212,7 @@ export function fullAliasFromRoomName(
 }
 
 /**
- * XXX What is this trying to do? It looks like it's getting the localpart from
+ * XXX: What is this trying to do? It looks like it's getting the localpart from
  * a room alias, but why is it splitting on hyphens and then putting spaces in??
  * @param roomId
  * @returns

--- a/src/matrix-utils.ts
+++ b/src/matrix-utils.ts
@@ -211,6 +211,12 @@ export function fullAliasFromRoomName(
   return `#${roomAliasLocalpartFromRoomName(roomName)}:${client.getDomain()}`;
 }
 
+/**
+ * XXX What is this trying to do? It looks like it's getting the localpart from
+ * a room alias, but why is it splitting on hyphens and then putting spaces in??
+ * @param roomId
+ * @returns
+ */
 export function roomNameFromRoomId(roomId: string): string {
   return roomId
     .match(/([^:]+):.*$/)[1]

--- a/src/room/useLoadGroupCall.ts
+++ b/src/room/useLoadGroupCall.ts
@@ -52,7 +52,11 @@ export const useLoadGroupCall = (
 
     const fetchOrCreateRoom = async (): Promise<Room> => {
       try {
-        const room = await client.joinRoom(roomIdOrAlias, { viaServers });
+        // We lowercase the localpart when we create the room, so we must lowercase
+        // it here too (we just do the whole alias).
+        const room = await client.joinRoom(roomIdOrAlias.toLowerCase(), {
+          viaServers,
+        });
         logger.info(
           `Joined ${roomIdOrAlias}, waiting room to be ready for group calls`
         );


### PR DESCRIPTION
As per comment. This was breaking PTT embedding because it generated a mixed case room alias.

Also add a comment to an undocumented and very strange function.