### PR TITLE
Be more clear about homeserver requirements in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ server {
 }
 ```
 
+By default, the app expects you to have [Synapse](https://matrix-org.github.io/synapse/latest/setup/installation.html) installed locally and running on port 8008. If you wish to use another homeserver, you can add a config file as above.
+
+Element Call requires a Synapse homeserver with registration enabled without any 3pid or token requirements, if you want it to be used by unregistered users. Furthermore, it cannot be used to log in to an existing homeserver where user accounts have joined normal rooms, as it cannot handle those yet.
+
+Therefore, to use a self-hosted Synapse homeserver, this is recommended to be a new server where any user account created has not joined any normal rooms anywhere in the Matrix federated network. The HS used can be setup to disable federation, so as to prevent spam registrations (if you keep registrations open) and to ensure Element Call continues to work in case any user decides to log in to their Element Call account using the standard Element app and joins normal rooms that Element Call cannot handle.
+
 ## Development
 
 Element Call is built against [matrix-js-sdk](https://github.com/matrix-org/matrix-js-sdk/pull/2553). To get started, clone, install, and link the package:
@@ -61,8 +67,6 @@ cd element-call
 yarn
 yarn link matrix-js-sdk
 ```
-
-By default, the app expects you to have [Synapse](https://matrix-org.github.io/synapse/latest/setup/installation.html) installed locally and running on port 8008. If you wish to use another homeserver, you can add a config file as above.
 
 You're now ready to launch the development server:
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ By default, the app expects you to have a Matrix homeserver (such as [Synapse](h
 
 Element Call requires a homeserver with registration enabled without any 3pid or token requirements, if you want it to be used by unregistered users. Furthermore, it is not recommended to use it with an existing homeserver where user accounts have joined normal rooms, as it may not be able to handle those yet and it may behave unreliably.
 
-Therefore, to use a self-hosted Synapse homeserver, this is recommended to be a new server where any user account created has not joined any normal rooms anywhere in the Matrix federated network. The homeserver used can be setup to disable federation, so as to prevent spam registrations (if you keep registrations open) and to ensure Element Call continues to work in case any user decides to log in to their Element Call account using the standard Element app and joins normal rooms that Element Call cannot handle.
+Therefore, to use a self-hosted homeserver, this is recommended to be a new server where any user account created has not joined any normal rooms anywhere in the Matrix federated network. The homeserver used can be setup to disable federation, so as to prevent spam registrations (if you keep registrations open) and to ensure Element Call continues to work in case any user decides to log in to their Element Call account using the standard Element app and joins normal rooms that Element Call cannot handle.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ server {
 }
 ```
 
-By default, the app expects you to have [Synapse](https://matrix-org.github.io/synapse/latest/setup/installation.html) installed locally and running on port 8008. If you wish to use another homeserver, you can add a config file as above.
+By default, the app expects you to have a Matrix homeserver (such as [Synapse](https://matrix-org.github.io/synapse/latest/setup/installation.html)) installed locally and running on port 8008. If you wish to use a homeserver on a different URL or one that is hosted on a different server, you can add a config file as above, and include the homeserver URL that you'd like to use.
 
-Element Call requires a Synapse homeserver with registration enabled without any 3pid or token requirements, if you want it to be used by unregistered users. Furthermore, it cannot be used to log in to an existing homeserver where user accounts have joined normal rooms, as it cannot handle those yet.
+Element Call requires a homeserver with registration enabled without any 3pid or token requirements, if you want it to be used by unregistered users. Furthermore, it is not recommended to use it with an existing homeserver where user accounts have joined normal rooms, as it may not be able to handle those yet and it may behave unreliably.
 
-Therefore, to use a self-hosted Synapse homeserver, this is recommended to be a new server where any user account created has not joined any normal rooms anywhere in the Matrix federated network. The HS used can be setup to disable federation, so as to prevent spam registrations (if you keep registrations open) and to ensure Element Call continues to work in case any user decides to log in to their Element Call account using the standard Element app and joins normal rooms that Element Call cannot handle.
+Therefore, to use a self-hosted Synapse homeserver, this is recommended to be a new server where any user account created has not joined any normal rooms anywhere in the Matrix federated network. The homeserver used can be setup to disable federation, so as to prevent spam registrations (if you keep registrations open) and to ensure Element Call continues to work in case any user decides to log in to their Element Call account using the standard Element app and joins normal rooms that Element Call cannot handle.
 
 ## Development
 


### PR DESCRIPTION
Updated README.md to include more detailed information about the limitations of Element Call and a recommended homeserver set up.

The reason for this update is that as a random person trying to self-host Element Call, I struggled to figure out how it works in relation to the HS it uses, and took some time to figure out it does not work unless open registration is enabled (which is generally bad practice, so I also eventually noticed the public instance at call.element.io uses a separate HS which is not federated).

I included my findings in the README so others trying to self-host have a clearer picture of the app's inner workings and particularities.