### PR TITLE
Don't pause audio streams on media actions

### DIFF
--- a/src/room/useGroupCall.ts
+++ b/src/room/useGroupCall.ts
@@ -158,6 +158,38 @@ export function useGroupCall(groupCall: GroupCall): UseGroupCallReturnType {
     [setState]
   );
 
+  const doNothingMediaActionCallback = useCallback(
+    (details: MediaSessionActionDetails) => {},
+    []
+  );
+
+  useEffect(() => {
+    // disable the media action keys, otherwise audio elements get paused when
+    // the user presses media keys or unplugs headphones, etc.
+    // Note there are actions for muting / unmuting a microphone & hanging up
+    // which we could wire up.
+    const mediaActions: MediaSessionAction[] = [
+      "play",
+      "pause",
+      "stop",
+      "nexttrack",
+      "previoustrack",
+    ];
+
+    for (const mediaAction of mediaActions) {
+      navigator.mediaSession.setActionHandler(
+        mediaAction,
+        doNothingMediaActionCallback
+      );
+    }
+
+    return () => {
+      for (const mediaAction of mediaActions) {
+        navigator.mediaSession.setActionHandler(mediaAction, null);
+      }
+    };
+  }, [doNothingMediaEventCallback]);
+
   useEffect(() => {
     function onGroupCallStateChanged() {
       updateState({

--- a/src/room/useGroupCall.ts
+++ b/src/room/useGroupCall.ts
@@ -188,7 +188,7 @@ export function useGroupCall(groupCall: GroupCall): UseGroupCallReturnType {
         navigator.mediaSession.setActionHandler(mediaAction, null);
       }
     };
-  }, [doNothingMediaEventCallback]);
+  }, [doNothingMediaActionCallback]);
 
   useEffect(() => {
     function onGroupCallStateChanged() {


### PR DESCRIPTION
This adds handlers for the media actions to do nothing, otherwise they cause the audio element for a random participant to get paused.

Fixes https://github.com/vector-im/element-call/issues/855