### PR TITLE
Add e2eEnabled parameter to Widget client

### DIFF
--- a/src/widget.ts
+++ b/src/widget.ts
@@ -101,7 +101,7 @@ export const widget: WidgetHelpers | null = (() => {
       // We need to do this now rather than later because it has capabilities to
       // request, and is responsible for starting the transport (should it be?)
 
-      const { roomId, userId, deviceId, baseUrl } = getUrlParams();
+      const { roomId, userId, deviceId, baseUrl, e2eEnabled } = getUrlParams();
       if (!roomId) throw new Error("Room ID must be supplied");
       if (!userId) throw new Error("User ID must be supplied");
       if (!deviceId) throw new Error("Device ID must be supplied");
@@ -147,6 +147,7 @@ export const widget: WidgetHelpers | null = (() => {
           userId,
           deviceId,
           timelineSupport: true,
+          useE2eForGroupCall: e2eEnabled,
         }
       );
       const clientPromise = client.startClient().then(() => client);


### PR DESCRIPTION
Allow to-device signaling in matryoshka mode to be unencrypted, like in the standalone client. This is useful especially for testing and also for clients which do not yet support encryption, like Quadrix. The default value for the optional `e2eEnabled` URL parameter is "true", so this should not have any impact on existing implementations using the matrix-widget-api, like Element Web.

I have tested this commit in a test build of Quadrix, at: https://github.com/alariej/quadrix/blob/7f134a3646932e3d4d92538ade1e6a63cc94fd5c/src/modules/ElementCall/index.tsx#L314