### PR TITLE
Fix for Android WebView, which does not support navigator.mediaSession

### DIFF
--- a/src/room/useGroupCall.ts
+++ b/src/room/useGroupCall.ts
@@ -189,7 +189,7 @@ export function useGroupCall(groupCall: GroupCall): UseGroupCallReturnType {
     ];
 
     for (const mediaAction of mediaActions) {
-      navigator.mediaSession.setActionHandler(
+      navigator.mediaSession?.setActionHandler(
         mediaAction,
         doNothingMediaActionCallback
       );
@@ -197,7 +197,7 @@ export function useGroupCall(groupCall: GroupCall): UseGroupCallReturnType {
 
     return () => {
       for (const mediaAction of mediaActions) {
-        navigator.mediaSession.setActionHandler(mediaAction, null);
+        navigator.mediaSession?.setActionHandler(mediaAction, null);
       }
     };
   }, [doNothingMediaActionCallback]);


### PR DESCRIPTION
Not sure why Android WebView is the only browser not supporting navigator.mediaSession:

https://developer.mozilla.org/en-US/docs/Web/API/Navigator/mediaSession#browser_compatibility

Tested this fix with a self-hosted instance of Element Call, embedded through matrix-widget-api using react-native-webview on an Android device.