### PR TITLE
Include OpenTelemetry traces in rageshakes

### DIFF
--- a/src/analytics/RageshakeSpanExporter.ts
+++ b/src/analytics/RageshakeSpanExporter.ts
@@ -1,0 +1,103 @@
+import { Attributes } from "@opentelemetry/api";
+import {
+  ExportResult,
+  ExportResultCode,
+  hrTimeToMilliseconds,
+} from "@opentelemetry/core";
+import { SpanExporter, ReadableSpan } from "@opentelemetry/sdk-trace-base";
+
+const dumpAttributes = (attr: Attributes) =>
+  Object.entries(attr).map(([key, value]) => ({
+    key,
+    type: typeof value,
+    value,
+  }));
+
+/**
+ * Exports spans on demand to the Jaeger JSON format, which can be attached to
+ * rageshakes and loaded into analysis tools like Jaeger and Stalk.
+ */
+export class RageshakeSpanExporter implements SpanExporter {
+  private readonly spans: ReadableSpan[] = [];
+
+  export(
+    spans: ReadableSpan[],
+    resultCallback: (result: ExportResult) => void
+  ): void {
+    this.spans.push(...spans);
+    resultCallback({ code: ExportResultCode.SUCCESS });
+  }
+
+  /**
+   * Dumps the spans collected so far as Jaeger-compatible JSON.
+   */
+  public dump(): string {
+    const traces = new Map<string, ReadableSpan[]>();
+
+    // Organize spans by their trace IDs
+    for (const span of this.spans) {
+      const traceId = span.spanContext().traceId;
+      let trace = traces.get(traceId);
+
+      if (trace === undefined) {
+        trace = [];
+        traces.set(traceId, trace);
+      }
+
+      trace.push(span);
+    }
+
+    const processId = "p1";
+    const processes = {
+      [processId]: {
+        serviceName: "element-call",
+        tags: [],
+      },
+      warnings: null,
+    };
+
+    return JSON.stringify({
+      // Honestly not sure what some of these fields mean, I just know that
+      // they're present in Jaeger JSON exports
+      total: 0,
+      limit: 0,
+      offset: 0,
+      errors: null,
+      data: [...traces.entries()].map(([traceId, spans]) => ({
+        traceID: traceId,
+        warnings: null,
+        processes,
+        spans: spans.map((span) => {
+          const ctx = span.spanContext();
+
+          return {
+            traceID: traceId,
+            spanID: ctx.spanId,
+            operationName: span.name,
+            processID: processId,
+            warnings: null,
+            startTime: hrTimeToMilliseconds(span.startTime),
+            duration: hrTimeToMilliseconds(span.duration),
+            references:
+              span.parentSpanId === undefined
+                ? []
+                : [
+                    {
+                      refType: "CHILD_OF",
+                      traceID: traceId,
+                      spanID: span.parentSpanId,
+                    },
+                  ],
+            tags: dumpAttributes(span.attributes),
+            logs: span.events.map((event) => ({
+              timestamp: hrTimeToMilliseconds(event.time),
+              fields: dumpAttributes(event.attributes ?? {}),
+            })),
+          };
+        }),
+      })),
+    });
+  }
+
+  async shutdown(): Promise<void> {}
+}

--- a/src/settings/submit-rageshake.ts
+++ b/src/settings/submit-rageshake.ts
@@ -25,6 +25,14 @@ import { useClient } from "../ClientContext";
 import { InspectorContext } from "../room/GroupCallInspector";
 import { useModalTriggerState } from "../Modal";
 import { Config } from "../config/Config";
+import { ElementCallOpenTelemetry } from "../otel/otel";
+
+const gzip = (text: string): Blob => {
+  // encode as UTF-8
+  const buf = new TextEncoder().encode(text);
+  // compress
+  return new Blob([pako.gzip(buf)]);
+};
 
 interface RageShakeSubmitOptions {
   sendLogs: boolean;
@@ -235,13 +243,14 @@ export function useSubmitRageshake(): {
           const logs = await getLogsForReport();
 
           for (const entry of logs) {
-            // encode as UTF-8
-            let buf = new TextEncoder().encode(entry.lines);
-            // compress
-            buf = pako.gzip(buf);
-
-            body.append("compressed-log", new Blob([buf]), entry.id);
+            body.append("compressed-log", gzip(entry.lines), entry.id);
           }
+
+          body.append(
+            "file",
+            gzip(ElementCallOpenTelemetry.instance.rageshakeExporter!.dump()),
+            "traces.json"
+          );
 
           if (inspectorState) {
             body.append(


### PR DESCRIPTION
This attaches OpenTelemetry traces to rageshakes as a gzipped file named 'traces.json', which, after unzipping, can be loaded directly into analysis tools like Jaeger or Stalk.

The file name is a little unfortunate—if I change it to 'traces.json.gz' then our rageshake server seems to reject it. I tried setting an explicit content type on the blob, but that didn't seem to work, so I could use ideas here.

There's another important caveat: Since exporters only receive spans after they've been ended, this currently won't attach any useful telemetry if you submit a rageshake in the middle of a call. I suggest we get this merged as a first iteration, and then figure out how to work around that.