### PR TITLE
Fix a crash when adding call events to telemetry

### DIFF
--- a/src/otel/OTelGroupCallMembership.ts
+++ b/src/otel/OTelGroupCallMembership.ts
@@ -74,7 +74,7 @@ function flattenVoipEventRecursive(
     );
 
   for (const [k, v] of Object.entries(obj)) {
-    if (["string", "number", "boolean"].includes(typeof v)) {
+    if (["string", "number", "boolean"].includes(typeof v) || v === null) {
       flatObject[prefix + k] = v;
     } else if (typeof v === "object") {
       flattenVoipEventRecursive(


### PR DESCRIPTION
Since `typeof null` is `'object'`, the `flattenVoipEventRecursive` function was mistakenly casting nulls to `Record<string, unknown>` in its `typeof v === "object"` case, causing `Object.entries` to explode.

Closes https://github.com/vector-im/element-call/issues/993