### PR TITLE
Include unended spans in rageshakes

### DIFF
--- a/src/otel/otel.ts
+++ b/src/otel/otel.ts
@@ -28,7 +28,7 @@ import { logger } from "matrix-js-sdk/src/logger";
 import { PosthogSpanExporter } from "../analytics/OtelPosthogExporter";
 import { Anonymity } from "../analytics/PosthogAnalytics";
 import { Config } from "../config/Config";
-import { RageshakeSpanExporter } from "../analytics/RageshakeSpanExporter";
+import { RageshakeSpanProcessor } from "../analytics/RageshakeSpanProcessor";
 
 const SERVICE_NAME = "element-call";
 
@@ -39,7 +39,7 @@ export class ElementCallOpenTelemetry {
   private _tracer: Tracer;
   private _anonymity: Anonymity;
   private otlpExporter: OTLPTraceExporter;
-  public readonly rageshakeExporter?: RageshakeSpanExporter;
+  public readonly rageshakeProcessor?: RageshakeSpanProcessor;
 
   static globalInit(): void {
     const config = Config.get();
@@ -89,11 +89,8 @@ export class ElementCallOpenTelemetry {
     }
 
     if (rageshakeUrl) {
-      logger.info("Enabling rageshake collector");
-      this.rageshakeExporter = new RageshakeSpanExporter();
-      this._provider.addSpanProcessor(
-        new SimpleSpanProcessor(this.rageshakeExporter)
-      );
+      this.rageshakeProcessor = new RageshakeSpanProcessor();
+      this._provider.addSpanProcessor(this.rageshakeProcessor);
     }
 
     const consoleExporter = new ConsoleSpanExporter();

--- a/src/settings/submit-rageshake.ts
+++ b/src/settings/submit-rageshake.ts
@@ -248,7 +248,7 @@ export function useSubmitRageshake(): {
 
           body.append(
             "file",
-            gzip(ElementCallOpenTelemetry.instance.rageshakeExporter!.dump()),
+            gzip(ElementCallOpenTelemetry.instance.rageshakeProcessor!.dump()),
             "traces.json"
           );
 


### PR DESCRIPTION
By turning the RageshakeSpanExporter into a SpanProcessor, it can now be notified of spans as soon as they're started.