### PR TITLE
Add jitter in webrtc stats

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "i18next-browser-languagedetector": "^6.1.8",
     "i18next-http-backend": "^1.4.4",
     "lodash": "^4.17.21",
-    "matrix-js-sdk": "github:matrix-org/matrix-js-sdk#170a52b09f02096f7c877323622d685a2d586065",
+    "matrix-js-sdk": "github:matrix-org/matrix-js-sdk#da6622f61ef060bacea2d7b8658fd2172d196f9d",
     "matrix-widget-api": "^1.3.1",
     "mermaid": "^8.13.8",
     "normalize.css": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "i18next-browser-languagedetector": "^6.1.8",
     "i18next-http-backend": "^1.4.4",
     "lodash": "^4.17.21",
-    "matrix-js-sdk": "github:matrix-org/matrix-js-sdk#da6622f61ef060bacea2d7b8658fd2172d196f9d",
+    "matrix-js-sdk": "github:matrix-org/matrix-js-sdk#a0bcb5777fe94e71a29d16e22450ebd1c577e81b",
     "matrix-widget-api": "^1.3.1",
     "mermaid": "^8.13.8",
     "normalize.css": "^8.0.1",

--- a/test/otel/ObjectFlattener-test.ts
+++ b/test/otel/ObjectFlattener-test.ts
@@ -56,6 +56,10 @@ describe("ObjectFlattener", () => {
           ["REMOTE_VIDEO_TRACK_ID", { height: 960, width: 1080 }],
         ]),
       },
+      jitter: new Map([
+        ["REMOTE_AUDIO_TRACK_ID", 2],
+        ["REMOTE_VIDEO_TRACK_ID", 50],
+      ]),
       codec: {
         local: new Map([
           ["LOCAL_AUDIO_TRACK_ID", "opus"],
@@ -164,6 +168,8 @@ describe("ObjectFlattener", () => {
         "matrix.stats.conn.framerate.local.LOCAL_VIDEO_TRACK_ID": 30,
         "matrix.stats.conn.framerate.remote.REMOTE_AUDIO_TRACK_ID": 0,
         "matrix.stats.conn.framerate.remote.REMOTE_VIDEO_TRACK_ID": 60,
+        "matrix.stats.conn.jitter.REMOTE_AUDIO_TRACK_ID": 2,
+        "matrix.stats.conn.jitter.REMOTE_VIDEO_TRACK_ID": 50,
         "matrix.stats.conn.packetLoss.download": 0,
         "matrix.stats.conn.packetLoss.total": 0,
         "matrix.stats.conn.packetLoss.upload": 0,

--- a/yarn.lock
+++ b/yarn.lock
@@ -10550,9 +10550,9 @@ matrix-events-sdk@0.0.1:
   resolved "https://registry.yarnpkg.com/matrix-events-sdk/-/matrix-events-sdk-0.0.1.tgz#c8c38911e2cb29023b0bbac8d6f32e0de2c957dd"
   integrity sha512-1QEOsXO+bhyCroIe2/A5OwaxHvBm7EsSQ46DEDn8RBIfQwN5HWBpFvyWWR4QY0KHPPnnJdI99wgRiAl7Ad5qaA==
 
-"matrix-js-sdk@github:matrix-org/matrix-js-sdk#170a52b09f02096f7c877323622d685a2d586065":
+"matrix-js-sdk@github:matrix-org/matrix-js-sdk#da6622f61ef060bacea2d7b8658fd2172d196f9d":
   version "24.0.0"
-  resolved "https://codeload.github.com/matrix-org/matrix-js-sdk/tar.gz/170a52b09f02096f7c877323622d685a2d586065"
+  resolved "https://codeload.github.com/matrix-org/matrix-js-sdk/tar.gz/da6622f61ef060bacea2d7b8658fd2172d196f9d"
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@matrix-org/matrix-sdk-crypto-js" "^0.1.0-alpha.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10550,9 +10550,9 @@ matrix-events-sdk@0.0.1:
   resolved "https://registry.yarnpkg.com/matrix-events-sdk/-/matrix-events-sdk-0.0.1.tgz#c8c38911e2cb29023b0bbac8d6f32e0de2c957dd"
   integrity sha512-1QEOsXO+bhyCroIe2/A5OwaxHvBm7EsSQ46DEDn8RBIfQwN5HWBpFvyWWR4QY0KHPPnnJdI99wgRiAl7Ad5qaA==
 
-"matrix-js-sdk@github:matrix-org/matrix-js-sdk#da6622f61ef060bacea2d7b8658fd2172d196f9d":
-  version "24.0.0"
-  resolved "https://codeload.github.com/matrix-org/matrix-js-sdk/tar.gz/da6622f61ef060bacea2d7b8658fd2172d196f9d"
+"matrix-js-sdk@github:matrix-org/matrix-js-sdk#a0bcb5777fe94e71a29d16e22450ebd1c577e81b":
+  version "24.1.0"
+  resolved "https://codeload.github.com/matrix-org/matrix-js-sdk/tar.gz/a0bcb5777fe94e71a29d16e22450ebd1c577e81b"
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@matrix-org/matrix-sdk-crypto-js" "^0.1.0-alpha.6"


### PR DESCRIPTION
The current develop branch [matrix-js-sdk](https://github.com/matrix-org/matrix-js-sdk/pull/3270)  contains jitter in the stats