### PR TITLE
Keep inspector from covering call buttons

### DIFF
--- a/src/room/InCallView.module.css
+++ b/src/room/InCallView.module.css
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 .inRoom {
-  position: relative;
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -24,6 +23,12 @@ limitations under the License.
   width: 100%;
   --footerPadding: 8px;
   --footerHeight: calc(50px + 2 * var(--footerPadding));
+}
+
+.controlsOverlay {
+  position: relative;
+  flex: 1;
+  display: flex;
 }
 
 .centerMessage {

--- a/src/room/InCallView.tsx
+++ b/src/room/InCallView.tsx
@@ -438,8 +438,10 @@ export function InCallView({
           </RightNav>
         </Header>
       )}
-      {renderContent()}
-      {footer}
+      <div className={styles.controlsOverlay}>
+        {renderContent()}
+        {footer}
+      </div>
       <GroupCallInspector
         client={client}
         groupCall={groupCall}


### PR DESCRIPTION
Before:

![Screenshot 2023-04-19 at 14-48-57 Element Call test](https://user-images.githubusercontent.com/48614497/233171694-59b60252-a0ef-44d4-9a86-1ce14609b570.png)

After:

![Screenshot 2023-04-19 at 14-45-33 Element Call test](https://user-images.githubusercontent.com/48614497/233171723-26ae0ac5-9800-4ec3-8e0b-c0cfd88e75da.png)

Closes https://github.com/vector-im/element-call/issues/954