### PR TITLE
Add .gz extension to to traces.json

### DIFF
--- a/src/settings/submit-rageshake.ts
+++ b/src/settings/submit-rageshake.ts
@@ -249,7 +249,7 @@ export function useSubmitRageshake(): {
           body.append(
             "file",
             gzip(ElementCallOpenTelemetry.instance.rageshakeProcessor!.dump()),
-            "traces.json"
+            "traces.json.gz"
           );
 
           if (inspectorState) {


### PR DESCRIPTION
As we are sending a gzipped file. This will make the rageshake server gunzip it when it serves it: https://github.com/matrix-org/rageshake/blob/master/logserver.go#L90