### PR TITLE
Revert "Add .gz extension to to traces.json"

### DIFF
--- a/src/settings/submit-rageshake.ts
+++ b/src/settings/submit-rageshake.ts
@@ -249,7 +249,7 @@ export function useSubmitRageshake(): {
           body.append(
             "file",
             gzip(ElementCallOpenTelemetry.instance.rageshakeProcessor!.dump()),
-            "traces.json.gz"
+            "traces.json"
           );
 
           if (inspectorState) {


### PR DESCRIPTION
Reverts vector-im/element-call#1016

It turns out this actually doesn't work.