### PR TITLE
Add data-testid tags for registration, login, displayname & logout

### DIFF
--- a/src/UserMenu.tsx
+++ b/src/UserMenu.tsx
@@ -116,8 +116,13 @@ export function UserMenu({
       {(props) => (
         <Menu {...props} label={t("User menu")} onAction={onAction}>
           {items.map(({ key, icon: Icon, label, dataTestid }) => (
-            <Item key={key} textValue={label} data-testid={dataTestid}>
-              <Icon width={24} height={24} className={styles.menuIcon} />
+            <Item key={key} textValue={label}>
+              <Icon
+                width={24}
+                height={24}
+                className={styles.menuIcon}
+                data-testid={dataTestid}
+              />
               <Body overflowEllipsis>{label}</Body>
             </Item>
           ))}

--- a/src/UserMenu.tsx
+++ b/src/UserMenu.tsx
@@ -58,6 +58,7 @@ export function UserMenu({
         key: "user",
         icon: UserIcon,
         label: displayName,
+        dataTestid: "usermenu_user",
       });
 
       if (isPasswordlessUser && !preventNavigation) {
@@ -65,6 +66,7 @@ export function UserMenu({
           key: "login",
           label: t("Sign in"),
           icon: LoginIcon,
+          dataTestid: "usermenu_login",
         });
       }
 
@@ -73,6 +75,7 @@ export function UserMenu({
           key: "logout",
           label: t("Sign out"),
           icon: LogoutIcon,
+          dataTestid: "usermenu_logout",
         });
       }
     }
@@ -93,7 +96,11 @@ export function UserMenu({
   return (
     <PopoverMenuTrigger placement="bottom right">
       <TooltipTrigger tooltip={tooltip} placement="bottom left">
-        <Button variant="icon" className={styles.userButton}>
+        <Button
+          variant="icon"
+          className={styles.userButton}
+          data-testid="usermenu_open"
+        >
           {isAuthenticated && (!isPasswordlessUser || avatarUrl) ? (
             <Avatar
               size={Size.SM}
@@ -108,8 +115,8 @@ export function UserMenu({
       </TooltipTrigger>
       {(props) => (
         <Menu {...props} label={t("User menu")} onAction={onAction}>
-          {items.map(({ key, icon: Icon, label }) => (
-            <Item key={key} textValue={label}>
+          {items.map(({ key, icon: Icon, label, dataTestid }) => (
+            <Item key={key} textValue={label} data-testid={dataTestid}>
               <Icon width={24} height={24} className={styles.menuIcon} />
               <Body overflowEllipsis>{label}</Body>
             </Item>

--- a/src/auth/LoginPage.tsx
+++ b/src/auth/LoginPage.tsx
@@ -88,6 +88,7 @@ export const LoginPage: FC = () => {
                   autoCapitalize="none"
                   prefix="@"
                   suffix={`:${Config.defaultServerName()}`}
+                  data-testid="login_username"
                 />
               </FieldRow>
               <FieldRow>
@@ -96,6 +97,7 @@ export const LoginPage: FC = () => {
                   ref={passwordRef}
                   placeholder={t("Password")}
                   label={t("Password")}
+                  data-testid="login_password"
                 />
               </FieldRow>
               {error && (
@@ -104,7 +106,11 @@ export const LoginPage: FC = () => {
                 </FieldRow>
               )}
               <FieldRow>
-                <Button type="submit" disabled={loading}>
+                <Button
+                  type="submit"
+                  disabled={loading}
+                  data-testid="login_login"
+                >
                   {loading ? t("Logging in…") : t("Login")}
                 </Button>
               </FieldRow>

--- a/src/auth/RegisterPage.tsx
+++ b/src/auth/RegisterPage.tsx
@@ -166,6 +166,7 @@ export const RegisterPage: FC = () => {
                   autoCapitalize="none"
                   prefix="@"
                   suffix={`:${Config.defaultServerName()}`}
+                  data-testid="register_username"
                 />
               </FieldRow>
               <FieldRow>
@@ -179,6 +180,7 @@ export const RegisterPage: FC = () => {
                   value={password}
                   placeholder={t("Password")}
                   label={t("Password")}
+                  data-testid="register_password"
                 />
               </FieldRow>
               <FieldRow>
@@ -193,6 +195,7 @@ export const RegisterPage: FC = () => {
                   placeholder={t("Confirm password")}
                   label={t("Confirm password")}
                   ref={confirmPasswordRef}
+                  data-testid="register_confirm_password"
                 />
               </FieldRow>
               <Caption>
@@ -217,7 +220,11 @@ export const RegisterPage: FC = () => {
                 </FieldRow>
               )}
               <FieldRow>
-                <Button type="submit" disabled={registering}>
+                <Button
+                  type="submit"
+                  disabled={registering}
+                  data-testid="register_register"
+                >
                   {registering ? t("Registering…") : t("Register")}
                 </Button>
               </FieldRow>

--- a/src/home/RegisteredView.tsx
+++ b/src/home/RegisteredView.tsx
@@ -133,6 +133,7 @@ export function RegisteredView({ client, isPasswordlessUser }: Props) {
                 type="text"
                 required
                 autoComplete="off"
+                data-testid="home_callName"
               />
 
               <Button
@@ -140,6 +141,7 @@ export function RegisteredView({ client, isPasswordlessUser }: Props) {
                 size="lg"
                 className={styles.button}
                 disabled={loading}
+                data-testid="home_go"
               >
                 {loading ? t("Loading…") : t("Go")}
               </Button>

--- a/src/home/UnauthenticatedView.tsx
+++ b/src/home/UnauthenticatedView.tsx
@@ -186,14 +186,14 @@ export const UnauthenticatedView: FC = () => {
         </main>
         <footer className={styles.footer}>
           <Body className={styles.mobileLoginLink}>
-            <Link color="primary" to="/login">
+            <Link color="primary" to="/login" data-testid="home_login">
               {t("Login to your account")}
             </Link>
           </Body>
           <Body>
             <Trans>
               Not registered yet?{" "}
-              <Link color="primary" to="/register">
+              <Link color="primary" to="/register" data-testid="home_register">
                 Create an account
               </Link>
             </Trans>

--- a/src/profile/ProfileModal.tsx
+++ b/src/profile/ProfileModal.tsx
@@ -119,6 +119,7 @@ export function ProfileModal({ client, ...rest }: Props) {
               placeholder={t("Display name")}
               value={displayName}
               onChange={onChangeDisplayName}
+              data-testid="profile_displayname"
             />
           </FieldRow>
           {error && (
@@ -130,7 +131,11 @@ export function ProfileModal({ client, ...rest }: Props) {
             <Button type="button" variant="secondary" onPress={onClose}>
               Cancel
             </Button>
-            <Button type="submit" disabled={loading}>
+            <Button
+              type="submit"
+              disabled={loading}
+              data-testid="profile_submit"
+            >
               {loading ? t("Saving…") : t("Save")}
             </Button>
           </FieldRow>


### PR DESCRIPTION
Adding more test IDs for various other bits of UI.

Currently not good to merge; I'm having issues understanding how to extend Item to render test IDs, it doesn't seem to be doing so in the same manner as other elements are, but i wanted to put it up to ask questions about it.