### PR TITLE
Subtly animate active speaker indicators

### DIFF
--- a/src/video-grid/VideoTile.module.css
+++ b/src/video-grid/VideoTile.module.css
@@ -45,7 +45,7 @@ limitations under the License.
   transform: scaleX(-1);
 }
 
-.videoTile.speaking::after {
+.videoTile::after {
   position: absolute;
   top: -1px;
   left: -1px;
@@ -54,6 +54,12 @@ limitations under the License.
   content: "";
   border-radius: var(--tileRadius);
   box-shadow: inset 0 0 0 4px var(--accent) !important;
+  opacity: 0;
+  transition: opacity ease 0.15s;
+}
+
+.videoTile.speaking::after {
+  opacity: 1;
 }
 
 .videoTile.maximised {


### PR DESCRIPTION
A light touch of animation here is consistent with what the designs call for, and what we've done with the toolbars on video tiles.