### PR TITLE
Make Element Call work in Firefox's resist fingerprinting mode

### DIFF
--- a/src/media-utils.ts
+++ b/src/media-utils.ts
@@ -47,7 +47,7 @@ export async function findDeviceByName(
  *
  * @return The available media devices
  */
-export async function getDevices(): Promise<MediaDeviceInfo[]> {
+export async function getNamedDevices(): Promise<MediaDeviceInfo[]> {
   // First get the devices without their labels, to learn what kinds of streams
   // we can request
   let devices: MediaDeviceInfo[];

--- a/src/room/GroupCallView.tsx
+++ b/src/room/GroupCallView.tsx
@@ -34,7 +34,7 @@ import { useSentryGroupCallHandler } from "./useSentryGroupCallHandler";
 import { useLocationNavigation } from "../useLocationNavigation";
 import { PosthogAnalytics } from "../analytics/PosthogAnalytics";
 import { useMediaHandler } from "../settings/useMediaHandler";
-import { findDeviceByName, getDevices } from "../media-utils";
+import { findDeviceByName, getNamedDevices } from "../media-utils";
 
 declare global {
   interface Window {
@@ -102,7 +102,7 @@ export function GroupCallView({
         // Get the available devices so we can match the selected device
         // to its ID. This involves getting a media stream (see docs on
         // the function) so we only do it once and re-use the result.
-        const devices = await getDevices();
+        const devices = await getNamedDevices();
 
         const { audioInput, videoInput } = ev.detail
           .data as unknown as JoinCallData;

--- a/src/settings/SettingsModal.tsx
+++ b/src/settings/SettingsModal.tsx
@@ -57,7 +57,9 @@ export const SettingsModal = (props: Props) => {
     audioOutput,
     audioOutputs,
     setAudioOutput,
+    useDeviceNames,
   } = useMediaHandler();
+  useDeviceNames();
 
   const [spatialAudio, setSpatialAudio] = useSpatialAudio();
   const [showInspector, setShowInspector] = useShowInspector();


### PR DESCRIPTION
This one is gonna take some explaining:

When in resist fingerprinting mode, Firefox exhibits some funny behavior: when we ask for the the list of media devices, it gives us fake device IDs. But when the js-sdk requests a stream for any of those devices, Firefox associates the stream with the real device ID.
    
Now, in order to get the names of devices included in their metadata when you query the device list, you need to be holding a stream. For this reason, `useMediaHandler` was set up to reload the device list whenever matrix-js-sdk got a new local stream. But because of the inconsistency in device IDs, it would enter an infinite cycle telling matrix-js-sdk to request a stream for the fake device ID, but with matrix-js-sdk always responding with the real device ID.
    
I already wasn't happy with `useMediaHandler`'s use of `@ts-ignore` comments to inspect private js-sdk fields, and in the meantime we've come up with a simpler function for requesting device names, so I decided to refactor `useMediaHandler` to use it instead. Importantly, it doesn't break in resist fingerprinting mode.
    
This created a new UX issue though: now, when on the lobby screen, `useMediaHandler` would request microphone access so it could get device names, followed immediately by a *second* pop-up for the lobby screen to request camera access. That's 1 pop-up too many, so I changed `useMediaHandler` to only request device names when a component is mounted that actually wants to show them. Currently, the settings modal is the only such component, and users normally only open it *after* granting full audio/video access, so this solution works out quite nicely.

Closes https://github.com/vector-im/element-call/issues/396
Closes https://github.com/vector-im/element-call/issues/886