### PR TITLE
Identify SVGs representing video muted and video unmuted

### DIFF
--- a/src/button/Button.tsx
+++ b/src/button/Button.tsx
@@ -171,7 +171,11 @@ export function VideoButton({
       tooltip={() => (muted ? t("Turn on camera") : t("Turn off camera"))}
     >
       <Button variant="toolbar" {...rest} off={muted}>
-        {muted ? <DisableVideoIcon /> : <VideoIcon />}
+        {muted ? (
+          <DisableVideoIcon data-testid="icon_videomute" />
+        ) : (
+          <VideoIcon data-testid="icon_video" />
+        )}
       </Button>
     </TooltipTrigger>
   );

--- a/src/video-grid/VideoTile.tsx
+++ b/src/video-grid/VideoTile.tsx
@@ -163,7 +163,10 @@ export const VideoTile = forwardRef<HTMLElement, Props>(
         )}
         {videoMuted && (
           <>
-            <div className={styles.videoMutedOverlay} />
+            <div
+              data-testid="videoTile_avatar"
+              className={styles.videoMutedOverlay}
+            />
             {avatar}
           </>
         )}


### PR DESCRIPTION
The underlying tests don't currently function due to #1072 but this PR at least allows us to identify the state and things to click - we can just avoid running the actual tests for now.