### PR TITLE
Don't require textual feedback

### DIFF
--- a/src/room/CallEndedView.tsx
+++ b/src/room/CallEndedView.tsx
@@ -115,7 +115,6 @@ export function CallEndedView({
             label={t("Your feedback")}
             placeholder={t("Your feedback")}
             type="textarea"
-            required
           />
         </FieldRow>{" "}
         <FieldRow>


### PR DESCRIPTION
We want to encourage scoring as much as possible for the purpose of our KPIs, even if it means we don't always get detailed textual feedback.