### PR TITLE
Fix tiles having the wrong states during screensharing

### DIFF
--- a/src/video-grid/VideoTile.tsx
+++ b/src/video-grid/VideoTile.tsx
@@ -101,14 +101,14 @@ export const VideoTile = forwardRef<HTMLDivElement, Props>(
         ref={tileRef}
         data-testid="videoTile"
       >
-        {!sfuParticipant.isCameraEnabled && (
+        {content === TileContent.UserMedia && !sfuParticipant.isCameraEnabled && (
           <>
             <div className={styles.videoMutedOverlay} />
             {getAvatar(data.member, targetWidth, targetHeight)}
           </>
         )}
         {!false &&
-          (sfuParticipant.isScreenShareEnabled ? (
+          (content === TileContent.ScreenShare ? (
             <div className={styles.presenterLabel}>
               <span>{t("{{name}} is presenting", { name })}</span>
             </div>


### PR DESCRIPTION
This fixes a couple bugs:

1. That muting your video while screensharing would cause the screensharing feed to be hidden as well
2. That while screensharing, your user media tile would incorrectly show the label that's supposed to appear only on the screenshare tile