### PR TITLE
Push code coverage percentages to codecov.io.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,3 +16,6 @@ jobs:
         run: "yarn install"
       - name: Jest
         run: "yarn run test"
+      - name: Upload to codecov
+        uses: codecov/codecov-action@v3
+        flags: unittests

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,4 +18,5 @@ jobs:
         run: "yarn run test"
       - name: Upload to codecov
         uses: codecov/codecov-action@v3
-        flags: unittests
+        with:
+          flags: unittests

--- a/package.json
+++ b/package.json
@@ -118,6 +118,11 @@
       "\\.(css|less|svg)+$": "identity-obj-proxy",
       "^\\./IndexedDBWorker\\?worker$": "<rootDir>/test/mocks/workerMock.ts",
       "^\\./olm$": "<rootDir>/test/mocks/olmMock.ts"
-    }
+    },
+    "collectCoverage": true,
+    "coverageReporters": [
+      "text",
+      "cobertura"
+    ]
   }
 }


### PR DESCRIPTION
https://app.codecov.io/gh/vector-im/element-call/tree/michaelk%2Freport_coverage/src for demonstration that the output works.

The comment from codecov in this PR is errorful because we haven't run this on main yet so there's no difference available.