### PR TITLE
Run tests for codecoverage after push to main

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,7 +2,7 @@ name: Run jest tests
 on:
   pull_request: {}
   push:
-    branches: [main]
+    branches: [livekit]
 jobs:
   jest:
     name: Run jest tests

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,8 @@
 name: Run jest tests
 on:
   pull_request: {}
+  push:
+    branches: [main]
 jobs:
   jest:
     name: Run jest tests


### PR DESCRIPTION
This allows us to generate a regular baseline to compare upcoming push requests against.