### PR TITLE
Update livekit branch (current default) to run tests on livekit and full-mesh branches

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,7 +2,7 @@ name: Run jest tests
 on:
   pull_request: {}
   push:
-    branches: [main]
+    branches: [livekit]
 jobs:
   jest:
     name: Run jest tests

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,7 +2,7 @@ name: Run jest tests
 on:
   pull_request: {}
   push:
-    branches: [livekit]
+    branches: [livekit, full-mesh]
 jobs:
   jest:
     name: Run jest tests

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,8 @@
 name: Run jest tests
 on:
   pull_request: {}
+  push:
+    branches: [main]
 jobs:
   jest:
     name: Run jest tests


### PR DESCRIPTION
This matches up with the changes in #1147 to build both branches; and is an extension to #1143