### PR TITLE
Commit codecov.io coverage workflow to livekit branch

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,3 +16,6 @@ jobs:
         run: "yarn install"
       - name: Jest
         run: "yarn run test"
+      - name: Upload to codecov
+        uses: codecov/codecov-action@v3
+        flags: unittests

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,4 +18,5 @@ jobs:
         run: "yarn run test"
       - name: Upload to codecov
         uses: codecov/codecov-action@v3
-        flags: unittests
+        with:
+          flags: unittests

--- a/package.json
+++ b/package.json
@@ -122,6 +122,11 @@
       "\\.(css|less|svg)+$": "identity-obj-proxy",
       "^\\./IndexedDBWorker\\?worker$": "<rootDir>/test/mocks/workerMock.ts",
       "^\\./olm$": "<rootDir>/test/mocks/olmMock.ts"
-    }
+    },
+    "collectCoverage": true,
+    "coverageReporters": [
+      "text",
+      "cobertura"
+    ]
   }
 }


### PR DESCRIPTION
Hopefully this will be the final iteration of this; the first PR  (#1117) ended up merged to main after it was branched to the livekit branch, so these commits are not on this specific branch (so we're still not uploading to codecov.io)

This PR just adds the same commits to the livekit branch. Hopefully it's the last one.