### PR TITLE
Improve the double click detection

### DIFF
--- a/src/video-grid/NewVideoGrid.tsx
+++ b/src/video-grid/NewVideoGrid.tsx
@@ -60,6 +60,11 @@ interface DragState {
   cursorY: number;
 }
 
+interface TapData {
+  tileId: string;
+  ts: number;
+}
+
 interface SlotProps {
   style?: CSSProperties;
 }
@@ -257,10 +262,7 @@ export function NewVideoGrid<T>({
       );
   };
 
-  const [lastTappedTileId, setLastTappedTileId] = useState<string | undefined>(
-    undefined
-  );
-  const [lastTapTime, setLastTapTime] = useState<number>(0);
+  const lastTap = useRef<TapData | null>(null);
 
   // Callback for useDrag. We could call useDrag here, but the default
   // pattern of spreading {...bind()} across the children to bind the gesture
@@ -279,12 +281,15 @@ export function NewVideoGrid<T>({
     if (tap) {
       const now = Date.now();
 
-      if (tileId === lastTappedTileId && now - lastTapTime < 500) {
+      if (
+        tileId === lastTap.current?.tileId &&
+        now - lastTap.current.ts < 500
+      ) {
         toggleFocus?.(items.find((i) => i.id === tileId)!);
+        lastTap.current = null;
+      } else {
+        lastTap.current = { tileId, ts: now };
       }
-
-      setLastTappedTileId(tileId);
-      setLastTapTime(now);
     } else {
       const tileController = springRef.current.find(
         (c) => (c.item as Tile<T>).item.id === tileId


### PR DESCRIPTION
So that it doesn't cause unnecessary renders, and interprets a series of three clicks as a double-click followed by a single click, rather than two overlapping double-clicks. (That behavior felt odd to me during testing of NewVideoGrid, which is why I picked up this small change.)