### PR TITLE
Add the livekit URL in matroyshka mode

### DIFF
--- a/src/widget.ts
+++ b/src/widget.ts
@@ -23,6 +23,7 @@ import type { MatrixClient } from "matrix-js-sdk/src/client";
 import type { IWidgetApiRequest } from "matrix-widget-api";
 import { LazyEventEmitter } from "./LazyEventEmitter";
 import { getUrlParams } from "./UrlParams";
+import { Config } from "./config/Config";
 
 // Subset of the actions in matrix-react-sdk
 export enum ElementWidgetActions {
@@ -156,9 +157,33 @@ export const widget: WidgetHelpers | null = (() => {
           timelineSupport: true,
           useE2eForGroupCall: e2eEnabled,
           fallbackICEServerAllowed: allowIceFallback,
+          // XXX: The client expects the list of foci in its constructor, but we don't
+          // know this until we fetch the config file. However, we can't wait to construct
+          // the client object or we'll miss the 'capabilities' request from the host app.
+          // As of writing this, I have made the embedded widget client send the 'contentLoaded'
+          // message so that we can use the widget API in less racy mode, but we need to change
+          // element-web to use waitForIFrameLoad=false. Once that change has rolled out,
+          // we can just start the client after we've fetched the config.
+          foci: [],
         }
       );
-      const clientPromise = client.startClient().then(() => client);
+
+      const clientPromise = new Promise((resolve) => {
+        (async () => {
+          await Config.init();
+          const livekit = Config.get().livekit;
+          const focus = livekit?.livekit_service_url;
+          // Now we've fetched the config, be evil and use the getter to inject the focus
+          // into the client (see above XXX).
+          if (focus) {
+            client.getFoci().push({
+              livekitServiceUrl: livekit.livekit_service_url,
+            });
+          }
+          await client.startClient();
+          resolve(client);
+        })();
+      });
 
       return { api, lazyActions, client: clientPromise };
     } else {

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -168,7 +168,7 @@ export const widget: WidgetHelpers | null = (() => {
         }
       );
 
-      const clientPromise = new Promise((resolve) => {
+      const clientPromise = new Promise<MatrixClient>((resolve) => {
         (async () => {
           await Config.init();
           const livekit = Config.get().livekit;

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -170,6 +170,8 @@ export const widget: WidgetHelpers | null = (() => {
 
       const clientPromise = new Promise<MatrixClient>((resolve) => {
         (async () => {
+          // wait for the config file to be ready (we load very early on so it might not
+          // be otherwise)
           await Config.init();
           const livekit = Config.get().livekit;
           const focus = livekit?.livekit_service_url;


### PR DESCRIPTION
This is a bit of a hack, as commented. The way to make it less of a hack is there too.

Fixes embedded mode, although users will get a permission prompt without https://github.com/matrix-org/matrix-react-sdk/pull/11209.

Fixes https://github.com/vector-im/element-call/issues/1201