### PR TITLE
Add support for accessing the web server from other devices

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@types/grecaptcha": "^3.0.4",
     "@types/sdp-transform": "^2.4.5",
     "@use-gesture/react": "^10.2.11",
+    "@vitejs/plugin-basic-ssl": "^1.0.1",
     "@vitejs/plugin-react": "^4.0.1",
     "classnames": "^2.3.1",
     "color-hash": "^2.0.1",

--- a/vite.config.js
+++ b/vite.config.js
@@ -19,6 +19,7 @@ import svgrPlugin from "vite-plugin-svgr";
 import htmlTemplate from "vite-plugin-html-template";
 import sentryVitePlugin from "@sentry/vite-plugin";
 import react from "@vitejs/plugin-react";
+import basicSsl from "@vitejs/plugin-basic-ssl";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
@@ -26,6 +27,7 @@ export default defineConfig(({ mode }) => {
 
   const plugins = [
     react(),
+    basicSsl(),
     svgrPlugin(),
     htmlTemplate.default({
       data: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4328,6 +4328,11 @@
   dependencies:
     "@use-gesture/core" "10.2.16"
 
+"@vitejs/plugin-basic-ssl@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@vitejs/plugin-basic-ssl/-/plugin-basic-ssl-1.0.1.tgz#48c46eab21e0730921986ce742563ae83fe7fe34"
+  integrity sha512-pcub+YbFtFhaGRTo1832FQHQSHvMrlb43974e2eS8EKleR3p1cDdkJFPci1UhwkEf1J9Bz+wKBSzqpKp7nNj2A==
+
 "@vitejs/plugin-react@^1.0.8":
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/@vitejs/plugin-react/-/plugin-react-1.3.2.tgz#2fcf0b6ce9bcdcd4cec5c760c199779d5657ece1"


### PR DESCRIPTION
`@vitejs/plugin-basic-ssl` enables SSL when running the Vite which means the `--host` flag (`yarn dev --host`) can be used to then access the app from other devices on the network which is useful for testing on other devices (e.g. mobile phones)