### PR TITLE
Fix avatar field in profile settings being hidden

### DIFF
--- a/src/input/AvatarInputField.tsx
+++ b/src/input/AvatarInputField.tsx
@@ -34,7 +34,7 @@ import styles from "./AvatarInputField.module.css";
 interface Props extends AllHTMLAttributes<HTMLInputElement> {
   id: string;
   label: string;
-  avatarUrl: string;
+  avatarUrl: string | undefined;
   displayName: string;
   onRemoveAvatar: () => void;
 }

--- a/src/settings/ProfileSettingsTab.tsx
+++ b/src/settings/ProfileSettingsTab.tsx
@@ -77,7 +77,7 @@ export function ProfileSettingsTab({ client }: Props) {
   return (
     <form onChange={onFormChange} ref={formRef} className={styles.content}>
       <FieldRow className={styles.avatarFieldRow}>
-        {avatarUrl && displayName && (
+        {displayName && (
           <AvatarInputField
             id="avatar"
             name="avatar"


### PR DESCRIPTION
It was being hidden when you didn't yet have an avatar set, which made it impossible to ever set one.

Regressed by https://github.com/vector-im/element-call/pull/1173