### PR TITLE
Put ghost participants behind a developer flag

### DIFF
--- a/src/room/InCallView.tsx
+++ b/src/room/InCallView.tsx
@@ -58,6 +58,7 @@ import {
 import {
   useShowInspector,
   useShowConnectionStats,
+  useShowGhosts,
 } from "../settings/useSetting";
 import { useModalTriggerState } from "../Modal";
 import { PosthogAnalytics } from "../analytics/PosthogAnalytics";
@@ -451,6 +452,8 @@ function useParticipantTiles(
     room: livekitRoom,
   });
 
+  const [showGhosts] = useShowGhosts();
+
   const items = useMemo(() => {
     // The IDs of the participants who published membership event to the room (i.e. are present from Matrix perspective).
     const matrixParticipants: Map<string, RoomMember> = new Map(
@@ -464,7 +467,6 @@ function useParticipantTiles(
 
     const hasPresenter =
       sfuParticipants.find((p) => p.isScreenShareEnabled) !== undefined;
-    let allGhosts = true;
 
     const speakActiveTime = new Date();
     speakActiveTime.setSeconds(speakActiveTime.getSeconds() - 10);
@@ -478,7 +480,7 @@ function useParticipantTiles(
 
         const id = sfuParticipant.identity;
         const member = matrixParticipants.get(id);
-        allGhosts &&= member === undefined;
+        if (member === undefined && !showGhosts) return []; // Hide the ghost
 
         const userMediaTile = {
           id,
@@ -526,10 +528,8 @@ function useParticipantTiles(
       tiles.length
     );
 
-    // If every item is a ghost, that probably means we're still connecting and
-    // shouldn't bother showing anything yet
-    return allGhosts ? [] : tiles;
-  }, [participants, sfuParticipants]);
+    return tiles;
+  }, [participants, sfuParticipants, showGhosts]);
 
   return items;
 }

--- a/src/settings/SettingsModal.tsx
+++ b/src/settings/SettingsModal.tsx
@@ -34,6 +34,7 @@ import {
   useOptInAnalytics,
   useDeveloperSettingsTab,
   useShowConnectionStats,
+  useShowGhosts,
 } from "./useSetting";
 import { FieldRow, InputField } from "../input/Input";
 import { Button } from "../button";
@@ -68,6 +69,7 @@ export const SettingsModal = (props: Props) => {
     useDeveloperSettingsTab();
   const [showConnectionStats, setShowConnectionStats] =
     useShowConnectionStats();
+  const [showGhosts, setShowGhosts] = useShowGhosts();
 
   const downloadDebugLog = useDownloadDebugLog();
 
@@ -246,6 +248,19 @@ export const SettingsModal = (props: Props) => {
             checked={showConnectionStats}
             onChange={(e: ChangeEvent<HTMLInputElement>) =>
               setShowConnectionStats(e.target.checked)
+            }
+          />
+        </FieldRow>
+        <FieldRow>
+          <InputField
+            id="showGhosts"
+            name="show-ghosts"
+            label="Show ghost participants"
+            description="Shows participants that are present in the LiveKit room but not in the Matrix call, for load testing purposes"
+            type="checkbox"
+            checked={showGhosts}
+            onChange={(e: ChangeEvent<HTMLInputElement>) =>
+              setShowGhosts(e.target.checked)
             }
           />
         </FieldRow>

--- a/src/settings/useSetting.ts
+++ b/src/settings/useSetting.ts
@@ -104,6 +104,8 @@ export const useDeveloperSettingsTab = () =>
 export const useShowConnectionStats = () =>
   useSetting("show-connection-stats", false);
 
+export const useShowGhosts = () => useSetting("show-ghosts", false);
+
 export const useDefaultDevices = () =>
   useSetting("defaultDevices", {
     audioinput: "",


### PR DESCRIPTION
Because of the slight delay between a participant leaving the LiveKit room and them leaving the Matrix call, they can appear as a ghost for a second while leaving, even during normal usage. Since ghosts are really just a developer feature used for load testing, I suggest we put this behind a developer flag to avoid 👻 spooking people.