### PR TITLE
Fix embedded mode

### DIFF
--- a/src/UrlParams.ts
+++ b/src/UrlParams.ts
@@ -90,8 +90,10 @@ interface UrlParams {
 
 /**
  * Gets the app parameters for the current URL.
- * @param query The URL query string
- * @param fragment The URL fragment string
+ * @param ignoreRoomAlias If true, does not try to parse a room alias from the URL
+ * @param search The URL search string
+ * @param pathname The URL path name
+ * @param hash The URL hash
  * @returns The app parameters encoded in the URL
  */
 export const getUrlParams = (

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -109,7 +109,7 @@ export const widget: WidgetHelpers | null = (() => {
         baseUrl,
         e2eEnabled,
         allowIceFallback,
-      } = getUrlParams();
+      } = getUrlParams(true);
       if (!roomId) throw new Error("Room ID must be supplied");
       if (!userId) throw new Error("User ID must be supplied");
       if (!deviceId) throw new Error("Device ID must be supplied");


### PR DESCRIPTION
This was trying to get the room alias, which causes the config to be read. We don't need the room alias here though, so pass the flag to not return it.

Regressed in https://github.com/vector-im/element-call/pull/1177