### PR TITLE
Set video enabled even if tracks are not yet initialized

### DIFF
--- a/src/room/VideoPreview.tsx
+++ b/src/room/VideoPreview.tsx
@@ -106,11 +106,11 @@ export function VideoPreview({ matrixInfo, onUserChoicesChanged }: Props) {
     onUserChoicesChanged({
       video: {
         selectedId: videoIn.selectedId,
-        enabled: videoEnabled && !!videoTrack,
+        enabled: videoEnabled,
       },
       audio: {
         selectedId: audioIn.selectedId,
-        enabled: audioEnabled && !!audioTrack,
+        enabled: audioEnabled,
       },
     });
   }, [


### PR DESCRIPTION
This could fix "muted on join issues" but could introduce issues where the buttons show unmuted even if no device is available.