### PR TITLE
Hide media device sections in settings if empty

### DIFF
--- a/src/settings/SettingsModal.tsx
+++ b/src/settings/SettingsModal.tsx
@@ -262,7 +262,7 @@ export const SettingsModal = (props: Props) => {
   );
 
   const tabs: JSX.Element[] = [];
-  tabs.push(audioTab, videoTab);
+  if (devices) tabs.push(audioTab, videoTab);
   if (!isEmbedded) tabs.push(profileTab);
   tabs.push(feedbackTab, moreTab);
   if (developerSettingsTab) tabs.push(developerTab);


### PR DESCRIPTION
Fixes https://github.com/vector-im/element-call/issues/1289