### PR TITLE
Fix joining with muted video in widget mode

### DIFF
--- a/src/room/GroupCallView.tsx
+++ b/src/room/GroupCallView.tsx
@@ -135,7 +135,7 @@ export function GroupCallView({
         }
 
         if (videoInput === null) {
-          latestMuteStates.current!.video.setEnabled?.(true);
+          latestMuteStates.current!.video.setEnabled?.(false);
         } else {
           const deviceId = await findDeviceByName(
             videoInput,


### PR DESCRIPTION
This typo was making it impossible to join a call in Element Call's widget mode with your camera off.