### PR TITLE
Disable full mesh in widget mode

### DIFF
--- a/src/widget.ts
+++ b/src/widget.ts
@@ -165,6 +165,7 @@ export const widget: WidgetHelpers | null = (() => {
           // element-web to use waitForIFrameLoad=false. Once that change has rolled out,
           // we can just start the client after we've fetched the config.
           livekitServiceURL: undefined,
+          useLivekitForGroupCalls: true,
         }
       );
 


### PR DESCRIPTION
We disabled full mesh on the client that's used in SPA mode, but forgot to do the same for the widget mode client.