### PR TITLE
Use a more suitable color for copy buttons

### DIFF
--- a/src/button/Button.module.css
+++ b/src/button/Button.module.css
@@ -193,7 +193,7 @@ limitations under the License.
 }
 
 .iconCopyButton svg * {
-  fill: var(--cpd-color-icon-accent-tertiary);
+  fill: var(--cpd-color-icon-secondary);
 }
 
 .iconCopyButton:hover svg * {


### PR DESCRIPTION
This is a change that I meant to include in https://github.com/vector-im/element-call/pull/1354, but forgot to commit.

Before|After
-|-
![Screenshot 2023-08-30 at 14-54-27 Element Call Home](https://github.com/vector-im/element-call/assets/48614497/0627b510-35dc-4ea8-b564-6abd97519add)|![Screenshot 2023-08-30 at 14-54-21 Element Call Home](https://github.com/vector-im/element-call/assets/48614497/95d5d2d8-b6f4-4d18-bc5e-bfe2a17d30b1)