### PR TITLE
Disable turn servers in widget mode

### DIFF
--- a/src/widget.ts
+++ b/src/widget.ts
@@ -147,7 +147,7 @@ export const widget: WidgetHelpers | null = (() => {
           receiveState,
           sendToDevice: sendRecvToDevice,
           receiveToDevice: sendRecvToDevice,
-          turnServers: true,
+          turnServers: false,
         },
         roomId,
         {


### PR DESCRIPTION
Enabeling this makes the client request the turn servers which is not yet supported by the rust widget api.