### PR TITLE
Tell the CI that the livekit branch isn't a PR

### DIFF
--- a/.github/workflows/netlify-pr.yaml
+++ b/.github/workflows/netlify-pr.yaml
@@ -6,6 +6,7 @@ on:
       - completed
     branches-ignore:
       - "main"
+      - "livekit"
 jobs:
   deploy:
     if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request'


### PR DESCRIPTION
This prevents it from trying to run the PR preview workflow on every build of the livekit branch.