### PR TITLE
Fix the mute icon being incorrect when using PTT

### DIFF
--- a/src/room/InCallView.tsx
+++ b/src/room/InCallView.tsx
@@ -190,8 +190,7 @@ export function InCallView({
     containerRef1,
     toggleMicrophone,
     toggleCamera,
-    (muted) =>
-      muteStates?.audio?.setEnabled && muteStates.audio.setEnabled(!muted)
+    (muted) => muteStates.audio.setEnabled?.(!muted)
   );
 
   const onDisconnected = useCallback(

--- a/src/room/InCallView.tsx
+++ b/src/room/InCallView.tsx
@@ -190,7 +190,8 @@ export function InCallView({
     containerRef1,
     toggleMicrophone,
     toggleCamera,
-    async (muted) => await localParticipant.setMicrophoneEnabled(!muted)
+    (muted) =>
+      muteStates?.audio?.setEnabled && muteStates.audio.setEnabled(!muted)
   );
 
   const onDisconnected = useCallback(


### PR DESCRIPTION
We were manipulating the participant's mute state directly for some reason, just for setting the mute state directly, which bypased the mutestates hook.