### PR TITLE
Check for existing track before creating one.

### DIFF
--- a/src/livekit/useECConnectionState.ts
+++ b/src/livekit/useECConnectionState.ts
@@ -59,7 +59,7 @@ async function doConnect(
   const hasMicrophoneTrack = Array.from(
     livekitRoom?.localParticipant.audioTracks.values()
   ).some((track: LocalTrackPublication) => {
-    return track.options?.source == Track.Source.Microphone;
+    return track.source == Track.Source.Microphone;
   });
   // We create a track in case there isn't any.
   if (!hasMicrophoneTrack) {

--- a/src/livekit/useECConnectionState.ts
+++ b/src/livekit/useECConnectionState.ts
@@ -56,13 +56,13 @@ async function doConnect(
   audioOptions: AudioCaptureOptions
 ): Promise<void> {
   await livekitRoom!.connect(sfuConfig!.url, sfuConfig!.jwt);
-  const hasMicrofonTrack = Array.from(
+  const hasMicrophoneTrack = Array.from(
     livekitRoom?.localParticipant.audioTracks.values()
   ).some((track: LocalTrackPublication) => {
     return track.options?.source == Track.Source.Microphone;
   });
   // We create a track in case there isn't any.
-  if (!hasMicrofonTrack) {
+  if (!hasMicrophoneTrack) {
     const audioTracks = await livekitRoom!.localParticipant.createTracks({
       audio: audioOptions,
     });


### PR DESCRIPTION
In `doConnect` a new track is created and published. If we are unmuted this leads to two tracks. In this PR we check if there is already a published track and only create the track if there is none.