### PR TITLE
Fix dropdowns in settings being cut off

### DIFF
--- a/src/Modal.module.css
+++ b/src/Modal.module.css
@@ -195,6 +195,10 @@ body[data-platform="ios"] .drawer {
   grid-area: close;
 }
 
+.body {
+  flex-grow: 1;
+}
+
 .dialog .body {
   padding-inline: var(--cpd-space-10x);
   padding-block: var(--cpd-space-10x) var(--cpd-space-12x);

--- a/src/tabs/Tabs.module.css
+++ b/src/tabs/Tabs.module.css
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 .tabContainer {
+  min-height: 100%;
   display: flex;
-  flex: 1;
   flex-direction: column;
 }
 


### PR DESCRIPTION
Before|After
-|-
<img width="604" alt="Screenshot 2023-09-18 at 18 39 23" src="https://github.com/vector-im/element-call/assets/48614497/642801a8-ead7-4cb9-8225-e1b8207eb601">|![Screenshot from 2023-09-18 17-35-31](https://github.com/vector-im/element-call/assets/48614497/2de1084c-306b-4ab4-bd16-42d61da36e04)