### PR TITLE
Make touchscreen detection more robust

### DIFF
--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -67,7 +67,7 @@ export function Modal({
   ...rest
 }: ModalProps) {
   const { t } = useTranslation();
-  const touchscreen = useMediaQuery("(hover: none)");
+  const touchscreen = useMediaQuery("(hover: none) or (pointer: coarse)");
   const onOpenChange = useCallback(
     (open: boolean) => {
       if (!open) onDismiss?.();

--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -67,6 +67,8 @@ export function Modal({
   ...rest
 }: ModalProps) {
   const { t } = useTranslation();
+  // Empirically, Chrome on Android can end up not matching (hover: none), but
+  // still matching (pointer: coarse) :/
   const touchscreen = useMediaQuery("(hover: none) or (pointer: coarse)");
   const onOpenChange = useCallback(
     (open: boolean) => {


### PR DESCRIPTION
Empirically, Chrome on Android can end up not matching (hover: none), but still matching (pointer: coarse). 😕