### PR TITLE
Firefox audio output issues fix

### DIFF
--- a/src/livekit/MediaDevicesContext.tsx
+++ b/src/livekit/MediaDevicesContext.tsx
@@ -125,7 +125,7 @@ interface Props {
 export const MediaDevicesProvider: FC<Props> = ({ children }) => {
   // Counts the number of callers currently using device names
   const [numCallersUsingNames, setNumCallersUsingNames] = useState(0);
-  const usingNames = numCallersUsingNames > 0 && !isFireFox();
+  const usingNames = numCallersUsingNames > 0;
 
   // Use output device names for output devices on all platforms except FF.
   const useOutputNames = usingNames && !isFireFox();

--- a/src/livekit/MediaDevicesContext.tsx
+++ b/src/livekit/MediaDevicesContext.tsx
@@ -26,9 +26,9 @@ import {
 } from "react";
 import { createMediaDeviceObserver } from "@livekit/components-core";
 import { Observable } from "rxjs";
-import { isFireFox } from "livekit-client/dist/src/room/utils";
 
 import {
+  isFirefox,
   useAudioInput,
   useAudioOutput,
   useVideoInput,
@@ -128,11 +128,11 @@ export const MediaDevicesProvider: FC<Props> = ({ children }) => {
   const usingNames = numCallersUsingNames > 0;
 
   // Use output device names for output devices on all platforms except FF.
-  const useOutputNames = usingNames && !isFireFox();
+  const useOutputNames = usingNames && !isFirefox();
 
   // Setting the audio device to sth. else than 'undefined' breaks echo-cancellation
   // and even can introduce multiple different output devices for one call.
-  const alwaysUseDefaultAudio = isFireFox();
+  const alwaysUseDefaultAudio = isFirefox();
 
   const [audioInputSetting, setAudioInputSetting] = useAudioInput();
   const [audioOutputSetting, setAudioOutputSetting] = useAudioOutput();
@@ -163,7 +163,7 @@ export const MediaDevicesProvider: FC<Props> = ({ children }) => {
   useEffect(() => {
     // Skip setting state for ff output. Redundent since it is set to always return 'undefined'
     // but makes it clear while debugging that this is not happening on FF. + perf ;)
-    if (audioOutput.selectedId !== undefined && !isFireFox())
+    if (audioOutput.selectedId !== undefined && !isFirefox())
       setAudioOutputSetting(audioOutput.selectedId);
   }, [setAudioOutputSetting, audioOutput.selectedId]);
 

--- a/src/livekit/MediaDevicesContext.tsx
+++ b/src/livekit/MediaDevicesContext.tsx
@@ -123,7 +123,7 @@ interface Props {
 }
 
 export const MediaDevicesProvider: FC<Props> = ({ children }) => {
-  // Counts the number of callers currently using device names
+  // Counts the number of callers currently using device names.
   const [numCallersUsingNames, setNumCallersUsingNames] = useState(0);
   const usingNames = numCallersUsingNames > 0;
 
@@ -162,7 +162,7 @@ export const MediaDevicesProvider: FC<Props> = ({ children }) => {
 
   useEffect(() => {
     // Skip setting state for ff output. Redundent since it is set to always return 'undefined'
-    // But makes it clear while debugging that this is not happening on FF. + perf ;)
+    // but makes it clear while debugging that this is not happening on FF. + perf ;)
     if (audioOutput.selectedId !== undefined && !isFireFox())
       setAudioOutputSetting(audioOutput.selectedId);
   }, [setAudioOutputSetting, audioOutput.selectedId]);

--- a/src/room/GroupCallView.tsx
+++ b/src/room/GroupCallView.tsx
@@ -224,7 +224,8 @@ export function GroupCallView({
 
       leaveRTCSession(rtcSession);
       if (widget) {
-        // we need to wait until the callEnded event is tracked. Otherwise the iFrame gets killed before the callEnded event got tracked.
+        // we need to wait until the callEnded event is tracked on posthog.
+        // Otherwise the iFrame gets killed before the callEnded event got tracked.
         await new Promise((resolve) => window.setTimeout(resolve, 10)); // 10ms
         widget.api.setAlwaysOnScreen(false);
         PosthogAnalytics.instance.logout();

--- a/src/settings/SettingsModal.tsx
+++ b/src/settings/SettingsModal.tsx
@@ -132,7 +132,7 @@ export const SettingsModal = (props: Props) => {
       }
     >
       {generateDeviceSelection(devices.audioInput, t("Microphone"))}
-      {generateDeviceSelection(devices.audioOutput, t("Speaker"))}
+      {/* {generateDeviceSelection(devices.audioOutput, t("Speaker"))} */}
     </TabItem>
   );
 

--- a/src/settings/SettingsModal.tsx
+++ b/src/settings/SettingsModal.tsx
@@ -18,6 +18,7 @@ import { ChangeEvent, Key, useCallback, useState } from "react";
 import { Item } from "@react-stately/collections";
 import { Trans, useTranslation } from "react-i18next";
 import { MatrixClient } from "matrix-js-sdk";
+import { isFireFox } from "livekit-client/dist/src/room/utils";
 
 import { Modal } from "../Modal";
 import styles from "./SettingsModal.module.css";
@@ -132,7 +133,8 @@ export const SettingsModal = (props: Props) => {
       }
     >
       {generateDeviceSelection(devices.audioInput, t("Microphone"))}
-      {/* {generateDeviceSelection(devices.audioOutput, t("Speaker"))} */}
+      {!isFireFox() &&
+        generateDeviceSelection(devices.audioOutput, t("Speaker"))}
     </TabItem>
   );
 

--- a/src/settings/SettingsModal.tsx
+++ b/src/settings/SettingsModal.tsx
@@ -18,7 +18,6 @@ import { ChangeEvent, Key, useCallback, useState } from "react";
 import { Item } from "@react-stately/collections";
 import { Trans, useTranslation } from "react-i18next";
 import { MatrixClient } from "matrix-js-sdk";
-import { isFireFox } from "livekit-client/dist/src/room/utils";
 
 import { Modal } from "../Modal";
 import styles from "./SettingsModal.module.css";
@@ -36,6 +35,7 @@ import {
   useDeveloperSettingsTab,
   useShowConnectionStats,
   useEnableE2EE,
+  isFirefox,
 } from "./useSetting";
 import { FieldRow, InputField } from "../input/Input";
 import { Button } from "../button";
@@ -133,7 +133,7 @@ export const SettingsModal = (props: Props) => {
       }
     >
       {generateDeviceSelection(devices.audioInput, t("Microphone"))}
-      {!isFireFox() &&
+      {!isFirefox() &&
         generateDeviceSelection(devices.audioOutput, t("Speaker"))}
     </TabItem>
   );

--- a/src/settings/useSetting.ts
+++ b/src/settings/useSetting.ts
@@ -16,6 +16,7 @@ limitations under the License.
 
 import { useCallback, useMemo } from "react";
 import { isE2EESupported } from "livekit-client";
+import { isFireFox } from "livekit-client/dist/src/room/utils";
 
 import { PosthogAnalytics } from "../analytics/PosthogAnalytics";
 import {
@@ -59,7 +60,6 @@ export const setSetting = <T>(name: string, newValue: T) =>
   setLocalStorageItem(getSettingKey(name), JSON.stringify(newValue));
 
 const canEnableSpatialAudio = () => {
-  const { userAgent } = navigator;
   // Spatial audio means routing audio through audio contexts. On Chrome,
   // this bypasses the AEC processor and so breaks echo cancellation.
   // We only allow spatial audio to be enabled on Firefox which we know
@@ -69,7 +69,7 @@ const canEnableSpatialAudio = () => {
   // widely enough, we can allow spatial audio everywhere. It's currently in a
   // chrome flag, so we could enable this in Electron if we enabled the chrome flag
   // in the Electron wrapper.
-  return userAgent.includes("Firefox");
+  return isFireFox();
 };
 
 export const useSpatialAudio = (): DisableableSetting<boolean> => {

--- a/src/settings/useSetting.ts
+++ b/src/settings/useSetting.ts
@@ -16,7 +16,6 @@ limitations under the License.
 
 import { useCallback, useMemo } from "react";
 import { isE2EESupported } from "livekit-client";
-import { isFireFox } from "livekit-client/dist/src/room/utils";
 
 import { PosthogAnalytics } from "../analytics/PosthogAnalytics";
 import {
@@ -59,6 +58,11 @@ export const getSetting = <T>(name: string, defaultValue: T): T => {
 export const setSetting = <T>(name: string, newValue: T) =>
   setLocalStorageItem(getSettingKey(name), JSON.stringify(newValue));
 
+export const isFirefox = () => {
+  const { userAgent } = navigator;
+  return userAgent.includes("Firefox");
+};
+
 const canEnableSpatialAudio = () => {
   // Spatial audio means routing audio through audio contexts. On Chrome,
   // this bypasses the AEC processor and so breaks echo cancellation.
@@ -69,7 +73,7 @@ const canEnableSpatialAudio = () => {
   // widely enough, we can allow spatial audio everywhere. It's currently in a
   // chrome flag, so we could enable this in Electron if we enabled the chrome flag
   // in the Electron wrapper.
-  return isFireFox();
+  return isFirefox();
 };
 
 export const useSpatialAudio = (): DisableableSetting<boolean> => {


### PR DESCRIPTION
In firefox it causes issue to do a manaul audio output selection. Thos happen when the settings modal is opend.
As a user this can be observed as: Pressing on settings => all other participants can hear an echo.
This pr tries to disable the minimum so that the issue does not occur anymore.

Fixes: #1437 And hopefully: #1438 