### PR TITLE
Fix layout toggle looking broken on Safari (I hope)

### DIFF
--- a/src/room/LayoutToggle.module.css
+++ b/src/room/LayoutToggle.module.css
@@ -24,6 +24,8 @@ limitations under the License.
 
 .toggle input {
   appearance: none;
+  /* Safari puts a margin on these, which is not removed via appearance: none */
+  margin: 0;
   outline: none !important;
 }
 


### PR DESCRIPTION
I don't have a Safari to test with, but according to https://moderncss.dev/pure-css-custom-styled-radio-buttons/, this should do the trick.