### PR TITLE
fix url by providin a last &

### DIFF
--- a/src/room/AppSelectionModal.tsx
+++ b/src/room/AppSelectionModal.tsx
@@ -63,7 +63,7 @@ export const AppSelectionModal: FC<Props> = ({ roomId }) => {
     });
 
     const result = new URL("element://call");
-    result.searchParams.set("url", url.toString());
+    result.searchParams.set("url", url.toString() + "&");
     return result.toString();
   }, [roomId, roomSharedKey]);
 

--- a/src/room/AppSelectionModal.tsx
+++ b/src/room/AppSelectionModal.tsx
@@ -63,6 +63,8 @@ export const AppSelectionModal: FC<Props> = ({ roomId }) => {
     });
 
     const result = new URL("element://call");
+    // Everything after the last & stripped away making us loose the last param. Most likely while removing the pwd.
+    // TODO fix the pwd removal function (or wherever this happens) to not delete everything after the last &.
     result.searchParams.set("url", url.toString() + "&");
     return result.toString();
   }, [roomId, roomSharedKey]);


### PR DESCRIPTION
everything after the last & will be stripped away while loading the page (i think in the same step where we remove the PWD. THat most likely also would be the better fix. (not deleting it in the first place) but for the release that should do.
 - hence we loose the last param (usually confined to room...) 
- going home kills the all the params which we need to fix!

Fixes: #1548 