### PR TITLE
Better error for browsers that don't support e2ee

### DIFF
--- a/public/locales/en-GB/app.json
+++ b/public/locales/en-GB/app.json
@@ -121,5 +121,6 @@
   "Yes, join call": "Yes, join call",
   "You": "You",
   "You were disconnected from the call": "You were disconnected from the call",
-  "Your feedback": "Your feedback"
+  "Your feedback": "Your feedback",
+  "Your web browser does not support media end-to-end encryption. Supported Browsers are Chrome, Safari, Firefox >=117": "Your web browser does not support media end-to-end encryption. Supported Browsers are Chrome, Safari, Firefox >=117"
 }


### PR DESCRIPTION

<img width="807" alt="Screenshot 2023-09-20 at 13 03 23" src="https://github.com/vector-im/element-call/assets/986903/40d462c0-9523-45dc-a3ce-7d44904cd920">


Fixes https://github.com/vector-im/element-call/issues/1549