### PR TITLE
Capture livekit's logs in rageshakes

### DIFF
--- a/src/livekit/useLiveKit.ts
+++ b/src/livekit/useLiveKit.ts
@@ -20,7 +20,6 @@ import {
   ExternalE2EEKeyProvider,
   Room,
   RoomOptions,
-  setLogLevel,
 } from "livekit-client";
 import { useLiveKitRoom } from "@livekit/components-react";
 import { useEffect, useMemo, useRef, useState } from "react";

--- a/src/livekit/useLiveKit.ts
+++ b/src/livekit/useLiveKit.ts
@@ -44,8 +44,6 @@ export type E2EEConfig = {
   sharedKey: string;
 };
 
-setLogLevel("debug");
-
 interface UseLivekitResult {
   livekitRoom?: Room;
   connState: ECConnectionState;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -23,13 +23,19 @@ import "matrix-js-sdk/src/browser-index";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { createBrowserHistory } from "history";
-
 import "./index.css";
+import { setLogLevel as setLKLogLevel } from "livekit-client";
+
 import App from "./App";
 import { init as initRageshake } from "./settings/rageshake";
 import { Initializer } from "./initializer";
 
 initRageshake();
+// set livekit's log level: we do this after initialising rageshakes because
+// we need rageshake to do its monkey patching first, so the livekit
+// logger gets the patched log funxction, so it picks up livekit's
+// logs.
+setLKLogLevel("debug");
 
 console.info(`Element Call ${import.meta.env.VITE_APP_VERSION || "dev"}`);
 


### PR DESCRIPTION
Not a great fix as livekit still does log initialisation in the root of a file, so it's all down to import order which runs first. It does occur that both EC and livekit use loglevel which supports logging extensions, so we should probably just make rageshake use that (there is probably even an extension to redirect logs somewhere).

Also this still doesn't capture logs from the e2ee worker which is a bit sad, but I don't think we are going to achieve this with rageshake's monkey patching.

Fixes https://github.com/vector-im/element-call/issues/1424