### PR TITLE
Refactor useIsRoomE2EE

### DIFF
--- a/src/e2ee/sharedKeyManagement.ts
+++ b/src/e2ee/sharedKeyManagement.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import { useEffect, useMemo } from "react";
-import { Room } from "matrix-js-sdk";
+import { Room } from "matrix-js-sdk/src/models/room";
 import { logger } from "matrix-js-sdk/src/logger";
 
 import { useEnableE2EE } from "../settings/useSetting";

--- a/src/e2ee/sharedKeyManagement.ts
+++ b/src/e2ee/sharedKeyManagement.ts
@@ -15,10 +15,11 @@ limitations under the License.
 */
 
 import { useEffect, useMemo } from "react";
+import { Room } from "matrix-js-sdk";
+import { logger } from "matrix-js-sdk/src/logger";
 
 import { useEnableE2EE } from "../settings/useSetting";
 import { useLocalStorage } from "../useLocalStorage";
-import { useClient } from "../ClientContext";
 import { PASSWORD_STRING, useUrlParams } from "../UrlParams";
 import { widget } from "../widget";
 
@@ -83,14 +84,19 @@ export const useManageRoomSharedKey = (roomId: string): string | null => {
   return e2eeSharedKey ?? urlPassword;
 };
 
-export const useIsRoomE2EE = (roomId: string): boolean | null => {
-  const { client } = useClient();
-  const room = useMemo(() => client?.getRoom(roomId) ?? null, [roomId, client]);
+export const useIsRoomE2EE = (room?: Room): boolean | null => {
   // For now, rooms in widget mode are never considered encrypted.
   // In the future, when widget mode gains encryption support, then perhaps we
   // should inspect the e2eEnabled URL parameter here?
-  return useMemo(
-    () => widget === null && (room === null || !room.getCanonicalAlias()),
+  const canonAlias = useMemo(
+    () => (room ? room.getCanonicalAlias() : null),
     [room]
   );
+
+  const result = room ? !canonAlias && !widget : null;
+  logger.debug(
+    `Room ${room?.roomId} has canon alias ${canonAlias}. Is E2EE: ${result}`
+  );
+
+  return result;
 };

--- a/src/room/AppSelectionModal.tsx
+++ b/src/room/AppSelectionModal.tsx
@@ -25,9 +25,10 @@ import { useIsRoomE2EE, useRoomSharedKey } from "../e2ee/sharedKeyManagement";
 import { getAbsoluteRoomUrl } from "../matrix-utils";
 import styles from "./AppSelectionModal.module.css";
 import { editFragmentQuery } from "../UrlParams";
+import { useClient } from "../ClientContext";
 
 interface Props {
-  roomId: string | null;
+  roomId: string | undefined;
 }
 
 export const AppSelectionModal: FC<Props> = ({ roomId }) => {
@@ -43,8 +44,11 @@ export const AppSelectionModal: FC<Props> = ({ roomId }) => {
     [setOpen]
   );
 
+  const { client } = useClient();
+  const room = useMemo(() => client?.getRoom(roomId) ?? null, [roomId, client]);
+
   const roomSharedKey = useRoomSharedKey(roomId ?? "");
-  const roomIsEncrypted = useIsRoomE2EE(roomId ?? "");
+  const roomIsEncrypted = useIsRoomE2EE(room ?? undefined);
   if (roomIsEncrypted && roomSharedKey === undefined) {
     logger.error(
       "Generating app redirect URL for encrypted room but don't have key available!"
@@ -58,7 +62,7 @@ export const AppSelectionModal: FC<Props> = ({ roomId }) => {
     // we got in our own URL and use that, but it's not a string that a human
     // ever sees so it's somewhat redundant. We just don't pass a name.
     const url = new URL(
-      roomId === null
+      !roomId
         ? window.location.href
         : getAbsoluteRoomUrl(roomId, undefined, roomSharedKey ?? undefined)
     );

--- a/src/room/GroupCallView.tsx
+++ b/src/room/GroupCallView.tsx
@@ -76,7 +76,7 @@ export function GroupCallView({
   const isJoined = useMatrixRTCSessionJoinState(rtcSession);
 
   const e2eeSharedKey = useManageRoomSharedKey(rtcSession.room.roomId);
-  const isRoomE2EE = useIsRoomE2EE(rtcSession.room.roomId);
+  const isRoomE2EE = useIsRoomE2EE(rtcSession.room);
 
   useEffect(() => {
     window.rtcSession = rtcSession;
@@ -88,7 +88,6 @@ export function GroupCallView({
   const { displayName, avatarUrl } = useProfile(client);
   const roomName = useRoomName(rtcSession.room);
   const roomAvatar = useRoomAvatar(rtcSession.room);
-  const roomEncrypted = useIsRoomE2EE(rtcSession.room.roomId)!;
 
   const matrixInfo = useMemo((): MatrixInfo => {
     return {
@@ -99,7 +98,7 @@ export function GroupCallView({
       roomName,
       roomAlias: rtcSession.room.getCanonicalAlias(),
       roomAvatar,
-      roomEncrypted,
+      roomEncrypted: isRoomE2EE!,
     };
   }, [
     displayName,
@@ -107,7 +106,7 @@ export function GroupCallView({
     rtcSession,
     roomName,
     roomAvatar,
-    roomEncrypted,
+    isRoomE2EE,
     client,
   ]);
 

--- a/src/room/RoomPage.tsx
+++ b/src/room/RoomPage.tsx
@@ -110,7 +110,7 @@ export const RoomPage: FC = () => {
       {content}
       {/* On Android and iOS, show a prompt to launch the mobile app. */}
       {appPrompt && (platform === "android" || platform === "ios") && (
-        <AppSelectionModal roomId={roomId} />
+        <AppSelectionModal roomId={roomId ?? undefined} />
       )}
     </>
   );


### PR DESCRIPTION
Make it take a room object rather than a room ID to avoid it depending on a side effect, ie. if the room object input changes, the hook will be re-run but if we can't get the room from the room ID for whatever reason, we'd be stuck.

Also add logging on why we decided a room was e2ee.