### PR TITLE
Revert "Capture livekit's logs in rageshakes"

### DIFF
--- a/src/livekit/useLiveKit.ts
+++ b/src/livekit/useLiveKit.ts
@@ -20,6 +20,7 @@ import {
   ExternalE2EEKeyProvider,
   Room,
   RoomOptions,
+  setLogLevel,
 } from "livekit-client";
 import { useLiveKitRoom } from "@livekit/components-react";
 import { useEffect, useMemo, useRef, useState } from "react";
@@ -42,6 +43,8 @@ import {
 export type E2EEConfig = {
   sharedKey: string;
 };
+
+setLogLevel("debug");
 
 interface UseLivekitResult {
   livekitRoom?: Room;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -23,19 +23,13 @@ import "matrix-js-sdk/src/browser-index";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { createBrowserHistory } from "history";
-import "./index.css";
-import { setLogLevel as setLKLogLevel } from "livekit-client";
 
+import "./index.css";
 import App from "./App";
 import { init as initRageshake } from "./settings/rageshake";
 import { Initializer } from "./initializer";
 
 initRageshake();
-// set livekit's log level: we do this after initialising rageshakes because
-// we need rageshake to do its monkey patching first, so the livekit
-// logger gets the patched log funxction, so it picks up livekit's
-// logs.
-setLKLogLevel("debug");
 
 console.info(`Element Call ${import.meta.env.VITE_APP_VERSION || "dev"}`);
 


### PR DESCRIPTION
Reverts vector-im/element-call#1566

This is causing while trees of objects to get logged, locking up the browser and causing disconnects and general chaos. Reverting until we can fix properly.