### PR TITLE
Re-enable livekit rageshake logging & with depth limit

### DIFF
--- a/src/livekit/useLiveKit.ts
+++ b/src/livekit/useLiveKit.ts
@@ -20,7 +20,6 @@ import {
   ExternalE2EEKeyProvider,
   Room,
   RoomOptions,
-  setLogLevel,
 } from "livekit-client";
 import { useLiveKitRoom } from "@livekit/components-react";
 import { useEffect, useMemo, useRef, useState } from "react";
@@ -43,8 +42,6 @@ import {
 export type E2EEConfig = {
   sharedKey: string;
 };
-
-setLogLevel("debug");
 
 interface UseLivekitResult {
   livekitRoom?: Room;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -25,12 +25,18 @@ import { createRoot } from "react-dom/client";
 import { createBrowserHistory } from "history";
 import "./index.css";
 import { logger } from "matrix-js-sdk/src/logger";
+import {
+  setLogExtension as setLKLogExtension,
+  setLogLevel,
+} from "livekit-client";
 
 import App from "./App";
 import { init as initRageshake } from "./settings/rageshake";
 import { Initializer } from "./initializer";
 
 initRageshake();
+setLogLevel("debug");
+setLKLogExtension(global.mx_rage_logger.log);
 
 logger.info(`Element Call ${import.meta.env.VITE_APP_VERSION || "dev"}`);
 

--- a/src/settings/rageshake.ts
+++ b/src/settings/rageshake.ts
@@ -566,7 +566,7 @@ const getCircularReplacer = function (): StringifyReplacer {
         depth = depthMap.get(value) ?? 0;
       }
 
-      // 'this' is supposed to be the object the value was foudn in, according to
+      // 'this' is supposed to be the object the value was found in, according to
       // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify
       // but that doesn't seem to be the case. Instead, we do a pre-pass on the children here to
       // remember what depth we saw them at.


### PR DESCRIPTION
Puts livekit logs back in the rageshake logs and adds a recursion limit to the object serialiser in rageshake.