### PR TITLE
Fix the i18n string scanner

### DIFF
--- a/i18next-parser.config.js
+++ b/i18next-parser.config.js
@@ -18,5 +18,6 @@ export default {
   output: "public/locales/$LOCALE/$NAMESPACE.json",
   input: ["src/**/*.{ts,tsx}"],
   sort: true,
-  useKeysAsDefaultValue: true,
+  // The key becomes the English version of the string
+  defaultValue: (_l, _ns, key) => key,
 };


### PR DESCRIPTION
Apparently the upgrade to i18next-parser v8 came with the removal of this `useKeysAsDefaultValues` option, and this is the new way to configure that behavior.