### PR TITLE
Update the colors of name tags

### DIFF
--- a/src/video-grid/VideoTile.module.css
+++ b/src/video-grid/VideoTile.module.css
@@ -71,8 +71,7 @@ limitations under the License.
   padding: var(--cpd-space-1x);
   padding-block: var(--cpd-space-1x);
   color: var(--cpd-color-text-primary);
-  /* TODO: un-hardcode this color. It comes from the dark theme. */
-  background-color: rgba(237, 244, 252, 0.79);
+  background-color: var(--cpd-color-bg-canvas-default);
   display: flex;
   align-items: center;
   border-radius: var(--cpd-radius-pill-effect);
@@ -81,11 +80,6 @@ limitations under the License.
   overflow: hidden;
   z-index: 1;
   box-shadow: var(--small-drop-shadow);
-}
-
-:global(.cpd-theme-dark) .nameTag {
-  /* TODO: un-hardcode this color. It comes from the light theme. */
-  background-color: rgba(2, 7, 13, 0.77);
 }
 
 .nameTag > svg {


### PR DESCRIPTION
This was changed in the designs so we don't have to hard-code colors for them anymore.

![Screenshot 2023-09-27 at 18-36-04 Element Call Home](https://github.com/vector-im/element-call/assets/48614497/b6a520d8-7fb2-4a82-a9ed-4cda49d05157)