### PR TITLE
Show the device that's actually in use

### DIFF
--- a/src/livekit/useLiveKit.ts
+++ b/src/livekit/useLiveKit.ts
@@ -159,6 +159,12 @@ export function useLiveKit(
       const syncDevice = (kind: MediaDeviceKind, device: MediaDevice) => {
         const id = device.selectedId;
         if (id !== undefined && room.getActiveDevice(kind) !== id) {
+          logger.info(
+            `Switching ${kind} device to ${
+              device.available.find((d) => d.deviceId === device.selectedId)
+                ?.label
+            } (${id})`
+          );
           room
             .switchActiveDevice(kind, id)
             .catch((e) =>

--- a/src/settings/SettingsModal.tsx
+++ b/src/settings/SettingsModal.tsx
@@ -99,8 +99,8 @@ export const SettingsModal = (props: Props) => {
 
     let selectedKey = devices.selectedId;
     // We may present a different device as the currently selected one if we have an active track
-    // from the default device, because the default device may have changed since we acquired the
-    // track, in which case we want to display the one we're actually using rather than what the
+    // from the default device, because the default device of the OS may have changed since we acquired the
+    // track, but EC did not update the track to match the new default, in which case we want to display the one we're actually using rather than what the
     // default is now.
     if (
       trackUsedByRoom &&


### PR DESCRIPTION
Feeds the current track (if any), and therefore device it's using into the device selection dropdown and implement a some somewhat complex logic to observe when the 'default' device has changed to a different actual devbice between when we opened it and now, and display the device we're actually using as selected instead.

The comments should explain more, including the caveat that we can't do the same detective work if the device is one of several devices on the same bit of hardware. This is because is uses the same groupId comparison technique used by Livekit in `normalizeDeviceId` to do a smiliar thing.

Fixes https://github.com/vector-im/element-call/issues/1646