### PR TITLE
Add logging & guards for mic pre-creation & focus

### DIFF
--- a/src/livekit/useECConnectionState.ts
+++ b/src/livekit/useECConnectionState.ts
@@ -63,7 +63,7 @@ async function doConnect(
   // mobile browsers to know we're doing a call.
   if (livekitRoom!.localParticipant.getTrack(Track.Source.Microphone)) {
     logger.warn(
-      "Pre-creating audio track but participant already appears to have an microphone track: this shouldn't happen!"
+      "Pre-creating audio track but participant already appears to have an microphone track: this shouldn't happen!",
     );
     return;
   }
@@ -81,7 +81,7 @@ async function doConnect(
   // check again having awaited for the track to create
   if (livekitRoom!.localParticipant.getTrack(Track.Source.Microphone)) {
     logger.warn(
-      "Publishing pre-created audio track but participant already appears to have an microphone track: this shouldn't happen!"
+      "Publishing pre-created audio track but participant already appears to have an microphone track: this shouldn't happen!",
     );
     return;
   }

--- a/src/livekit/useECConnectionState.ts
+++ b/src/livekit/useECConnectionState.ts
@@ -19,6 +19,7 @@ import {
   ConnectionState,
   Room,
   RoomEvent,
+  Track,
 } from "livekit-client";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { logger } from "matrix-js-sdk/src/logger";
@@ -60,6 +61,14 @@ async function doConnect(
   // doesn't publish it until you unmute. We want to publish it from the start so we're
   // always capturing audio: it helps keep bluetooth headsets in the right mode and
   // mobile browsers to know we're doing a call.
+  if (livekitRoom!.localParticipant.getTrack(Track.Source.Microphone)) {
+    logger.warn(
+      "Pre-creating audio track but participant already appears to have an microphone track: this shouldn't happen!"
+    );
+    return;
+  }
+
+  logger.info("Pre-creating microphone track");
   const audioTracks = await livekitRoom!.localParticipant.createTracks({
     audio: audioOptions,
   });
@@ -69,6 +78,14 @@ async function doConnect(
   }
   if (!audioEnabled) await audioTracks[0].mute();
 
+  // check again having awaited for the track to create
+  if (livekitRoom!.localParticipant.getTrack(Track.Source.Microphone)) {
+    logger.warn(
+      "Publishing pre-created audio track but participant already appears to have an microphone track: this shouldn't happen!"
+    );
+    return;
+  }
+  logger.info("Publishing pre-created mic track");
   await livekitRoom?.localParticipant.publishTrack(audioTracks[0]);
 }
 

--- a/src/room/useActiveFocus.ts
+++ b/src/room/useActiveFocus.ts
@@ -20,6 +20,7 @@ import {
 } from "matrix-js-sdk/src/matrixrtc/MatrixRTCSession";
 import { useCallback, useEffect, useState } from "react";
 import { deepCompare } from "matrix-js-sdk/src/utils";
+import { logger } from "matrix-js-sdk/src/logger";
 
 import { LivekitFocus } from "../livekit/LivekitFocus";
 
@@ -27,7 +28,16 @@ function getActiveFocus(
   rtcSession: MatrixRTCSession,
 ): LivekitFocus | undefined {
   const oldestMembership = rtcSession.getOldestMembership();
-  return oldestMembership?.getActiveFoci()[0] as LivekitFocus;
+  const focus = oldestMembership?.getActiveFoci()[0] as LivekitFocus;
+
+  if (focus) {
+    logger.info(
+      `Got active focus for call from ${oldestMembership?.sender}/${oldestMembership?.deviceId}`,
+      focus
+    );
+  }
+
+  return focus;
 }
 
 /**

--- a/src/room/useActiveFocus.ts
+++ b/src/room/useActiveFocus.ts
@@ -33,7 +33,7 @@ function getActiveFocus(
   if (focus) {
     logger.info(
       `Got active focus for call from ${oldestMembership?.sender}/${oldestMembership?.deviceId}`,
-      focus
+      focus,
     );
   }
 


### PR DESCRIPTION
Logs & guard for pre-recating the mic track as well as logging what we select as the active focus (JWT URL + livekit alias).