### PR TITLE
Re-enable screen sharing on Safari

### DIFF
--- a/src/room/InCallView.tsx
+++ b/src/room/InCallView.tsx
@@ -87,9 +87,6 @@ import {
 import { useOpenIDSFU } from "../livekit/openIDSFU";
 
 const canScreenshare = "getDisplayMedia" in (navigator.mediaDevices ?? {});
-// There is currently a bug in Safari our our code with cloning and sending MediaStreams
-// or with getUsermedia and getDisplaymedia being used within the same session.
-// For now we can disable screensharing in Safari.
 const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
 
 // How long we wait after a focus switch before showing the real participant list again
@@ -369,7 +366,7 @@ export const InCallView: FC<InCallViewProps> = ({
     );
 
     if (!reducedControls) {
-      if (canScreenshare && !hideScreensharing && !isSafari) {
+      if (canScreenshare && !hideScreensharing) {
         buttons.push(
           <ScreenshareButton
             key="3"


### PR DESCRIPTION
Appears to work fine now, and no reason to think it shouldn't on Livekit.

We still force no animations on Safari which uses isSafari. There's no comment to say why, so it's a mystery. I've removed the comment about disabling screensharing which is no longer true.

Fixes https://github.com/vector-im/element-call/issues/1762