### PR TITLE
Fix using a non-default audio device

### DIFF
--- a/src/livekit/useLiveKit.ts
+++ b/src/livekit/useLiveKit.ts
@@ -127,7 +127,7 @@ export function useLiveKit(
 
   const connectionState = useECConnectionState(
     {
-      deviceId: initialDevices.current.audioOutput.selectedId,
+      deviceId: initialDevices.current.audioInput.selectedId,
     },
     initialMuteStates.current.audio.enabled,
     room,


### PR DESCRIPTION
We were passing the output option when we wanted the input, so the mic track pre-creation would just always use the system default.