### PR TITLE
Update the invite button icon

### DIFF
--- a/src/button/InviteButton.tsx
+++ b/src/button/InviteButton.tsx
@@ -17,14 +17,14 @@ limitations under the License.
 import { ComponentPropsWithoutRef, FC } from "react";
 import { Button } from "@vector-im/compound-web";
 import { useTranslation } from "react-i18next";
-import UserAddSolidIcon from "@vector-im/compound-design-tokens/icons/user-add-solid.svg?react";
+import UserAddIcon from "@vector-im/compound-design-tokens/icons/user-add.svg?react";
 
 export const InviteButton: FC<
   Omit<ComponentPropsWithoutRef<"button">, "children">
 > = (props) => {
   const { t } = useTranslation();
   return (
-    <Button kind="secondary" size="sm" Icon={UserAddSolidIcon} {...props}>
+    <Button kind="secondary" size="sm" Icon={UserAddIcon} {...props}>
       {t("Invite")}
     </Button>
   );


### PR DESCRIPTION
The design specs have changed to always use the outline variants of icons on buttons like this.

![Screenshot 2023-10-16 at 12-38-02 Element Call Home](https://github.com/vector-im/element-call/assets/48614497/40680018-5077-4090-a18e-7aee0d3faa71)