### PR TITLE
Add hideControls url param for screen recordings.

### DIFF
--- a/src/UrlParams.ts
+++ b/src/UrlParams.ts
@@ -65,7 +65,7 @@ interface UrlParams {
   /**
    * Whether the controls should be shown. For screen recording no controls can be desired.
    */
-  hideControls:boolean;
+  showControls: boolean;
   /**
    * Whether to hide the screen-sharing button.
    */
@@ -199,7 +199,7 @@ export const getUrlParams = (
     appPrompt: parser.getFlagParam("appPrompt", true),
     preload: parser.getFlagParam("preload"),
     hideHeader: parser.getFlagParam("hideHeader"),
-    hideControls: parser.getFlagParam("hideControls"),
+    showControls: parser.getFlagParam("showControls"),
     hideScreensharing: parser.getFlagParam("hideScreensharing"),
     e2eEnabled: parser.getFlagParam("enableE2e", true),
     userId: parser.getParam("userId"),

--- a/src/UrlParams.ts
+++ b/src/UrlParams.ts
@@ -63,6 +63,10 @@ interface UrlParams {
    */
   hideHeader: boolean;
   /**
+   * Whether the controls should be shown. For screen recording no controls can be desired.
+   */
+  hideControls:boolean;
+  /**
    * Whether to hide the screen-sharing button.
    */
   hideScreensharing: boolean;
@@ -195,6 +199,7 @@ export const getUrlParams = (
     appPrompt: parser.getFlagParam("appPrompt", true),
     preload: parser.getFlagParam("preload"),
     hideHeader: parser.getFlagParam("hideHeader"),
+    hideControls: parser.getFlagParam("hideControls"),
     hideScreensharing: parser.getFlagParam("hideScreensharing"),
     e2eEnabled: parser.getFlagParam("enableE2e", true),
     userId: parser.getParam("userId"),

--- a/src/room/InCallView.module.css
+++ b/src/room/InCallView.module.css
@@ -98,3 +98,12 @@ limitations under the License.
     gap: var(--cpd-space-4x);
   }
 }
+
+.footerThin {
+  padding-top: var(--cpd-space-3x);
+  padding-bottom: var(--cpd-space-5x);
+}
+
+.footerHidden {
+  display: none;
+}

--- a/src/room/InCallView.tsx
+++ b/src/room/InCallView.tsx
@@ -41,6 +41,7 @@ import { useTranslation } from "react-i18next";
 import useMeasure from "react-use-measure";
 import { logger } from "matrix-js-sdk/src/logger";
 import { MatrixRTCSession } from "matrix-js-sdk/src/matrixrtc/MatrixRTCSession";
+import classNames from "classnames";
 
 import LogoMark from "../icons/LogoMark.svg?react";
 import LogoType from "../icons/LogoType.svg?react";
@@ -177,7 +178,7 @@ export const InCallView: FC<InCallViewProps> = ({
 
   const [showConnectionStats] = useShowConnectionStats();
 
-  const { hideScreensharing } = useUrlParams();
+  const { hideScreensharing, hideControls } = useUrlParams();
 
   const { isScreenShareEnabled, localParticipant } = useLocalParticipant({
     room: livekitRoom,
@@ -387,7 +388,15 @@ export const InCallView: FC<InCallViewProps> = ({
       />,
     );
     footer = (
-      <div className={styles.footer}>
+      <div
+        className={classNames(
+          hideControls
+            ? hideHeader
+              ? [styles.footer, styles.footerHidden]
+              : [styles.footer, styles.footerThin]
+            : styles.footer,
+        )}
+      >
         {!mobile && !hideHeader && (
           <div className={styles.logo}>
             <LogoMark width={24} height={24} aria-hidden />
@@ -398,8 +407,8 @@ export const InCallView: FC<InCallViewProps> = ({
             />
           </div>
         )}
-        <div className={styles.buttons}>{buttons}</div>
-        {!mobile && !hideHeader && (
+        {!hideControls && <div className={styles.buttons}>{buttons}</div>}
+        {!mobile && !hideHeader && !hideControls && (
           <LayoutToggle
             className={styles.layout}
             layout={layout}
@@ -424,7 +433,7 @@ export const InCallView: FC<InCallViewProps> = ({
             />
           </LeftNav>
           <RightNav>
-            {!reducedControls && onShareClick !== null && (
+            {!reducedControls && !hideControls && onShareClick !== null && (
               <InviteButton onClick={onShareClick} />
             )}
           </RightNav>

--- a/src/room/InCallView.tsx
+++ b/src/room/InCallView.tsx
@@ -178,7 +178,7 @@ export const InCallView: FC<InCallViewProps> = ({
 
   const [showConnectionStats] = useShowConnectionStats();
 
-  const { hideScreensharing, hideControls } = useUrlParams();
+  const { hideScreensharing, showControls } = useUrlParams();
 
   const { isScreenShareEnabled, localParticipant } = useLocalParticipant({
     room: livekitRoom,
@@ -390,7 +390,7 @@ export const InCallView: FC<InCallViewProps> = ({
     footer = (
       <div
         className={classNames(
-          hideControls
+          showControls
             ? hideHeader
               ? [styles.footer, styles.footerHidden]
               : [styles.footer, styles.footerThin]
@@ -407,8 +407,8 @@ export const InCallView: FC<InCallViewProps> = ({
             />
           </div>
         )}
-        {!hideControls && <div className={styles.buttons}>{buttons}</div>}
-        {!mobile && !hideHeader && !hideControls && (
+        {!showControls && <div className={styles.buttons}>{buttons}</div>}
+        {!mobile && !hideHeader && !showControls && (
           <LayoutToggle
             className={styles.layout}
             layout={layout}
@@ -433,7 +433,7 @@ export const InCallView: FC<InCallViewProps> = ({
             />
           </LeftNav>
           <RightNav>
-            {!reducedControls && !hideControls && onShareClick !== null && (
+            {!reducedControls && !showControls && onShareClick !== null && (
               <InviteButton onClick={onShareClick} />
             )}
           </RightNav>


### PR DESCRIPTION
`showControls=false` 
<img width="2168" alt="Screenshot 2023-10-21 at 01 05 41" src="https://github.com/vector-im/element-call/assets/16718859/77947b91-d0a9-4da1-a652-570fa19d004e">


`hideHeader=true`
<img width="2168" alt="Screenshot 2023-10-21 at 01 05 34" src="https://github.com/vector-im/element-call/assets/16718859/0a3ffa86-5a88-4823-bc9e-3bdb8909fac3">

reference without flags
<img width="2168" alt="Screenshot 2023-10-21 at 01 05 24" src="https://github.com/vector-im/element-call/assets/16718859/8422479e-1f9f-4746-afc7-ee51544d2729">