### PR TITLE
Fix not hanging up when using the close button (EXA EXI)

### DIFF
--- a/src/room/GroupCallView.tsx
+++ b/src/room/GroupCallView.tsx
@@ -244,7 +244,7 @@ export const GroupCallView: FC<Props> = ({
       const onHangup = async (
         ev: CustomEvent<IWidgetApiRequest>,
       ): Promise<void> => {
-        leaveRTCSession(rtcSession);
+        await leaveRTCSession(rtcSession);
         widget!.api.transport.reply(ev.detail, {});
         widget!.api.setAlwaysOnScreen(false);
       };

--- a/src/rtcSessionHelpers.ts
+++ b/src/rtcSessionHelpers.ts
@@ -57,8 +57,9 @@ const widgetPostHangupProcedure = async (
   widget.api.setAlwaysOnScreen(false);
   PosthogAnalytics.instance.logout();
 
-  // we will always send the hangup event after the memberships have been updated
+  // We send the hangup event after the memberships have been updated
   // calling leaveRTCSession.
+  // We need to wait because this makes the client hosting this widget killing the IFrame.
   widget.api.transport.send(ElementWidgetActions.HangupCall, {});
 };
 

--- a/src/rtcSessionHelpers.ts
+++ b/src/rtcSessionHelpers.ts
@@ -19,6 +19,7 @@ import { MatrixRTCSession } from "matrix-js-sdk/src/matrixrtc/MatrixRTCSession";
 import { PosthogAnalytics } from "./analytics/PosthogAnalytics";
 import { LivekitFocus } from "./livekit/LivekitFocus";
 import { Config } from "./config/Config";
+import { ElementWidgetActions, WidgetHelpers, widget } from "./widget";
 
 function makeFocus(livekitAlias: string): LivekitFocus {
   const urlFromConf = Config.get().livekit!.livekit_service_url;
@@ -47,9 +48,25 @@ export function enterRTCSession(rtcSession: MatrixRTCSession): void {
   rtcSession.joinRoomSession([makeFocus(livekitAlias)]);
 }
 
+const widgetPostHangupProcedure = async (
+  widget: WidgetHelpers,
+): Promise<void> => {
+  // we need to wait until the callEnded event is tracked on posthog.
+  // Otherwise the iFrame gets killed before the callEnded event got tracked.
+  await new Promise((resolve) => window.setTimeout(resolve, 10)); // 10ms
+  widget.api.setAlwaysOnScreen(false);
+  PosthogAnalytics.instance.logout();
+
+  // we will always send the hangup event after the memberships have been updated
+  // calling leaveRTCSession.
+  widget.api.transport.send(ElementWidgetActions.HangupCall, {});
+};
+
 export async function leaveRTCSession(
   rtcSession: MatrixRTCSession,
 ): Promise<void> {
-  //groupCallOTelMembership?.onLeaveCall();
   await rtcSession.leaveRoomSession();
+  if (widget) {
+    await widgetPostHangupProcedure(widget);
+  }
 }

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -57,7 +57,7 @@ export interface ScreenshareStartData {
   desktopCapturerSourceId: string;
 }
 
-interface WidgetHelpers {
+export interface WidgetHelpers {
   api: WidgetApi;
   lazyActions: LazyEventEmitter;
   client: Promise<MatrixClient>;


### PR DESCRIPTION
This make sure that on Ios and Adroid the we always send the hangup event when the fromWidget Hangup event is sent.

(independent if it is triggered by a toWidget hangup event or pressing the in call hangup button)