### PR TITLE
Close precreated tracks if we never add them

### DIFF
--- a/src/livekit/useECConnectionState.ts
+++ b/src/livekit/useECConnectionState.ts
@@ -87,6 +87,9 @@ async function doConnect(
     logger.warn(
       "Publishing pre-created audio track but participant already appears to have an microphone track: this shouldn't happen!",
     );
+    for (const t of audioTracks) {
+      t.stop();
+    }
     return;
   }
   logger.info("Publishing pre-created mic track");


### PR DESCRIPTION
As the log line says, this should never happen, but if it does we still shouldn't leak tracks.