### PR TITLE
Make E2EEConfig required

### DIFF
--- a/src/room/GroupCallView.tsx
+++ b/src/room/GroupCallView.tsx
@@ -249,11 +249,13 @@ export const GroupCallView: FC<Props> = ({
     }
   }, [isJoined, rtcSession]);
 
-  const e2eeConfig = useMemo((): E2EEConfig | undefined => {
+  const e2eeConfig = useMemo((): E2EEConfig => {
     if (perParticipantE2EE) {
       return { mode: E2eeType.PER_PARTICIPANT };
     } else if (e2eeSharedKey) {
       return { mode: E2eeType.SHARED_KEY, sharedKey: e2eeSharedKey };
+    } else {
+      return { mode: E2eeType.NONE };
     }
   }, [perParticipantE2EE, e2eeSharedKey]);
 

--- a/src/room/InCallView.tsx
+++ b/src/room/InCallView.tsx
@@ -95,7 +95,7 @@ const POST_FOCUS_PARTICIPANT_UPDATE_DELAY_MS = 3000;
 
 export interface ActiveCallProps
   extends Omit<InCallViewProps, "livekitRoom" | "connState"> {
-  e2eeConfig?: E2EEConfig;
+  e2eeConfig: E2EEConfig;
 }
 
 export const ActiveCall: FC<ActiveCallProps> = (props) => {
@@ -109,10 +109,6 @@ export const ActiveCall: FC<ActiveCallProps> = (props) => {
 
   if (!livekitRoom) {
     return null;
-  }
-
-  if (props.e2eeConfig && !livekitRoom.isE2EEEnabled) {
-    livekitRoom.setE2EEEnabled(!!props.e2eeConfig);
   }
 
   return (


### PR DESCRIPTION
Previously it could be either undefined or type None which meant the same thing: no need to have both, just make it required.

This also means we can move the line to set e2ee enabled into a more sensible place rather than in the ActiveCall de-nulling wrapper.