### PR TITLE
Keep screenshares when switching focus

### DIFF
--- a/src/livekit/useECConnectionState.ts
+++ b/src/livekit/useECConnectionState.ts
@@ -177,6 +177,8 @@ export function useECConnectionState(
       }
     }
 
+    // Flag that we're currently switching focus. This will get reset when the
+    // connection state changes back to connected in onConnStateChanged above.
     setSwitchingFocus(true);
     await livekitRoom?.disconnect();
     setIsInDoConnect(true);

--- a/src/room/InCallView.tsx
+++ b/src/room/InCallView.tsx
@@ -200,6 +200,9 @@ export const InCallView: FC<InCallViewProps> = ({
   );
 
   const onLeavePress = useCallback(() => {
+    // Disconnect from the room. We don't do this in onLeave because that's
+    // also called on an unintentional disconnect. Plus we don't have the
+    // livekit room in onLeave anyway.
     livekitRoom.disconnect();
     onLeave();
   }, [livekitRoom, onLeave]);

--- a/src/room/InCallView.tsx
+++ b/src/room/InCallView.tsx
@@ -200,8 +200,9 @@ export const InCallView: FC<InCallViewProps> = ({
   );
 
   const onLeavePress = useCallback(() => {
+    livekitRoom.disconnect();
     onLeave();
-  }, [onLeave]);
+  }, [livekitRoom, onLeave]);
 
   useEffect(() => {
     widget?.api.transport.send(


### PR DESCRIPTION
This also removes the use of the useLivekitRoom hook: we had reached the point where the only thing it was actually doing was disconnecting, so we now do that in the onClick handler for the leave button (I don't think we need to disconnect on unmount?). It was otherwise just getting in the way and causing tracks to be enabled/disabled when we didn't want them to be. This also removes the need for the blockAudio code.

Fixes https://github.com/vector-im/element-call/issues/1413
Based on: https://github.com/vector-im/element-call/pull/1891