### PR TITLE
Mark E2EEenabled flag as deprecated

### DIFF
--- a/docs/url-params.md
+++ b/docs/url-params.md
@@ -112,8 +112,9 @@ Whether to hide the screen-sharing button.
 hideScreensharing: boolean; (default: false)
 ```
 
-**enableE2EE**
-Whether to use end-to-end encryption.
+**enableE2EE** (Deprecated)
+Whether to use end-to-end encryption. This is a legacy flag for the full mesh branch.
+It is not used on the livekit branch and has no impact there!
 
 ```
 enableE2EE: boolean; (default: true)


### PR DESCRIPTION
@dbkr If I understand your comment on the other PR right, this is the correct description for this flag.