### PR TITLE
Hide rooms we don't have the key for in recents list

### DIFF
--- a/src/UrlParams.ts
+++ b/src/UrlParams.ts
@@ -32,7 +32,7 @@ interface RoomIdentifier {
 // the situations that call for this behavior ('isEmbedded'). This makes it
 // clearer what each flag means, and helps us avoid coupling Element Call's
 // behavior to the needs of specific consumers.
-interface UrlParams {
+export interface UrlParams {
   // Widget api related params
   widgetId: string | null;
   parentUrl: string | null;

--- a/src/e2ee/sharedKeyManagement.ts
+++ b/src/e2ee/sharedKeyManagement.ts
@@ -45,9 +45,10 @@ export function getKeyForRoom(roomId: string): string | null {
 function saveKeyFromUrlParams(urlParams: UrlParams): void {
   if (!urlParams.password || !urlParams.roomId) return;
 
-  // We set the Item by only using data from the url. This way we
-  // make sure, we always have matching pairs in the LocalStorage,
-  // as they occur in the call links.
+  // Take the key from the URL and save it.
+  // It's important to always use the room ID specified in the URL
+  // when saving keys rather than whatever the current room ID might be,
+  // in case we've moved to a different room but the URL hasn't changed.
   saveKeyForRoom(urlParams.roomId, urlParams.password);
 }
 

--- a/src/matrix-utils.ts
+++ b/src/matrix-utils.ts
@@ -36,9 +36,8 @@ import IndexedDBWorker from "./IndexedDBWorker?worker";
 import { getUrlParams, PASSWORD_STRING } from "./UrlParams";
 import { loadOlm } from "./olm";
 import { Config } from "./config/Config";
-import { setLocalStorageItem } from "./useLocalStorage";
-import { getRoomSharedKeyLocalStorageKey } from "./e2ee/sharedKeyManagement";
 import { E2eeType } from "./e2ee/e2eeType";
+import { saveKeyForRoom } from "./e2ee/sharedKeyManagement";
 
 export const fallbackICEServerAllowed =
   import.meta.env.VITE_FALLBACK_STUN_ALLOWED === "true";
@@ -359,10 +358,7 @@ export async function createRoom(
   let password;
   if (e2ee == E2eeType.SHARED_KEY) {
     password = secureRandomBase64Url(16);
-    setLocalStorageItem(
-      getRoomSharedKeyLocalStorageKey(result.room_id),
-      password,
-    );
+    saveKeyForRoom(result.room_id, password);
   }
 
   return {


### PR DESCRIPTION
This is an annoyingly large change duplicating a lot of the key management stuff into regular non-hooks functions since we can't call a hook in a loop. Feels like there should be a less terrible way of doing this.