### PR TITLE
Fix joining calls with no media permission

### DIFF
--- a/src/livekit/useLiveKit.ts
+++ b/src/livekit/useLiveKit.ts
@@ -245,11 +245,25 @@ export function useLiveKit(
               );
             }
           } catch (e) {
-            logger.error(
-              "Failed to sync audio mute state with LiveKit (will retry to sync in 1s):",
-              e,
-            );
-            setTimeout(() => syncMuteState(iterCount + 1, type), 1000);
+            if ((e as DOMException).name === "NotAllowedError") {
+              logger.error(
+                "Fatal errror while syncing mute state: resetting",
+                e,
+              );
+              if (type === MuteDevice.Microphone) {
+                audioMuteUpdating.current = false;
+                muteStates.audio.setEnabled?.(false);
+              } else {
+                videoMuteUpdating.current = false;
+                muteStates.video.setEnabled?.(false);
+              }
+            } else {
+              logger.error(
+                "Failed to sync audio mute state with LiveKit (will retry to sync in 1s):",
+                e,
+              );
+              setTimeout(() => syncMuteState(iterCount + 1, type), 1000);
+            }
           }
         }
       };

--- a/src/room/VideoPreview.tsx
+++ b/src/room/VideoPreview.tsx
@@ -82,6 +82,8 @@ export const VideoPreview: FC<Props> = ({
     },
     (error) => {
       logger.error("Error while creating preview Tracks:", error);
+      muteStates.audio.setEnabled?.(false);
+      muteStates.video.setEnabled?.(false);
     },
   );
   const videoTrack = useMemo(


### PR DESCRIPTION
You can still try to unmute your media in the preview screen and the button will show unmuted, but then mute again once you actually join, so not 100% perfect but better.

Fixes https://github.com/vector-im/element-call/issues/1907
Fixes https://github.com/vector-im/element-call/issues/1661