### PR TITLE
Fix not disconnecting from livekit session.

### DIFF
--- a/src/room/InCallView.tsx
+++ b/src/room/InCallView.tsx
@@ -72,7 +72,7 @@ import { OTelGroupCallMembership } from "../otel/OTelGroupCallMembership";
 import { SettingsModal } from "../settings/SettingsModal";
 import { useRageshakeRequestModal } from "../settings/submit-rageshake";
 import { RageshakeRequestModal } from "./RageshakeRequestModal";
-import { E2EEConfig, useLiveKit } from "../livekit/useLiveKit";
+import { E2EEConfig } from "../livekit/useLiveKit";
 import { useFullscreen } from "./useFullscreen";
 import { useLayoutStates } from "../video-grid/Layout";
 import { useWakeLock } from "../useWakeLock";
@@ -85,7 +85,6 @@ import {
   ECAddonConnectionState,
   ECConnectionState,
 } from "../livekit/useECConnectionState";
-import { useOpenIDSFU } from "../livekit/openIDSFU";
 
 const canScreenshare = "getDisplayMedia" in (navigator.mediaDevices ?? {});
 const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
@@ -93,27 +92,22 @@ const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
 // How long we wait after a focus switch before showing the real participant list again
 const POST_FOCUS_PARTICIPANT_UPDATE_DELAY_MS = 3000;
 
-export interface ActiveCallProps
-  extends Omit<InCallViewProps, "livekitRoom" | "connState"> {
+export interface ActiveCallProps extends InCallViewProps {
   e2eeConfig: E2EEConfig;
 }
 
 export const ActiveCall: FC<ActiveCallProps> = (props) => {
-  const sfuConfig = useOpenIDSFU(props.client, props.rtcSession);
-  const { livekitRoom, connState } = useLiveKit(
-    props.rtcSession,
-    props.muteStates,
-    sfuConfig,
-    props.e2eeConfig,
-  );
-
-  if (!livekitRoom) {
+  if (!props.livekitRoom) {
     return null;
   }
 
   return (
-    <RoomContext.Provider value={livekitRoom}>
-      <InCallView {...props} livekitRoom={livekitRoom} connState={connState} />
+    <RoomContext.Provider value={props.livekitRoom}>
+      <InCallView
+        {...props}
+        livekitRoom={props.livekitRoom}
+        connState={props.connState}
+      />
     </RoomContext.Provider>
   );
 };

--- a/src/rtcSessionHelpers.ts
+++ b/src/rtcSessionHelpers.ts
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 import { MatrixRTCSession } from "matrix-js-sdk/src/matrixrtc/MatrixRTCSession";
+import { Room } from "livekit-client";
 
 import { PosthogAnalytics } from "./analytics/PosthogAnalytics";
 import { LivekitFocus } from "./livekit/LivekitFocus";
@@ -68,7 +69,9 @@ const widgetPostHangupProcedure = async (
 
 export async function leaveRTCSession(
   rtcSession: MatrixRTCSession,
+  livekitRoom: Room | undefined,
 ): Promise<void> {
+  await livekitRoom?.disconnect();
   await rtcSession.leaveRoomSession();
   if (widget) {
     await widgetPostHangupProcedure(widget);


### PR DESCRIPTION
This happens if there is an error while
(due to opening the app in another tab)
the call is running. The lk session ends if we reroute to `/` (or quit the widget IFrame)
but we never explicitly disconnect from livekit.

This implementation pulls out the livekit hook from the `ActiveCall` view into the `GroupCallView` to be able to call `livekitRoom.disconnect` in in the corresponding effects.

An alternative would be to move the disconnect effects into the ActiveCall. I think this would be better but before doint the effor I would like to get another opinoin on this.