### PR TITLE
Hotfix for hangup disconnect screen

### DIFF
--- a/src/rtcSessionHelpers.ts
+++ b/src/rtcSessionHelpers.ts
@@ -71,8 +71,8 @@ export async function leaveRTCSession(
   rtcSession: MatrixRTCSession,
   livekitRoom: Room | undefined,
 ): Promise<void> {
-  await livekitRoom?.disconnect();
   await rtcSession.leaveRoomSession();
+  await livekitRoom?.disconnect();
   if (widget) {
     await widgetPostHangupProcedure(widget);
   }


### PR DESCRIPTION
 -  we cannot disconnect livekit before ending the rtcsession.