### PR TITLE
Fix the invite modal overflowing

### DIFF
--- a/src/room/InviteModal.module.css
+++ b/src/room/InviteModal.module.css
@@ -18,6 +18,7 @@ limitations under the License.
   text-align: center;
   color: var(--cpd-color-text-secondary);
   margin-block-end: var(--cpd-space-8x);
+  overflow-wrap: break-word;
 }
 
 .button {


### PR DESCRIPTION
If the URL was the wrong shape, it could cause the modal to overflow, so it needs an extra nudge to line break in the right places.