### PR TITLE
Fix the settings label

### DIFF
--- a/src/UserMenu.tsx
+++ b/src/UserMenu.tsx
@@ -66,7 +66,7 @@ export const UserMenu: FC<Props> = ({
       arr.push({
         key: "settings",
         icon: SettingsIcon,
-        label: "common.settings",
+        label: t("common.settings"),
       });
 
       if (isPasswordlessUser && !preventNavigation) {


### PR DESCRIPTION
We were displaying the raw translation key rather than the translated text.