### PR TITLE
Ignore React Spectrum updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,5 +7,19 @@
       "matchPackagePatterns": ["matrix-js-sdk"],
       "enabled": false
     }
+  ],
+  "ignoreDeps": [
+    "@react-aria/button",
+    "@react-aria/focus",
+    "@react-aria/menu",
+    "@react-aria/overlays",
+    "@react-aria/select",
+    "@react-aria/tabs",
+    "@react-aria/tooltip",
+    "@react-aria/utils",
+    "@react-stately/collections",
+    "@react-stately/select",
+    "@react-stately/tooltip",
+    "@react-stately/tree"
   ]
 }


### PR DESCRIPTION
A couple different people (me and Dave) have tried and failed to find an easy way to upgrade these, and in the future we won't need these dependencies at all once the switch to Compound Web is finished, so let's not generate Renovate PRs for them.