### PR TITLE
Don't confuse screen share tiles with user media

### DIFF
--- a/src/state/CallViewModel.ts
+++ b/src/state/CallViewModel.ts
@@ -216,8 +216,8 @@ export class CallViewModel extends ViewModel {
               largeBaseSize: true,
               placeNear: id,
               data:
-                tilesById.get(id)?.data ??
-                new ScreenShareTileViewModel(id, member, p),
+                tilesById.get(screenShareId)?.data ??
+                new ScreenShareTileViewModel(screenShareId, member, p),
             };
             return [userMediaTile, screenShareTile];
           } else {


### PR DESCRIPTION
A regression due to https://github.com/vector-im/element-call/pull/1961 was causing screen share tiles to show up as if they were another copy of the associated user media tile. It turns out this was a simple matter of confused IDs.