### PR TITLE
Remove the gappy sync hack

### DIFF
--- a/src/matrix-utils.ts
+++ b/src/matrix-utils.ts
@@ -188,16 +188,8 @@ export async function initClient(
     await client.store.startup();
   }
 
-  if (client.initCrypto) {
-    await client.initCrypto();
-  }
-
-  await client.startClient({
-    // dirty hack to reduce chance of gappy syncs
-    // should be fixed by spotting gaps and backpaginating
-    initialSyncLimit: 50,
-  });
-
+  await client.initCrypto();
+  await client.startClient();
   await waitForSync(client);
 
   return client;


### PR DESCRIPTION
This hack was added in the early days of Element Call, back when we were doing call signaling using non-state room events, and missing part of a room's history could cause calls to fall apart. Nowadays we use state events for signaling, and all this hack is doing is making sync times unnecessarily long, so we can remove it.