### PR TITLE
Add crop to fit toggle to context menu

### DIFF
--- a/public/locales/en-GB/app.json
+++ b/public/locales/en-GB/app.json
@@ -143,6 +143,7 @@
   "unmute_microphone_button_label": "Unmute microphone",
   "version": "Version: {{version}}",
   "video_tile": {
+    "change_fit_contain": "Crop to fit",
     "exit_full_screen": "Exit full screen",
     "full_screen": "Full screen",
     "mute_for_me": "Mute for me",

--- a/src/state/TileViewModel.ts
+++ b/src/state/TileViewModel.ts
@@ -167,6 +167,12 @@ export class UserMediaTileViewModel extends BaseTileViewModel {
    */
   public readonly videoEnabled: StateObservable<boolean>;
 
+  private readonly _cropVideo = new BehaviorSubject(true);
+  /**
+   * Whether the tile video should be contained inside the tile or be cropped to fit.
+   */
+  public readonly cropVideo = state(this._cropVideo);
+
   public constructor(
     id: string,
     member: RoomMember | undefined,
@@ -203,6 +209,10 @@ export class UserMediaTileViewModel extends BaseTileViewModel {
 
   public toggleLocallyMuted(): void {
     this._locallyMuted.next(!this._locallyMuted.value);
+  }
+
+  public toggleFitContain(): void {
+    this._cropVideo.next(!this._cropVideo.value);
   }
 
   public setLocalVolume(value: number): void {

--- a/src/video-grid/VideoTile.module.css
+++ b/src/video-grid/VideoTile.module.css
@@ -73,7 +73,7 @@ borders don't support gradients */
 .videoTile video {
   inline-size: 100%;
   block-size: 100%;
-  object-fit: cover;
+  object-fit: contain;
   background-color: var(--cpd-color-bg-subtle-primary);
   /* This transform is a no-op, but it forces Firefox to use a different
   rendering path, one that actually clips the corners of <video> elements into
@@ -87,6 +87,10 @@ borders don't support gradients */
 
 .videoTile.screenshare video {
   object-fit: contain;
+}
+
+.videoTile.cropVideo video {
+  object-fit: cover;
 }
 
 .videoTile.videoMuted video {

--- a/src/video-grid/VideoTile.tsx
+++ b/src/video-grid/VideoTile.tsx
@@ -213,9 +213,16 @@ const UserMediaTile = subscribe<UserMediaTileProps, HTMLDivElement>(
     const mirror = useStateObservable(vm.mirror);
     const speaking = useStateObservable(vm.speaking);
     const locallyMuted = useStateObservable(vm.locallyMuted);
+    const cropVideo = useStateObservable(vm.cropVideo);
     const localVolume = useStateObservable(vm.localVolume);
     const onChangeMute = useCallback(() => vm.toggleLocallyMuted(), [vm]);
+    const onChangeFitContain = useCallback(() => vm.toggleFitContain(), [vm]);
     const onSelectMute = useCallback((e: Event) => e.preventDefault(), []);
+    const onSelectFitContain = useCallback(
+      (e: Event) => e.preventDefault(),
+      [],
+    );
+
     const onChangeLocalVolume = useCallback(
       (v: number) => vm.setLocalVolume(v),
       [vm],
@@ -232,6 +239,13 @@ const UserMediaTile = subscribe<UserMediaTileProps, HTMLDivElement>(
           label={t("common.profile")}
           onSelect={onOpenProfile}
         />
+        <ToggleMenuItem
+          Icon={ExpandIcon}
+          label={t("video_tile.change_fit_contain")}
+          checked={cropVideo}
+          onChange={onChangeFitContain}
+          onSelect={onSelectFitContain}
+        />
       </>
     ) : (
       <>
@@ -241,6 +255,13 @@ const UserMediaTile = subscribe<UserMediaTileProps, HTMLDivElement>(
           checked={locallyMuted}
           onChange={onChangeMute}
           onSelect={onSelectMute}
+        />
+        <ToggleMenuItem
+          Icon={ExpandIcon}
+          label={t("video_tile.change_fit_contain")}
+          checked={cropVideo}
+          onChange={onChangeFitContain}
+          onSelect={onSelectFitContain}
         />
         {/* TODO: Figure out how to make this slider keyboard accessible */}
         <MenuItem as="div" Icon={VolumeIcon} label={null} onSelect={null}>
@@ -264,6 +285,7 @@ const UserMediaTile = subscribe<UserMediaTileProps, HTMLDivElement>(
         className={classNames(className, {
           [styles.mirror]: mirror,
           [styles.speaking]: showSpeakingIndicator && speaking,
+          [styles.cropVideo]: cropVideo,
         })}
         style={style}
         targetWidth={targetWidth}


### PR DESCRIPTION
This adds a toggle to the context menu so we can switch between cropped (`object-fit: cover`) and the uncropped full video (`object-fit: contain`).

It defaults to `Crop to fit: true` (as it did before) Without using the context menu it should behave the same as before.
Fixes: https://github.com/element-hq/element-call/issues/664

<img width="200" alt="Screenshot 2024-01-26 at 04 27 08" src="https://github.com/element-hq/element-call/assets/16718859/3a00c9f1-496e-4260-8c4c-0c61bef8df6f">
<img width="200" alt="Screenshot 2024-01-26 at 04 27 22" src="https://github.com/element-hq/element-call/assets/16718859/6ef650c0-db1c-49a8-b3cf-db3dd84d8f33">
<img width="200" alt="Screenshot 2024-01-26 at 04 27 34" src="https://github.com/element-hq/element-call/assets/16718859/3597d190-07b8-4ee6-b418-66adf060337b">

Signed-off-by: Timo K <toger5@hotmail.de>