### PR TITLE
Remove the disablePictureInPicture Firefox hack

### DIFF
--- a/src/room/VideoPreview.tsx
+++ b/src/room/VideoPreview.tsx
@@ -114,14 +114,7 @@ export const VideoPreview: FC<Props> = ({
         playsInline
         // There's no reason for this to be focusable
         tabIndex={-1}
-        // React supports the disablePictureInPicture attribute, but Firefox
-        // only recognizes a value of "true", whereas React sets it to the empty
-        // string. So we need to bypass React and set it specifically to "true".
-        // https://bugzilla.mozilla.org/show_bug.cgi?id=1865748
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        // eslint-disable-next-line react/no-unknown-property
-        disablepictureinpicture="true"
+        disablePictureInPicture
       />
       {!muteStates.video.enabled && (
         <div className={styles.avatarContainer}>

--- a/src/video-grid/VideoTile.tsx
+++ b/src/video-grid/VideoTile.tsx
@@ -134,14 +134,7 @@ const Tile = forwardRef<HTMLDivElement, TileProps>(
               trackRef={video}
               // There's no reason for this to be focusable
               tabIndex={-1}
-              // React supports the disablePictureInPicture attribute, but Firefox
-              // only recognizes a value of "true", whereas React sets it to the empty
-              // string. So we need to bypass React and set it specifically to "true".
-              // https://bugzilla.mozilla.org/show_bug.cgi?id=1865748
-              // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-              // @ts-ignore
-              // eslint-disable-next-line react/no-unknown-property
-              disablepictureinpicture="true"
+              disablePictureInPicture
             />
           )}
         </div>


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1865748 is fixed in Firefox 122.0, so we can now use the attribute the normal way.