### PR TITLE
Add customHomeserver url Param

### DIFF
--- a/docs/url-params.md
+++ b/docs/url-params.md
@@ -210,12 +210,12 @@ that is in use for the current user.
 viaServers: string; (default: undefined)
 ```
 
-**customHomeserver**
+**homeserver**
 This defines the homeserver that is going to be used when registering
 a new (guest) user.
 This can be user to configure a non default guest user server when
 creating a spa link.
 
 ```
-customHomeserver: string; (default: undefined)
+homeserver: string; (default: undefined)
 ```

--- a/docs/url-params.md
+++ b/docs/url-params.md
@@ -199,3 +199,23 @@ If set to false, the widget will show a blank page after leaving the call.
 ```
 returnToLobby: boolean; (default: false)
 ```
+
+**viaServers**
+This defines the homeserver that is going to be used when joining a room.
+It has to be set to a non default value for links to rooms
+that are not on the default homeserver,
+that is in use for the current user.
+
+```
+viaServers: string; (default: undefined)
+```
+
+**customHomeserver**
+This defines the homeserver that is going to be used when registering
+a new (guest) user.
+This can be user to configure a non default guest user server when
+creating a spa link.
+
+```
+customHomeserver: string; (default: undefined)
+```

--- a/src/UrlParams.ts
+++ b/src/UrlParams.ts
@@ -143,7 +143,7 @@ export interface UrlParams {
    * This can be user to configure a non default guest user server when
    * creating a spa link.
    */
-  customHomeserver: string | null;
+  homeserver: string | null;
 }
 
 // This is here as a stopgap, but what would be far nicer is a function that
@@ -244,7 +244,7 @@ export const getUrlParams = (
     skipLobby: parser.getFlagParam("skipLobby"),
     returnToLobby: parser.getFlagParam("returnToLobby"),
     viaServers: parser.getParam("viaServers"),
-    customHomeserver: parser.getParam("customHomeserver"),
+    homeserver: parser.getParam("homeserver"),
   };
 };
 

--- a/src/UrlParams.ts
+++ b/src/UrlParams.ts
@@ -130,6 +130,20 @@ export interface UrlParams {
    * This is useful for video rooms.
    */
   returnToLobby: boolean;
+  /**
+   * This defines the homeserver that is going to be used when joining a room.
+   * It has to be set to a non default value for links to rooms
+   * that are not on the default homeserver,
+   * that is in use for the current user.
+   */
+  viaServers: string | null;
+  /**
+   * This defines the homeserver that is going to be used when registering
+   * a new (guest) user.
+   * This can be user to configure a non default guest user server when
+   * creating a spa link.
+   */
+  customHomeserver: string | null;
 }
 
 // This is here as a stopgap, but what would be far nicer is a function that
@@ -229,6 +243,8 @@ export const getUrlParams = (
     perParticipantE2EE: parser.getFlagParam("perParticipantE2EE"),
     skipLobby: parser.getFlagParam("skipLobby"),
     returnToLobby: parser.getFlagParam("returnToLobby"),
+    viaServers: parser.getParam("viaServers"),
+    customHomeserver: parser.getParam("customHomeserver"),
   };
 };
 

--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import { getUrlParams } from "../UrlParams";
 import {
   DEFAULT_CONFIG,
   ConfigOptions,
@@ -45,10 +46,18 @@ export class Config {
 
   // Convenience accessors
   public static defaultHomeserverUrl(): string | undefined {
-    return Config.get().default_server_config?.["m.homeserver"].base_url;
+    return (
+      getUrlParams().customHomeserver ??
+      Config.get().default_server_config?.["m.homeserver"].base_url
+    );
   }
 
   public static defaultServerName(): string | undefined {
+    const customHomeserver = getUrlParams().customHomeserver;
+    if (customHomeserver) {
+      const url = new URL(customHomeserver);
+      return url.hostname;
+    }
     return Config.get().default_server_config?.["m.homeserver"].server_name;
   }
 

--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -47,15 +47,15 @@ export class Config {
   // Convenience accessors
   public static defaultHomeserverUrl(): string | undefined {
     return (
-      getUrlParams().customHomeserver ??
+      getUrlParams().homeserver ??
       Config.get().default_server_config?.["m.homeserver"].base_url
     );
   }
 
   public static defaultServerName(): string | undefined {
-    const customHomeserver = getUrlParams().customHomeserver;
-    if (customHomeserver) {
-      const url = new URL(customHomeserver);
+    const homeserver = getUrlParams().homeserver;
+    if (homeserver) {
+      const url = new URL(homeserver);
       return url.hostname;
     }
     return Config.get().default_server_config?.["m.homeserver"].server_name;


### PR DESCRIPTION
This is an additional url param that allows to overwrite the homeserberUrl configured in EC.
This is usefult if a clinet that wants to create a call link wants users to end up on a specific homeserver.