### PR TITLE
Tell Renovate that we don't use semantic commits

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,7 @@
       "enabled": false
     }
   ],
+  "semanticCommits": "disabled",
   "ignoreDeps": [
     "@react-aria/button",
     "@react-aria/focus",


### PR DESCRIPTION
Because the author of the vitest PR used the semantic commit naming convention, Renovate now thinks our entire repo uses semantic commits and has renamed all of its PRs.