### PR TITLE
Tell Renovate to ignore @react-types/dialog

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,6 +21,7 @@
     "@react-stately/collections",
     "@react-stately/select",
     "@react-stately/tooltip",
-    "@react-stately/tree"
+    "@react-stately/tree",
+    "@react-types/dialog"
   ]
 }


### PR DESCRIPTION
It's part of React Spectrum, which we're trying to avoid updating at this time because we're phasing out usage of the libraries and upgrading them is painful.