### PR TITLE
Theme loading without flickering

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "i18next-http-backend": "^2.0.0",
     "livekit-client": "^2.0.2",
     "lodash": "^4.17.21",
-    "matrix-js-sdk": "github:matrix-org/matrix-js-sdk#8123e9a3f1142a7619758c0a238172b007e3a06a",
+    "matrix-js-sdk": "github:matrix-org/matrix-js-sdk#d55c6a36df539f6adacc335efe5b9be27c9cee4a",
     "matrix-widget-api": "^1.3.1",
     "normalize.css": "^8.0.1",
     "pako": "^2.0.4",

--- a/public/index.html
+++ b/public/index.html
@@ -13,7 +13,8 @@
     </script>
   </head>
 
-  <body class="nodisplay">
+  <!-- The default class is: .no-theme {display: none}. It will be overwritten once the app is loaded. -->
+  <body class="no-theme">
     <div id="root"></div>
   </body>
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -13,7 +13,7 @@
     </script>
   </head>
 
-  <body class="cpd-theme-dark">
+  <body class="nodisplay">
     <div id="root"></div>
   </body>
 </html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -72,7 +72,9 @@ export const App: FC<AppProps> = ({ history }) => {
   const [loaded, setLoaded] = useState(false);
   useEffect(() => {
     Initializer.init()?.then(() => {
+      if (loaded) return;
       setLoaded(true);
+      widget?.api.sendContentLoaded();
     });
   });
 

--- a/src/FullScreenView.tsx
+++ b/src/FullScreenView.tsx
@@ -27,6 +27,7 @@ import styles from "./FullScreenView.module.css";
 import { TranslatedError } from "./TranslatedError";
 import { Config } from "./config/Config";
 import { RageshakeButton } from "./settings/RageshakeButton";
+import { useUrlParams } from "./UrlParams";
 
 interface FullScreenViewProps {
   className?: string;
@@ -37,12 +38,11 @@ export const FullScreenView: FC<FullScreenViewProps> = ({
   className,
   children,
 }) => {
+  const { hideHeader } = useUrlParams();
   return (
     <div className={classNames(styles.page, className)}>
       <Header>
-        <LeftNav>
-          <HeaderLogo />
-        </LeftNav>
+        <LeftNav>{!hideHeader && <HeaderLogo />}</LeftNav>
         <RightNav />
       </Header>
       <div className={styles.container}>

--- a/src/auth/useInteractiveRegistration.ts
+++ b/src/auth/useInteractiveRegistration.ts
@@ -50,6 +50,7 @@ export const useInteractiveRegistration = (): {
 
   useEffect(() => {
     if (widget) return;
+    // An empty registerRequest is used to get the privacy policy and recaptcha key.
     authClient.current!.registerRequest({}).catch((error) => {
       setPrivacyPolicyUrl(
         error.data?.params["m.login.terms"]?.policies?.privacy_policy?.en?.url,

--- a/src/index.css
+++ b/src/index.css
@@ -158,7 +158,7 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 /* We use this to not render the page at all until we know the theme.*/
-.nodisplay {
+.no-theme {
   opacity: 0;
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -157,6 +157,10 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
+/* We use this to not render the page at all until we know the theme.*/
+.nodisplay {
+  opacity: 0;
+}
 
 html,
 body,

--- a/src/useTheme.ts
+++ b/src/useTheme.ts
@@ -17,11 +17,9 @@ limitations under the License.
 import { useLayoutEffect, useRef } from "react";
 
 import { useUrlParams } from "./UrlParams";
-import { widget } from "./widget";
 
 export const useTheme = (): void => {
   const { theme: themeName } = useUrlParams();
-  const contentLoadedSent = useRef<boolean>(false);
   const previousTheme = useRef<string | null>(document.body.classList.item(0));
   useLayoutEffect(() => {
     // If the url does not contain a theme props we default to "dark".
@@ -39,9 +37,5 @@ export const useTheme = (): void => {
       previousTheme.current = themeString;
     }
     document.body.classList.remove("nodisplay");
-    if (!contentLoadedSent.current) {
-      widget?.api.sendContentLoaded();
-      contentLoadedSent.current = true;
-    }
   }, [previousTheme, themeName]);
 };

--- a/src/useTheme.ts
+++ b/src/useTheme.ts
@@ -36,6 +36,6 @@ export const useTheme = (): void => {
       document.body.classList.add(themeString);
       previousTheme.current = themeString;
     }
-    document.body.classList.remove("nodisplay");
+    document.body.classList.remove("no-theme");
   }, [previousTheme, themeName]);
 };

--- a/src/useTheme.ts
+++ b/src/useTheme.ts
@@ -21,6 +21,7 @@ import { widget } from "./widget";
 
 export const useTheme = (): void => {
   const { theme: themeName } = useUrlParams();
+  const contentLoadedSent = useRef<boolean>(false);
   const previousTheme = useRef<string | null>(document.body.classList.item(0));
   useLayoutEffect(() => {
     // If the url does not contain a theme props we default to "dark".
@@ -38,5 +39,9 @@ export const useTheme = (): void => {
       previousTheme.current = themeString;
     }
     document.body.classList.remove("nodisplay");
+    if (!contentLoadedSent.current) {
+      widget?.api.sendContentLoaded();
+      contentLoadedSent.current = true;
+    }
   }, [previousTheme, themeName]);
 };

--- a/src/useTheme.ts
+++ b/src/useTheme.ts
@@ -17,15 +17,15 @@ limitations under the License.
 import { useLayoutEffect, useRef } from "react";
 
 import { useUrlParams } from "./UrlParams";
+import { widget } from "./widget";
 
 export const useTheme = (): void => {
   const { theme: themeName } = useUrlParams();
   const previousTheme = useRef<string | null>(document.body.classList.item(0));
   useLayoutEffect(() => {
-    // Don't update the current theme if the url does not contain a theme prop.
-    if (!themeName) return;
-    const theme = themeName.includes("light") ? "light" : "dark";
-    const themeHighContrast = themeName.includes("high-contrast") ? "-hc" : "";
+    // If the url does not contain a theme props we default to "dark".
+    const theme = themeName?.includes("light") ? "light" : "dark";
+    const themeHighContrast = themeName?.includes("high-contrast") ? "-hc" : "";
     const themeString = "cpd-theme-" + theme + themeHighContrast;
     if (themeString !== previousTheme.current) {
       document.body.classList.remove(
@@ -37,5 +37,6 @@ export const useTheme = (): void => {
       document.body.classList.add(themeString);
       previousTheme.current = themeString;
     }
+    document.body.classList.remove("nodisplay");
   }, [previousTheme, themeName]);
 };

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -158,6 +158,8 @@ export const widget = ((): WidgetHelpers | null => {
           useE2eForGroupCall: e2eEnabled,
           fallbackICEServerAllowed: allowIceFallback,
         },
+        // ContentLoaded event will be sent as soon as the theme is set (see useTheme.ts)
+        false,
       );
 
       const clientPromise = new Promise<MatrixClient>((resolve) => {


### PR DESCRIPTION
The theme did flicker because there is a default theme shown before any JS is loaded.
When the layoutEffect from the useTheme hook is reached the theme gets updated -> If its a different theme ("light", "dark") one can see a very short flicker.

This is particularly annoying in widget mode.

To work around this we only send the contentLoaded action once the theme is set.
This relies on the js sdk not sending this action automatically AND the react sdk needs to be configured with waitForIframe=false, so that it does not consider the widget to be ready once the IFrame is loaded. 
Until the content_loadedaction is sent (which now is equivalent to: until EC is loaded), we will not show the widget. Instead the EW loading screen is shown.
This also saves us from the flickering: EW widget loading screen -> EC normal screen with header -> EC loading screen -> EC lobby.

This relies on:
Js-sdk PR that allows to disable sending the content loaded action right after the client is initialized but before the first react update (default behaviour of the js sdk):
https://github.com/matrix-org/matrix-js-sdk/pull/4086

EW PR that sets waitForIframe=false and shows the widget loading screen until the receiving the content_loaded action:
https://github.com/matrix-org/matrix-react-sdk/pull/12292
Signed-off-by: Timo K <toger5@hotmail.de>

The type failiours will be fixed once https://github.com/matrix-org/matrix-js-sdk/pull/4086 is merged.