### PR TITLE
Drop unsupported field from backend/livekit.yaml

### DIFF
--- a/backend/livekit.yaml
+++ b/backend/livekit.yaml
@@ -22,5 +22,3 @@ turn:
   external_tls: true
 keys:
   devkey: secret
-signal_relay:
-  enabled: true


### PR DESCRIPTION
`signal_relay.enabled` was removed in v1.5.3: livekit/livekit@3f2f850