### PR TITLE
Fix participants disappearing during focus switch (probably)

### DIFF
--- a/src/state/useObservable.ts
+++ b/src/state/useObservable.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 New Vector Ltd
+Copyright 2023-2024 New Vector Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,18 +14,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { useEffect, useRef } from "react";
+import { useRef } from "react";
 import { BehaviorSubject, Observable } from "rxjs";
 
 /**
  * React hook that creates an Observable from a changing value. The Observable
- * replays its current value upon subscription, emits whenever the value
- * changes, and completes when the component is unmounted.
+ * replays its current value upon subscription and emits whenever the value
+ * changes.
  */
 export function useObservable<T>(value: T): Observable<T> {
   const subject = useRef<BehaviorSubject<T>>();
   subject.current ??= new BehaviorSubject(value);
   if (value !== subject.current.value) subject.current.next(value);
-  useEffect(() => subject.current!.complete(), []);
   return subject.current;
 }


### PR DESCRIPTION
I discovered that this hook was calling `complete` on the returned observable almost immediately when it gets mounted. This caused the call view model to never know when the application was switching focuses. At first I thought this was just because I forgot to move the call to `complete` to the effect's clean-up function, but even with that changed, React still calls the effect twice in strict mode. So, let's just remove the call entirely.