### PR TITLE
Experiment with different timeouts

### DIFF
--- a/src/livekit/useECConnectionState.ts
+++ b/src/livekit/useECConnectionState.ts
@@ -28,6 +28,13 @@ import * as Sentry from "@sentry/react";
 
 import { SFUConfig, sfuConfigEquals } from "./openIDSFU";
 
+declare global {
+  interface Window {
+    peerConnectionTimeout?: number;
+    websocketTimeout?: number;
+  }
+}
+
 /*
  * Additional values for states that a call can be in, beyond what livekit
  * provides in ConnectionState. Also reconnects the call if the SFU Config
@@ -124,7 +131,12 @@ async function connectAndPublish(
   micTrack: LocalTrack | undefined,
   screenshareTracks: MediaStreamTrack[],
 ): Promise<void> {
-  await livekitRoom!.connect(sfuConfig!.url, sfuConfig!.jwt);
+  await livekitRoom!.connect(sfuConfig!.url, sfuConfig!.jwt, {
+    // Due to stability issues on Firefox we are testing the effect of different
+    // timeouts, and allow these values to be set through the console
+    peerConnectionTimeout: window.peerConnectionTimeout ?? 45000,
+    websocketTimeout: window.websocketTimeout ?? 45000,
+  });
 
   if (micTrack) {
     logger.info(`Publishing precreated mic track`);


### PR DESCRIPTION
This lets you set the global variables `peerConnectionTimeout` and `websocketTimeout` to see what LiveKit does with different values.