### PR TITLE
Limit homserver to not cover the whole loginview input with the string.

### DIFF
--- a/src/auth/LoginPage.tsx
+++ b/src/auth/LoginPage.tsx
@@ -82,7 +82,12 @@ export const LoginPage: FC = () => {
     },
     [login, location, history, homeserver, setClient],
   );
-
+  // we need to limit the length of the homserver name to not cover the whole loginview input with the string.
+  let shortendHomeserverName = Config.defaultServerName()?.slice(0, 25);
+  shortendHomeserverName =
+    shortendHomeserverName?.length !== Config.defaultServerName()?.length
+      ? shortendHomeserverName + "..."
+      : shortendHomeserverName;
   return (
     <>
       <div className={styles.container}>
@@ -102,7 +107,7 @@ export const LoginPage: FC = () => {
                   autoCorrect="off"
                   autoCapitalize="none"
                   prefix="@"
-                  suffix={`:${Config.defaultServerName()}`}
+                  suffix={`:${shortendHomeserverName}`}
                   data-testid="login_username"
                 />
               </FieldRow>


### PR DESCRIPTION
![Screenshot from 2024-04-11 10-44-07](https://github.com/element-hq/element-call/assets/16718859/25e0b9d2-c8a4-41cc-b2ad-668391e0a7f7)
![Screenshot from 2024-04-11 10-44-17](https://github.com/element-hq/element-call/assets/16718859/a3db0398-caf7-46af-a8b4-332683f174f0)
