### PR TITLE
Drop unsupported field from backend/livekit.yaml

### DIFF
--- a/backend/livekit.yaml
+++ b/backend/livekit.yaml
@@ -1,5 +1,4 @@
 port: 7880
-environment: dev
 bind_addresses:
   - "0.0.0.0"
 rtc:


### PR DESCRIPTION
`environment` was removed in v1.6.0: livekit/livekit@10c8582