### PR TITLE
Fix device enabled/disabled flickering in lobby

### DIFF
--- a/src/room/VideoPreview.tsx
+++ b/src/room/VideoPreview.tsx
@@ -68,8 +68,8 @@ export const VideoPreview: FC<Props> = ({
     deviceId: devices.audioInput.selectedId,
   };
 
-  const tracks = usePreviewTracks(
-    {
+  const deviceConfig = useMemo(() => {
+    return {
       // The only reason we request audio here is to get the audio permission
       // request over with at the same time. But changing the audio settings
       // shouldn't cause this hook to recreate the track, which is why we
@@ -80,13 +80,15 @@ export const VideoPreview: FC<Props> = ({
       video: muteStates.video.enabled && {
         deviceId: devices.videoInput.selectedId,
       },
-    },
-    (error) => {
-      logger.error("Error while creating preview Tracks:", error);
-      muteStates.audio.setEnabled?.(false);
-      muteStates.video.setEnabled?.(false);
-    },
-  );
+    };
+  }, [devices.videoInput.selectedId, muteStates.video.enabled]);
+
+  const tracks = usePreviewTracks(deviceConfig, (error) => {
+    logger.error("Error while creating preview Tracks:", error);
+    muteStates.audio.setEnabled?.(false);
+    muteStates.video.setEnabled?.(false);
+  });
+
   const videoTrack = useMemo(
     () =>
       tracks?.find((t) => t.kind === Track.Kind.Video) as


### PR DESCRIPTION
Fixes: https://github.com/element-hq/voip-internal/issues/248

Use `useMemo` to not change the parameters that are used to call usePreviewDevice.
