### PR TITLE
Remove unsupported LiveKit config option

### DIFF
--- a/backend/livekit.yaml
+++ b/backend/livekit.yaml
@@ -1,5 +1,4 @@
 port: 7880
-environment: dev
 bind_addresses:
   - "0.0.0.0"
 rtc:


### PR DESCRIPTION
This config option is no longer supported by LiveKit (https://github.com/livekit/livekit/commit/10c8582a6b01c37fb2db7e343b5204c713fbb7cd) and will crash the server if specified.