### PR TITLE
Don't auto-join knock room on invite after leave

### DIFF
--- a/src/room/useLoadGroupCall.ts
+++ b/src/room/useLoadGroupCall.ts
@@ -168,7 +168,10 @@ export const useLoadGroupCall = (
           async (room, membership, prevMembership) => {
             if (roomId !== room.roomId) return;
             activeRoom.current = room;
-            if (membership === KnownMembership.Invite) {
+            if (
+              membership === KnownMembership.Invite &&
+              prevMembership === KnownMembership.Knock
+            ) {
               await client.joinRoom(room.roomId, { viaServers });
               joinedRoom = room;
               logger.log("Auto-joined %s", room.roomId);


### PR DESCRIPTION
If you send a knock that is rejected, or your knock is accepted and you are later removed from the room, do not automatically accept subsequent invites to that room.

Note that the auto-join behaviour happened only if the page was not refreshed after sending a knock.