### PR TITLE
package.json add name field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "element-call",
   "version": "0.0.0",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
I noticed, that the `package.json` is missing the name field. It is usually required and breaks some tools if it's missing.

For example I was packaging this for nixpkgs https://github.com/NixOS/nixpkgs/pull/300966, and had to patch it.

It would be great, if this would be upstreamed.