### PR TITLE
Remove `EventType.GroupCallPrefix` from widget capabilities

### DIFF
--- a/src/widget.ts
+++ b/src/widget.ts
@@ -123,7 +123,6 @@ export const widget = ((): WidgetHelpers | null => {
       const receiveState = [
         { eventType: EventType.RoomMember },
         { eventType: EventType.RoomEncryption },
-        { eventType: EventType.GroupCallPrefix },
         { eventType: EventType.GroupCallMemberPrefix },
       ];
       const sendRecvToDevice = [


### PR DESCRIPTION
Its not used anymore.