### PR TITLE
Reduce noise coming from Renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,9 +3,36 @@
   "extends": ["config:base"],
   "packageRules": [
     {
-      "description": "Disable renoavte for packages we want to monitor ourselves",
-      "matchPackagePatterns": ["matrix-js-sdk"],
+      "extends": ["group:allNonMajor", "schedule:weekly"]
+    },
+    {
+      "description": "Disable Renovate for packages we want to monitor ourselves",
+      "groupName": "manually updated packages",
+      "matchPackageNames": ["matrix-js-sdk"],
       "enabled": false
+    },
+    {
+      "groupName": "matrix-widget-api",
+      "matchPackageNames": ["matrix-widget-api"]
+    },
+    {
+      "groupName": "Compound",
+      "matchPackagePrefixes": ["@vector-im/compound-"],
+      "schedule": "before 5am on Tuesday and Friday"
+    },
+    {
+      "groupName": "LiveKit client",
+      "matchPackageNames": ["livekit-client"]
+    },
+    {
+      "groupName": "LiveKit components",
+      "matchPackagePrefixes": ["@livekit/components-"]
+    },
+    {
+      "groupName": "Vaul",
+      "matchPackageNames": ["vaul"],
+      "extends": ["schedule:monthly"],
+      "prHeader": "Please review modals on mobile for visual regressions."
     }
   ],
   "semanticCommits": "disabled",


### PR DESCRIPTION
What I've tried to do here is to group most dependency updates together and put them on a weekly schedule. Some of our more sensitive dependencies such as LiveKit and Compound have been put into separate groups, so we still receive frequent updates for them.

Closes https://github.com/element-hq/element-call/issues/2440