### PR TITLE
Refine Renovate config further

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,14 +6,20 @@
       "extends": ["group:allNonMajor", "schedule:weekly"]
     },
     {
+      "groupName": "GitHub Actions",
+      "matchDepTypes": ["action"],
+      "pinDigests": true,
+      "extends": ["schedule:monthly"]
+    },
+    {
       "description": "Disable Renovate for packages we want to monitor ourselves",
       "groupName": "manually updated packages",
-      "matchPackageNames": ["matrix-js-sdk"],
+      "matchDepNames": ["matrix-js-sdk"],
       "enabled": false
     },
     {
       "groupName": "matrix-widget-api",
-      "matchPackageNames": ["matrix-widget-api"]
+      "matchDepNames": ["matrix-widget-api"]
     },
     {
       "groupName": "Compound",
@@ -22,7 +28,7 @@
     },
     {
       "groupName": "LiveKit client",
-      "matchPackageNames": ["livekit-client"]
+      "matchDepNames": ["livekit-client"]
     },
     {
       "groupName": "LiveKit components",
@@ -30,7 +36,7 @@
     },
     {
       "groupName": "Vaul",
-      "matchPackageNames": ["vaul"],
+      "matchDepNames": ["vaul"],
       "extends": ["schedule:monthly"],
       "prHeader": "Please review modals on mobile for visual regressions."
     }


### PR DESCRIPTION
By getting it to pin GitHub Actions to specific commits, which hardens our workflows, and fixing a warning about `matchPackageNames`