### PR TITLE
Make widgets request the room creation event

### DIFF
--- a/src/widget.ts
+++ b/src/widget.ts
@@ -125,6 +125,7 @@ export const widget = ((): WidgetHelpers | null => {
         },
       ];
       const receiveState = [
+        { eventType: EventType.RoomCreate },
         { eventType: EventType.RoomMember },
         { eventType: EventType.RoomEncryption },
         { eventType: EventType.GroupCallMemberPrefix },


### PR DESCRIPTION
This allows the widget to check the room version, so it can know about version-specific auth rules (namely MSC3779).