### PR TITLE
Add config to send session membership state events

### DIFF
--- a/src/config/ConfigOptions.ts
+++ b/src/config/ConfigOptions.ts
@@ -74,8 +74,9 @@ export interface ConfigOptions {
     feature_group_calls_without_video_and_audio?: boolean;
     /**
      * Send device-specific call session membership state events
-     * instead of the legacy user-specific call membership state events,
-     * but not in rooms that contain active calls with legacy state events.
+     * instead of the legacy user-specific call membership state events.
+     * This setting has not effect when the user joins an active call with legacy state events.
+     * For compatibility Element Call will always join running legacy calls with legacy state events.```
      */
     feature_use_device_session_member_events?: boolean;
   };

--- a/src/config/ConfigOptions.ts
+++ b/src/config/ConfigOptions.ts
@@ -65,11 +65,19 @@ export interface ConfigOptions {
   };
 
   /**
-   * Allow to join a group calls without audio and video.
-   * TEMPORARY: Is a feature that's not proved and experimental
+   * TEMPORARY experimental features.
    */
   features?: {
-    feature_group_calls_without_video_and_audio: boolean;
+    /**
+     * Allow to join group calls without audio and video.
+     */
+    feature_group_calls_without_video_and_audio?: boolean;
+    /**
+     * Send device-specific call session membership state events
+     * instead of the legacy user-specific call membership state events,
+     * but not in rooms that contain active calls with legacy state events.
+     */
+    feature_use_device_session_member_events?: boolean;
   };
 
   /**

--- a/src/config/ConfigOptions.ts
+++ b/src/config/ConfigOptions.ts
@@ -73,10 +73,11 @@ export interface ConfigOptions {
      */
     feature_group_calls_without_video_and_audio?: boolean;
     /**
-     * Send device-specific call session membership state events
-     * instead of the legacy user-specific call membership state events.
-     * This setting has not effect when the user joins an active call with legacy state events.
-     * For compatibility Element Call will always join running legacy calls with legacy state events.```
+     * Send device-specific call session membership state events instead of
+     * legacy user-specific call membership state events.
+     * This setting has no effect when the user joins an active call with
+     * legacy state events. For compatibility, Element Call will always join
+     * active legacy calls with legacy state events.
      */
     feature_use_device_session_member_events?: boolean;
   };

--- a/src/rtcSessionHelpers.ts
+++ b/src/rtcSessionHelpers.ts
@@ -108,10 +108,17 @@ export async function enterRTCSession(
 
   // right now we assume everything is a room-scoped call
   const livekitAlias = rtcSession.room.roomId;
+  const useDeviceSessionMemberEvents =
+    Config.get().features?.feature_use_device_session_member_events;
   rtcSession.joinRoomSession(
     await makePreferredLivekitFoci(rtcSession, livekitAlias),
     makeActiveFocus(),
-    { manageMediaKeys: encryptMedia },
+    {
+      manageMediaKeys: encryptMedia,
+      ...(useDeviceSessionMemberEvents !== undefined && {
+        useLegacyMemberEvents: !useDeviceSessionMemberEvents,
+      }),
+    },
   );
 }
 


### PR DESCRIPTION
If not set, legacy call membership state events are sent instead. Even if set, legacy events are sent in rooms with active legacy calls.