### PR TITLE
Don't update mute when reaching the user count threshold.

### DIFF
--- a/src/room/GroupCallView.tsx
+++ b/src/room/GroupCallView.tsx
@@ -80,17 +80,14 @@ export const GroupCallView: FC<Props> = ({
   const memberships = useMatrixRTCSessionMemberships(rtcSession);
   const isJoined = useMatrixRTCSessionJoinState(rtcSession);
 
-  // The mute state reactively gets updated once the participant count reaches the threshold.
-  // The user then still is able to unmute again.
-  // The more common case is that the user is muted from the start (participant count is already over the threshold).
-  const autoMuteHappened = useRef(false);
-  useEffect(() => {
-    if (autoMuteHappened.current) return;
-    if (memberships.length >= MUTE_PARTICIPANT_COUNT) {
+  // this should be useEffectEvent (only available in experimental versions)
+  const participantMuteOnce = useCallback(() => {
+    if (memberships.length >= MUTE_PARTICIPANT_COUNT)
       muteStates.audio.setEnabled?.(false);
-      autoMuteHappened.current = true;
-    }
-  }, [autoMuteHappened, memberships, muteStates.audio]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => participantMuteOnce(), [participantMuteOnce]);
 
   useEffect(() => {
     window.rtcSession = rtcSession;

--- a/src/room/GroupCallView.tsx
+++ b/src/room/GroupCallView.tsx
@@ -80,14 +80,12 @@ export const GroupCallView: FC<Props> = ({
   const memberships = useMatrixRTCSessionMemberships(rtcSession);
   const isJoined = useMatrixRTCSessionJoinState(rtcSession);
 
-  // this should be useEffectEvent (only available in experimental versions)
-  const participantMuteOnce = useCallback(() => {
+  // This should use `useEffectEvent` (only available in experimental versions)
+  useEffect(() => {
     if (memberships.length >= MUTE_PARTICIPANT_COUNT)
       muteStates.audio.setEnabled?.(false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
-  useEffect(() => participantMuteOnce(), [participantMuteOnce]);
 
   useEffect(() => {
     window.rtcSession = rtcSession;


### PR DESCRIPTION
Fixes: https://github.com/element-hq/element-call/issues/2464

The idea is to mute whenever the participant count reaches 8 or more ppl. since there is a high chance for multiple users joining at the same time we update the mute state whenever we reach over 8ppl. So that a scheduled meeting still starts with everyone muted even though the meeting looked empty when the users were still in the lobby.

This changes it to only check this condition once at the beginningof the lobby and where the call just loaded (the client knows the user account)