### PR TITLE
Enable lint rules for Promise handling to discourage misuse of them

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -48,6 +48,12 @@ module.exports = {
       },
     ],
     "react/display-name": "error",
+    // Encourage proper usage of Promises:
+    "@typescript-eslint/no-floating-promises": "error",
+    "@typescript-eslint/no-misused-promises": "error",
+    "@typescript-eslint/promise-function-async": "error",
+    "@typescript-eslint/require-await": "error",
+    "@typescript-eslint/await-thenable": "error",
   },
   settings: {
     react: {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ import * as Sentry from "@sentry/react";
 import { OverlayProvider } from "@react-aria/overlays";
 import { History } from "history";
 import { TooltipProvider } from "@vector-im/compound-web";
+import { logger } from "matrix-js-sdk/src/logger";
 
 import { HomePage } from "./home/HomePage";
 import { LoginPage } from "./auth/LoginPage";
@@ -71,11 +72,15 @@ interface AppProps {
 export const App: FC<AppProps> = ({ history }) => {
   const [loaded, setLoaded] = useState(false);
   useEffect(() => {
-    Initializer.init()?.then(() => {
-      if (loaded) return;
-      setLoaded(true);
-      widget?.api.sendContentLoaded();
-    });
+    Initializer.init()
+      ?.then(async () => {
+        if (loaded) return;
+        setLoaded(true);
+        await widget?.api.sendContentLoaded();
+      })
+      .catch((e) => {
+        logger.error(e);
+      });
   });
 
   const errorPage = <CrashView />;

--- a/src/UserMenuContainer.tsx
+++ b/src/UserMenuContainer.tsx
@@ -40,7 +40,7 @@ export const UserMenuContainer: FC<Props> = ({ preventNavigation = false }) => {
   const [settingsTab, setSettingsTab] = useState(defaultSettingsTab);
 
   const onAction = useCallback(
-    async (value: string) => {
+    (value: string) => {
       switch (value) {
         case "user":
           setSettingsTab("profile");

--- a/src/analytics/PosthogSpanProcessor.ts
+++ b/src/analytics/PosthogSpanProcessor.ts
@@ -52,7 +52,9 @@ export class PosthogSpanProcessor implements SpanProcessor {
           this.onSummaryReportStart(span);
           return;
       }
-    });
+    }).catch((e) => {
+      // noop
+      });
   }
 
   public onEnd(span: ReadableSpan): void {
@@ -157,7 +159,8 @@ export class PosthogSpanProcessor implements SpanProcessor {
   /**
    * Shutdown the processor.
    */
-  public shutdown(): Promise<void> {
-    return Promise.resolve();
+  // eslint-disable-next-line @typescript-eslint/require-await
+  public async shutdown(): Promise<void> {
+    return;
   }
 }

--- a/src/analytics/PosthogSpanProcessor.ts
+++ b/src/analytics/PosthogSpanProcessor.ts
@@ -43,17 +43,19 @@ export class PosthogSpanProcessor implements SpanProcessor {
 
   public onStart(span: Span): void {
     // Hack: Yield to allow attributes to be set before processing
-    Promise.resolve().then(() => {
-      switch (span.name) {
-        case "matrix.groupCallMembership":
-          this.onGroupCallMembershipStart(span);
-          return;
-        case "matrix.groupCallMembership.summaryReport":
-          this.onSummaryReportStart(span);
-          return;
-      }
-    }).catch((e) => {
-      // noop
+    Promise.resolve()
+      .then(() => {
+        switch (span.name) {
+          case "matrix.groupCallMembership":
+            this.onGroupCallMembershipStart(span);
+            return;
+          case "matrix.groupCallMembership.summaryReport":
+            this.onSummaryReportStart(span);
+            return;
+        }
+      })
+      .catch((e) => {
+        // noop
       });
   }
 

--- a/src/auth/useInteractiveLogin.ts
+++ b/src/auth/useInteractiveLogin.ts
@@ -41,7 +41,7 @@ export function useInteractiveLogin(): (
 
     const interactiveAuth = new InteractiveAuth({
       matrixClient: authClient,
-      doRequest: (): Promise<LoginResponse> =>
+      doRequest: async (): Promise<LoginResponse> =>
         authClient.login("m.login.password", {
           identifier: {
             type: "m.id.user",
@@ -50,7 +50,7 @@ export function useInteractiveLogin(): (
           password,
         }),
       stateUpdated: (): void => {},
-      requestEmailToken: (): Promise<{ sid: string }> => {
+      requestEmailToken: async (): Promise<{ sid: string }> => {
         return Promise.resolve({ sid: "" });
       },
     });

--- a/src/auth/useInteractiveRegistration.ts
+++ b/src/auth/useInteractiveRegistration.ts
@@ -21,6 +21,7 @@ import {
   MatrixClient,
   RegisterResponse,
 } from "matrix-js-sdk/src/matrix";
+import { logger } from "matrix-js-sdk/src/logger";
 
 import { initClient } from "../matrix-utils";
 import { Session } from "../ClientContext";
@@ -73,7 +74,7 @@ export const useInteractiveRegistration = (): {
     ): Promise<[MatrixClient, Session]> => {
       const interactiveAuth = new InteractiveAuth({
         matrixClient: authClient.current!,
-        doRequest: (auth): Promise<RegisterResponse> =>
+        doRequest: async (auth): Promise<RegisterResponse> =>
           authClient.current!.registerRequest({
             username,
             password,
@@ -85,17 +86,25 @@ export const useInteractiveRegistration = (): {
           }
 
           if (nextStage === "m.login.terms") {
-            interactiveAuth.submitAuthDict({
-              type: "m.login.terms",
-            });
+            interactiveAuth
+              .submitAuthDict({
+                type: "m.login.terms",
+              })
+              .catch((e) => {
+                logger.error(e);
+              });
           } else if (nextStage === "m.login.recaptcha") {
-            interactiveAuth.submitAuthDict({
-              type: "m.login.recaptcha",
-              response: recaptchaResponse,
-            });
+            interactiveAuth
+              .submitAuthDict({
+                type: "m.login.recaptcha",
+                response: recaptchaResponse,
+              })
+              .catch((e) => {
+                logger.error(e);
+              });
           }
         },
-        requestEmailToken: (): Promise<{ sid: string }> => {
+        requestEmailToken: async (): Promise<{ sid: string }> => {
           return Promise.resolve({ sid: "dummy" });
         },
       });

--- a/src/auth/useRecaptcha.ts
+++ b/src/auth/useRecaptcha.ts
@@ -73,7 +73,7 @@ export function useRecaptcha(sitekey?: string): {
     }
   }, [recaptchaId, sitekey]);
 
-  const execute = useCallback((): Promise<string> => {
+  const execute = useCallback(async (): Promise<string> => {
     if (!sitekey) {
       return Promise.resolve("");
     }
@@ -105,7 +105,12 @@ export function useRecaptcha(sitekey?: string): {
         },
       };
 
-      window.grecaptcha.execute();
+      window.grecaptcha.execute().then(
+        () => {}, // noop
+        (e) => {
+          logger.error("Recaptcha execution failed", e);
+        },
+      );
 
       const iframe = document.querySelector<HTMLIFrameElement>(
         'iframe[src*="recaptcha/api2/bframe"]',

--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -30,17 +30,21 @@ export class Config {
     return this.internalInstance.config;
   }
 
-  public static init(): Promise<void> {
+  public static async init(): Promise<void> {
     if (Config.internalInstance?.initPromise) {
       return Config.internalInstance.initPromise;
     }
     Config.internalInstance = new Config();
-    Config.internalInstance.initPromise = new Promise<void>((resolve) => {
-      downloadConfig("../config.json").then((config) => {
-        Config.internalInstance.config = { ...DEFAULT_CONFIG, ...config };
-        resolve();
-      });
-    });
+    Config.internalInstance.initPromise = new Promise<void>(
+      (resolve, reject) => {
+        downloadConfig("../config.json")
+          .then((config) => {
+            Config.internalInstance.config = { ...DEFAULT_CONFIG, ...config };
+            resolve();
+          })
+          .catch(reject);
+      },
+    );
     return Config.internalInstance.initPromise;
   }
 

--- a/src/e2ee/matrixKeyProvider.ts
+++ b/src/e2ee/matrixKeyProvider.ts
@@ -55,19 +55,24 @@ export class MatrixKeyProvider extends BaseKeyProvider {
     }
   }
 
-  private onEncryptionKeyChanged = async (
+  private onEncryptionKeyChanged = (
     encryptionKey: Uint8Array,
     encryptionKeyIndex: number,
     participantId: string,
-  ): Promise<void> => {
-    this.onSetEncryptionKey(
-      await createKeyMaterialFromBuffer(encryptionKey),
-      participantId,
-      encryptionKeyIndex,
-    );
+  ): void => {
+    createKeyMaterialFromBuffer(encryptionKey)
+      .then((keyMaterial) => {
+        this.onSetEncryptionKey(keyMaterial, participantId, encryptionKeyIndex);
 
-    logger.debug(
-      `Sent new key to livekit room=${this.rtcSession?.room.roomId} participantId=${participantId} encryptionKeyIndex=${encryptionKeyIndex}`,
-    );
+        logger.debug(
+          `Sent new key to livekit room=${this.rtcSession?.room.roomId} participantId=${participantId} encryptionKeyIndex=${encryptionKeyIndex}`,
+        );
+      })
+      .catch((e) => {
+        logger.error(
+          `Failed to create key material from buffer for livekit room=${this.rtcSession?.room.roomId} participantId=${participantId} encryptionKeyIndex=${encryptionKeyIndex}`,
+          e,
+        );
+      });
   };
 }

--- a/src/initializer.tsx
+++ b/src/initializer.tsx
@@ -19,6 +19,7 @@ import { initReactI18next } from "react-i18next";
 import LanguageDetector from "i18next-browser-languagedetector";
 import Backend from "i18next-http-backend";
 import * as Sentry from "@sentry/react";
+import { logger } from "matrix-js-sdk/src/logger";
 
 import { getUrlParams } from "./UrlParams";
 import { Config } from "./config/Config";
@@ -84,6 +85,9 @@ export class Initializer {
           order: ["urlFragment", "navigator"],
           caches: [],
         },
+      })
+      .catch((e) => {
+        logger.error("Failed to initialize i18n", e);
       });
 
     // Custom Themeing
@@ -143,10 +147,14 @@ export class Initializer {
     // config
     if (this.loadStates.config === LoadState.None) {
       this.loadStates.config = LoadState.Loading;
-      Config.init().then(() => {
-        this.loadStates.config = LoadState.Loaded;
-        this.initStep(resolve);
-      });
+      Config.init()
+        .then(() => {
+          this.loadStates.config = LoadState.Loaded;
+          this.initStep(resolve);
+        })
+        .catch((e) => {
+          logger.error("Failed to load config", e);
+        });
     }
 
     //sentry (only initialize after the config is ready)

--- a/src/livekit/openIDSFU.ts
+++ b/src/livekit/openIDSFU.ts
@@ -54,7 +54,9 @@ export function useOpenIDSFU(
         ? await getSFUConfigWithOpenID(client, activeFocus)
         : undefined;
       setSFUConfig(sfuConfig);
-    })();
+    })().catch((e) => {
+      logger.error("Failed to get SFU config", e);
+    });
   }, [client, activeFocus]);
 
   return sfuConfig;

--- a/src/livekit/useECConnectionState.ts
+++ b/src/livekit/useECConnectionState.ts
@@ -45,7 +45,7 @@ export enum ECAddonConnectionState {
   // We are switching from one focus to another (or between livekit room aliases on the same focus)
   ECSwitchingFocus = "ec_switching_focus",
   // The call has just been initialised and is waiting for credentials to arrive before attempting
-  // to connect. This distinguishes from the 'Disconected' state which is now just for when livekit
+  // to connect. This distinguishes from the 'Disconnected' state which is now just for when livekit
   // gives up on connectivity and we consider the call to have failed.
   ECWaiting = "ec_waiting",
 }
@@ -159,9 +159,13 @@ async function connectAndPublish(
     `Publishing ${screenshareTracks.length} precreated screenshare tracks`,
   );
   for (const st of screenshareTracks) {
-    livekitRoom.localParticipant.publishTrack(st, {
-      source: Track.Source.ScreenShare,
-    });
+    livekitRoom.localParticipant
+      .publishTrack(st, {
+        source: Track.Source.ScreenShare,
+      })
+      .catch((e) => {
+        logger.error("Failed to publish screenshare track", e);
+      });
   }
 }
 
@@ -239,7 +243,9 @@ export function useECConnectionState(
         `SFU config changed! URL was ${currentSFUConfig.current?.url} now ${sfuConfig?.url}`,
       );
 
-      doFocusSwitch();
+      doFocusSwitch().catch((e) => {
+        logger.error("Failed to switch focus", e);
+      });
     } else if (
       !sfuConfigValid(currentSFUConfig.current) &&
       sfuConfigValid(sfuConfig)
@@ -256,7 +262,11 @@ export function useECConnectionState(
         sfuConfig!,
         initialAudioEnabled,
         initialAudioOptions,
-      ).finally(() => setIsInDoConnect(false));
+      )
+        .catch((e) => {
+          logger.error("Failed to connect to SFU", e);
+        })
+        .finally(() => setIsInDoConnect(false));
     }
 
     currentSFUConfig.current = Object.assign({}, sfuConfig);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -34,7 +34,10 @@ import { App } from "./App";
 import { init as initRageshake } from "./settings/rageshake";
 import { Initializer } from "./initializer";
 
-initRageshake();
+initRageshake().catch((e) => {
+  logger.error("Failed to initialize rageshake", e);
+});
+
 setLogLevel("debug");
 setLKLogExtension(global.mx_rage_logger.log);
 

--- a/src/matrix-utils.ts
+++ b/src/matrix-utils.ts
@@ -231,7 +231,7 @@ function fullAliasFromRoomName(roomName: string, client: MatrixClient): string {
  * @param client A matrix client object
  */
 export function sanitiseRoomNameInput(input: string): string {
-  // check to see if the user has enetered a fully qualified room
+  // check to see if the user has entered a fully qualified room
   // alias. If so, turn it into just the localpart because that's what
   // we use
   const parts = input.split(":", 2);
@@ -335,11 +335,17 @@ export async function createRoom(
 
   // Wait for the room to arrive
   await new Promise<void>((resolve, reject) => {
-    const onRoom = async (room: Room): Promise<void> => {
-      if (room.roomId === (await createPromise).room_id) {
-        resolve();
-        cleanUp();
-      }
+    const onRoom = (room: Room): void => {
+      createPromise
+        .then((result) => {
+          if (room.roomId === result.room_id) {
+            resolve();
+            cleanUp();
+          }
+        })
+        .catch((e) => {
+          logger.error("Failed to wait for the room to arrive", e);
+        });
     };
     createPromise.catch((e) => {
       reject(e);

--- a/src/media-utils.ts
+++ b/src/media-utils.ts
@@ -20,11 +20,11 @@ limitations under the License.
  * @param devices The list of devices to search
  * @returns A matching media device or undefined if no matching device was found
  */
-export async function findDeviceByName(
+export function findDeviceByName(
   deviceName: string,
   kind: MediaDeviceKind,
   devices: MediaDeviceInfo[],
-): Promise<string | undefined> {
+): string | undefined {
   const deviceInfo = devices.find(
     (d) => d.kind === kind && d.label === deviceName,
   );

--- a/src/olm.ts
+++ b/src/olm.ts
@@ -25,5 +25,5 @@ let olmLoaded: Promise<void> | null = null;
 /**
  * Loads Olm, if not already loaded.
  */
-export const loadOlm = (): Promise<void> =>
+export const loadOlm = async (): Promise<void> =>
   (olmLoaded ??= Olm.init({ locateFile: () => olmWasmPath }));

--- a/src/otel/otel.ts
+++ b/src/otel/otel.ts
@@ -99,7 +99,9 @@ export class ElementCallOpenTelemetry {
 
   public dispose(): void {
     opentelemetry.trace.disable();
-    this._provider?.shutdown();
+    this._provider?.shutdown().catch((e) => {
+      logger.error("Failed to shutdown OpenTelemetry", e);
+    });
   }
 
   public get isOtlpEnabled(): boolean {

--- a/src/room/GroupCallView.tsx
+++ b/src/room/GroupCallView.tsx
@@ -168,11 +168,7 @@ export const GroupCallView: FC<Props> = ({
       if (videoInput === null) {
         latestMuteStates.current!.video.setEnabled?.(false);
       } else {
-        const deviceId = findDeviceByName(
-          videoInput,
-          "videoinput",
-          devices,
-        );
+        const deviceId = findDeviceByName(videoInput, "videoinput", devices);
         if (!deviceId) {
           logger.warn("Unknown video input: " + videoInput);
           latestMuteStates.current!.video.setEnabled?.(false);

--- a/src/room/InCallView.tsx
+++ b/src/room/InCallView.tsx
@@ -39,6 +39,7 @@ import useMeasure from "react-use-measure";
 import { MatrixRTCSession } from "matrix-js-sdk/src/matrixrtc/MatrixRTCSession";
 import classNames from "classnames";
 import { useStateObservable } from "@react-rxjs/core";
+import { logger } from "matrix-js-sdk/src/logger";
 
 import LogoMark from "../icons/LogoMark.svg?react";
 import LogoType from "../icons/LogoType.svg?react";
@@ -98,7 +99,9 @@ export const ActiveCall: FC<ActiveCallProps> = (props) => {
 
   useEffect(() => {
     return (): void => {
-      livekitRoom?.disconnect();
+      livekitRoom?.disconnect().catch((e) => {
+        logger.error("Failed to disconnect from livekit room", e);
+      });
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -193,12 +196,16 @@ export const InCallView: FC<InCallViewProps> = subscribe(
     );
 
     useEffect(() => {
-      widget?.api.transport.send(
-        layout === "grid"
-          ? ElementWidgetActions.TileLayout
-          : ElementWidgetActions.SpotlightLayout,
-        {},
-      );
+      widget?.api.transport
+        .send(
+          layout === "grid"
+            ? ElementWidgetActions.TileLayout
+            : ElementWidgetActions.SpotlightLayout,
+          {},
+        )
+        .catch((e) => {
+          logger.error("Failed to send layout change to widget API", e);
+        });
     }, [layout]);
 
     useEffect(() => {

--- a/src/room/RoomPage.tsx
+++ b/src/room/RoomPage.tsx
@@ -68,11 +68,13 @@ export const RoomPage: FC = () => {
     // a URL param, automatically register a passwordless user
     if (!loading && !authenticated && displayName && !widget) {
       setIsRegistering(true);
-      registerPasswordlessUser(displayName).finally(() => {
-        setIsRegistering(false);
-      }).catch((e) => {
-        logger.error("Failed to register passwordless user", e);
-      });
+      registerPasswordlessUser(displayName)
+        .finally(() => {
+          setIsRegistering(false);
+        })
+        .catch((e) => {
+          logger.error("Failed to register passwordless user", e);
+        });
     }
   }, [
     loading,

--- a/src/room/RoomPage.tsx
+++ b/src/room/RoomPage.tsx
@@ -70,6 +70,8 @@ export const RoomPage: FC = () => {
       setIsRegistering(true);
       registerPasswordlessUser(displayName).finally(() => {
         setIsRegistering(false);
+      }).catch((e) => {
+        logger.error("Failed to register passwordless user", e);
       });
     }
   }, [

--- a/src/room/useFullscreen.ts
+++ b/src/room/useFullscreen.ts
@@ -28,7 +28,9 @@ const isFullscreen = (): boolean =>
 
 function enterFullscreen(): void {
   if (document.body.requestFullscreen) {
-    document.body.requestFullscreen();
+    document.body.requestFullscreen().catch((e) => {
+      logger.error("Failed to enter fullscreen", e);
+    });
   } else if (document.body.webkitRequestFullscreen) {
     document.body.webkitRequestFullscreen();
   } else {
@@ -38,7 +40,9 @@ function enterFullscreen(): void {
 
 function exitFullscreen(): void {
   if (document.exitFullscreen) {
-    document.exitFullscreen();
+    document.exitFullscreen().catch((e) => {
+      logger.error("Failed to exit fullscreen", e);
+    });
   } else if (document.webkitExitFullscreen) {
     document.webkitExitFullscreen();
   } else {

--- a/src/room/useLoadGroupCall.ts
+++ b/src/room/useLoadGroupCall.ts
@@ -95,7 +95,6 @@ export const useLoadGroupCall = (
   viaServers: string[],
 ): GroupCallStatus => {
   const [state, setState] = useState<GroupCallStatus>({ kind: "loading" });
-  const [loadInProgress, setLoadInProgress] = useState(false);
   const activeRoom = useRef<Room>();
   const { t } = useTranslation();
 
@@ -329,12 +328,8 @@ export const useLoadGroupCall = (
       });
     };
 
-    logger.log(
-      `useLoadGroupCall() state.kind=${state.kind} loadInProgress=${loadInProgress}`,
-    );
-    if (state.kind === "loading" && !loadInProgress) {
+    if (state.kind === "loading") {
       logger.log("Start loading group call");
-      setLoadInProgress(true);
       waitForClientSyncing()
         .then(fetchOrCreateGroupCall)
         .then((rtcSession) => setState({ kind: "loaded", rtcSession }))
@@ -350,7 +345,6 @@ export const useLoadGroupCall = (
     state,
     t,
     viaServers,
-    loadInProgress,
   ]);
 
   return state;

--- a/src/rtcSessionHelpers.ts
+++ b/src/rtcSessionHelpers.ts
@@ -36,6 +36,7 @@ export function makeActiveFocus(): LivekitFocusActive {
   };
 }
 
+// eslint-disable-next-line @typescript-eslint/require-await
 async function makePreferredLivekitFoci(
   rtcSession: MatrixRTCSession,
   livekitAlias: string,

--- a/src/rtcSessionHelpers.ts
+++ b/src/rtcSessionHelpers.ts
@@ -128,13 +128,13 @@ const widgetPostHangupProcedure = async (
   // we need to wait until the callEnded event is tracked on posthog.
   // Otherwise the iFrame gets killed before the callEnded event got tracked.
   await new Promise((resolve) => window.setTimeout(resolve, 10)); // 10ms
-  widget.api.setAlwaysOnScreen(false);
+  await widget.api.setAlwaysOnScreen(false);
   PosthogAnalytics.instance.logout();
 
   // We send the hangup event after the memberships have been updated
   // calling leaveRTCSession.
   // We need to wait because this makes the client hosting this widget killing the IFrame.
-  widget.api.transport.send(ElementWidgetActions.HangupCall, {});
+  await widget.api.transport.send(ElementWidgetActions.HangupCall, {});
 };
 
 export async function leaveRTCSession(

--- a/src/settings/FeedbackSettingsTab.tsx
+++ b/src/settings/FeedbackSettingsTab.tsx
@@ -17,6 +17,7 @@ limitations under the License.
 import { FC, useCallback } from "react";
 import { randomString } from "matrix-js-sdk/src/randomstring";
 import { useTranslation } from "react-i18next";
+import { logger } from "matrix-js-sdk/src/logger";
 
 import { Button } from "../button";
 import { FieldRow, InputField, ErrorMessage } from "../input/Input";
@@ -51,6 +52,8 @@ export const FeedbackSettingsTab: FC<Props> = ({ roomId }) => {
         sendLogs,
         rageshakeRequestId,
         roomId,
+      }).catch((e) => {
+        logger.error("Failed to send feedback rageshake", e);
       });
 
       if (roomId && sendLogs) {

--- a/src/settings/ProfileSettingsTab.tsx
+++ b/src/settings/ProfileSettingsTab.tsx
@@ -17,6 +17,7 @@ limitations under the License.
 import { FC, useCallback, useEffect, useMemo, useRef } from "react";
 import { MatrixClient } from "matrix-js-sdk/src/client";
 import { useTranslation } from "react-i18next";
+import { logger } from "matrix-js-sdk/src/logger";
 
 import { useProfile } from "../profile/useProfile";
 import { FieldRow, InputField, ErrorMessage } from "../input/Input";
@@ -70,6 +71,8 @@ export const ProfileSettingsTab: FC<Props> = ({ client }) => {
           // @ts-ignore
           avatar: avatar && avatarSize > 0 ? avatar : undefined,
           removeAvatar: removeAvatar.current && (!avatar || avatarSize === 0),
+        }).catch((e) => {
+          logger.error("Failed to save profile", e);
         });
       }
     };

--- a/src/settings/RageshakeButton.tsx
+++ b/src/settings/RageshakeButton.tsx
@@ -16,6 +16,7 @@ limitations under the License.
 
 import { useTranslation } from "react-i18next";
 import { FC, useCallback } from "react";
+import { logger } from "matrix-js-sdk/src/logger";
 
 import { Button } from "../button";
 import { Config } from "../config/Config";
@@ -34,6 +35,8 @@ export const RageshakeButton: FC<Props> = ({ description }) => {
     submitRageshake({
       description,
       sendLogs: true,
+    }).catch((e) => {
+      logger.error("Failed to send rageshake", e);
     });
   }, [submitRageshake, description]);
 

--- a/src/settings/rageshake.ts
+++ b/src/settings/rageshake.ts
@@ -138,13 +138,17 @@ class IndexedDBLogStore {
     this.id = "instance-" + randomString(16);
 
     loggerInstance.on(ConsoleLoggerEvent.Log, this.onLoggerLog);
-    window.addEventListener("beforeunload", this.flush);
+    window.addEventListener("beforeunload", () => {
+      this.flush().catch((e) =>
+        logger.error("Failed to flush logs before unload", e),
+      );
+    });
   }
 
   /**
    * @return {Promise} Resolves when the store is ready.
    */
-  public connect(): Promise<void> {
+  public async connect(): Promise<void> {
     const req = this.indexedDB.open("logs");
     return new Promise((resolve, reject) => {
       req.onsuccess = (): void => {
@@ -200,16 +204,10 @@ class IndexedDBLogStore {
   // Throttled function to flush logs. We use throttle rather
   // than debounce as we want logs to be written regularly, otherwise
   // if there's a constant stream of logging, we'd never write anything.
-  private throttledFlush = throttle(
-    () => {
-      this.flush();
-    },
-    MAX_FLUSH_INTERVAL_MS,
-    {
-      leading: false,
-      trailing: true,
-    },
-  );
+  private throttledFlush = throttle(() => this.flush, MAX_FLUSH_INTERVAL_MS, {
+    leading: false,
+    trailing: true,
+  });
 
   /**
    * Flush logs to disk.
@@ -230,7 +228,7 @@ class IndexedDBLogStore {
    *
    * @return {Promise} Resolved when the logs have been flushed.
    */
-  public flush = (): Promise<void> => {
+  public flush = async (): Promise<void> => {
     // check if a flush() operation is ongoing
     if (this.flushPromise) {
       if (this.flushAgainPromise) {
@@ -239,7 +237,7 @@ class IndexedDBLogStore {
       }
       // queue up a flush to occur immediately after the pending one completes.
       this.flushAgainPromise = this.flushPromise
-        .then(() => {
+        .then(async () => {
           return this.flush();
         })
         .then(() => {
@@ -296,7 +294,7 @@ class IndexedDBLogStore {
 
     // Returns: a string representing the concatenated logs for this ID.
     // Stops adding log fragments when the size exceeds maxSize
-    function fetchLogs(id: string, maxSize: number): Promise<string> {
+    async function fetchLogs(id: string, maxSize: number): Promise<string> {
       const objectStore = db!
         .transaction("logs", "readonly")
         .objectStore("logs");
@@ -326,7 +324,7 @@ class IndexedDBLogStore {
     }
 
     // Returns: A sorted array of log IDs. (newest first)
-    function fetchLogIds(): Promise<string[]> {
+    async function fetchLogIds(): Promise<string[]> {
       // To gather all the log IDs, query for all records in logslastmod.
       const o = db!
         .transaction("logslastmod", "readonly")
@@ -346,7 +344,7 @@ class IndexedDBLogStore {
       });
     }
 
-    function deleteLogs(id: number): Promise<void> {
+    async function deleteLogs(id: number): Promise<void> {
       return new Promise<void>((resolve, reject) => {
         const txn = db!.transaction(["logs", "logslastmod"], "readwrite");
         const o = txn.objectStore("logs");
@@ -404,7 +402,7 @@ class IndexedDBLogStore {
       logger.log("Removing logs: ", removeLogIds);
       // Don't await this because it's non-fatal if we can't clean up
       // logs.
-      Promise.all(removeLogIds.map((id) => deleteLogs(id))).then(
+      Promise.all(removeLogIds.map(async (id) => deleteLogs(id))).then(
         () => {
           logger.log(`Removed ${removeLogIds.length} old logs.`);
         },
@@ -442,7 +440,7 @@ class IndexedDBLogStore {
  * @return {Promise<T[]>} Resolves to an array of whatever you returned from
  * resultMapper.
  */
-function selectQuery<T>(
+async function selectQuery<T>(
   store: IDBObjectStore,
   keyRange: IDBKeyRange | undefined,
   resultMapper: (cursor: IDBCursorWithValue) => T,
@@ -471,7 +469,7 @@ declare global {
   // eslint-disable-next-line no-var, camelcase
   var mx_rage_logger: ConsoleLogger;
   // eslint-disable-next-line no-var, camelcase
-  var mx_rage_initStoragePromise: Promise<void>;
+  var mx_rage_initStoragePromise: Promise<void> | undefined;
 }
 
 /**
@@ -481,7 +479,7 @@ declare global {
  * be set up immediately for the logs.
  * @return {Promise} Resolves when set up.
  */
-export function init(): Promise<void> {
+export async function init(): Promise<void> {
   global.mx_rage_logger = new ConsoleLogger();
   setLogExtension(global.mx_rage_logger.log);
 
@@ -493,7 +491,7 @@ export function init(): Promise<void> {
  * then this no-ops.
  * @return {Promise} Resolves when complete.
  */
-function tryInitStorage(): Promise<void> {
+async function tryInitStorage(): Promise<void> {
   if (global.mx_rage_initStoragePromise) {
     return global.mx_rage_initStoragePromise;
   }

--- a/src/settings/submit-rageshake.ts
+++ b/src/settings/submit-rageshake.ts
@@ -298,10 +298,14 @@ export function useRageshakeRequest(): (
 
   const sendRageshakeRequest = useCallback(
     (roomId: string, rageshakeRequestId: string) => {
-      // @ts-expect-error - org.matrix.rageshake_request is not part of `keyof TimelineEvents` but it is okay to sent a custom event.
-      client!.sendEvent(roomId, "org.matrix.rageshake_request", {
-        request_id: rageshakeRequestId,
-      });
+      client!
+        // @ts-expect-error - org.matrix.rageshake_request is not part of `keyof TimelineEvents` but it is okay to sent a custom event.
+        .sendEvent(roomId, "org.matrix.rageshake_request", {
+          request_id: rageshakeRequestId,
+        })
+        .catch((e) => {
+          logger.error("Failed to send org.matrix.rageshake_request event", e);
+        });
     },
     [client],
   );

--- a/src/state/CallViewModel.ts
+++ b/src/state/CallViewModel.ts
@@ -263,7 +263,7 @@ export class CallViewModel extends ViewModel {
                   });
               }),
               // Then unhold them
-            ]).then(() => Promise.resolve({ unhold: ps })),
+            ]).then(() => ({ unhold: ps })),
           );
         } else {
           return EMPTY;

--- a/src/useWakeLock.ts
+++ b/src/useWakeLock.ts
@@ -28,19 +28,22 @@ export function useWakeLock(): void {
 
       // The lock is automatically released whenever the window goes invisible,
       // so we need to reacquire it on visibility changes
-      const onVisibilityChange = async (): Promise<void> => {
+      const onVisibilityChange = (): void => {
         if (document.visibilityState === "visible") {
-          try {
-            lock = await navigator.wakeLock.request("screen");
-            // Handle the edge case where this component unmounts before the
-            // promise resolves
-            if (!mounted)
-              lock
-                .release()
-                .catch((e) => logger.warn("Can't release wake lock", e));
-          } catch (e) {
-            logger.warn("Can't acquire wake lock", e);
-          }
+          navigator.wakeLock
+            .request("screen")
+            .then((newLock) => {
+              lock = newLock;
+              // Handle the edge case where this component unmounts before the
+              // promise resolves
+              if (!mounted)
+                lock
+                  .release()
+                  .catch((e) => logger.warn("Can't release wake lock", e));
+            })
+            .catch((e) => {
+              logger.warn("Can't acquire wake lock", e);
+            });
         }
       };
 

--- a/src/video-grid/NewVideoGrid.tsx
+++ b/src/video-grid/NewVideoGrid.tsx
@@ -27,6 +27,7 @@ import {
 } from "react";
 import useMeasure from "react-use-measure";
 import { zip } from "lodash";
+import { logger } from "matrix-js-sdk/src/logger";
 
 import styles from "./NewVideoGrid.module.css";
 import {
@@ -214,7 +215,9 @@ export function NewVideoGrid<T>({
   // Because we're using react-spring in imperative mode, we're responsible for
   // firing animations manually whenever the tiles array updates
   useEffect(() => {
-    springRef.start();
+    Promise.all(springRef.start()).catch((e) => {
+      logger.warn("Failed to start tile animations", e);
+    });
   }, [tiles, springRef]);
 
   const animateDraggedTile = (endOfGesture: boolean): void => {
@@ -250,7 +253,10 @@ export function NewVideoGrid<T>({
                 ((key): boolean =>
                   key === "zIndex" || key === "x" || key === "y"),
             },
-      );
+      )
+      .catch((e) => {
+        logger.warn("Failed to animate dragged tile", e);
+      });
 
     const overTile = tiles.find(
       (t) =>

--- a/src/video-grid/VideoGrid.tsx
+++ b/src/video-grid/VideoGrid.tsx
@@ -1324,7 +1324,9 @@ export function VideoGrid<T>({
       draggingTileRef.current = null;
     }
 
-    api.start(animate(newTiles));
+    Promise.all(api.start(animate(newTiles))).catch((e) => {
+      logger.error("Failed to start animations", e);
+    });
   };
 
   const onTileDragRef = useRef(onTileDrag);

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -170,17 +170,15 @@ export const widget = ((): WidgetHelpers | null => {
         false,
       );
 
-      const clientPromise = new Promise<MatrixClient>((resolve) => {
-        (async (): Promise<void> => {
-          // wait for the config file to be ready (we load very early on so it might not
-          // be otherwise)
-          await Config.init();
-          await client.startClient({ clientWellKnownPollPeriod: 60 * 10 });
-          resolve(client);
-        })();
-      });
+      const clientPromise = async (): Promise<MatrixClient> => {
+        // wait for the config file to be ready (we load very early on so it might not
+        // be otherwise)
+        await Config.init();
+        await client.startClient({ clientWellKnownPollPeriod: 60 * 10 });
+        return client;
+      };
 
-      return { api, lazyActions, client: clientPromise };
+      return { api, lazyActions, client: clientPromise() };
     } else {
       logger.info("No widget API available");
       return null;


### PR DESCRIPTION
Whilst working on the codebase I noticed that promises are not always being handled/treated correctly.

The purpose of enabling these lint rules to force a conscious decision around how Promises are handled including the errors.

The `@typescript-eslint/promise-function-async` rule is a stylistic one, so less important.

I'm anticipating this my prompt some discussion rather than just being merged as is 😇.