### PR TITLE
Add DeviceMute widget action `io.element.device_mute`.

### DIFF
--- a/src/widget.ts
+++ b/src/widget.ts
@@ -46,12 +46,13 @@ export enum ElementWidgetActions {
   // host -> Element Call telling EC to stop screen sharing, or that
   // the user cancelled when selecting a source after a ScreenshareRequest
   ScreenshareStop = "io.element.screenshare_stop",
-  // This can be sent as form or to widget
+  // This can be sent as from or to widget
   // fromWidget: updates the client about the current device mute state
   // toWidget: the client requests a specific device mute configuration
-  // (the reply will always be the resulting configuration)
-  // (it is possible to sent an empty configuration
-  // -> this will allow the client to only get the current state)
+  //   The reply will always be the resulting configuration
+  //   It is possible to sent an empty configuration or only a change for audio or video.
+  //   An undefined field means that EC will not keep the mute state as is.
+  //   -> this will allow the client to only get the current state
   //
   // The data of the widget action request and the response are:
   // {

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -46,6 +46,19 @@ export enum ElementWidgetActions {
   // host -> Element Call telling EC to stop screen sharing, or that
   // the user cancelled when selecting a source after a ScreenshareRequest
   ScreenshareStop = "io.element.screenshare_stop",
+  // This can be sent as form or to widget
+  // fromWidget: updates the client about the current device mute state
+  // toWidget: the client requests a specific device mute configuration
+  // (the reply will always be the resulting configuration)
+  // (it is possible to sent an empty configuration
+  // -> this will allow the client to only get the current state)
+  //
+  // The data of the widget action request and the response are:
+  // {
+  //   audio_enabled?: boolean,
+  //   video_enabled?: boolean
+  // }
+  DeviceMute = "io.element.device_mute",
 }
 
 export interface JoinCallData {
@@ -88,6 +101,7 @@ export const widget = ((): WidgetHelpers | null => {
         ElementWidgetActions.SpotlightLayout,
         ElementWidgetActions.ScreenshareStart,
         ElementWidgetActions.ScreenshareStop,
+        ElementWidgetActions.DeviceMute,
       ].forEach((action) => {
         api.on(`action:${action}`, (ev: CustomEvent<IWidgetApiRequest>) => {
           ev.preventDefault();

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -50,8 +50,9 @@ export enum ElementWidgetActions {
   // fromWidget: updates the client about the current device mute state
   // toWidget: the client requests a specific device mute configuration
   //   The reply will always be the resulting configuration
-  //   It is possible to sent an empty configuration or only a change for audio or video.
-  //   An undefined field means that EC will not keep the mute state as is.
+  //   It is possible to sent an empty configuration to retrieve the current values or
+  //   just one of the fields to update that particular value
+  //   An undefined field means that EC will keep the mute state as is.
   //   -> this will allow the client to only get the current state
   //
   // The data of the widget action request and the response are:


### PR DESCRIPTION
This allows to send mute requests ("toWidget") and get the current mute state as a response.
And it will update the client about each change of mute states.