### PR TITLE
Update js-sdk to check for MSC3779 in room version

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "i18next-http-backend": "^2.0.0",
     "livekit-client": "^2.0.2",
     "lodash": "^4.17.21",
-    "matrix-js-sdk": "github:matrix-org/matrix-js-sdk#238eea0ef5c82d0a11b8d5cc5c04104d6c94c4c1",
+    "matrix-js-sdk": "github:matrix-org/matrix-js-sdk#25a7c9e140652e13b1b874a6c2e6c20ec07f1a32",
     "matrix-widget-api": "^1.3.1",
     "normalize.css": "^8.0.1",
     "observable-hooks": "^4.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6684,9 +6684,9 @@ matrix-events-sdk@0.0.1:
   resolved "https://registry.yarnpkg.com/matrix-events-sdk/-/matrix-events-sdk-0.0.1.tgz#c8c38911e2cb29023b0bbac8d6f32e0de2c957dd"
   integrity sha512-1QEOsXO+bhyCroIe2/A5OwaxHvBm7EsSQ46DEDn8RBIfQwN5HWBpFvyWWR4QY0KHPPnnJdI99wgRiAl7Ad5qaA==
 
-"matrix-js-sdk@github:matrix-org/matrix-js-sdk#238eea0ef5c82d0a11b8d5cc5c04104d6c94c4c1":
+"matrix-js-sdk@github:matrix-org/matrix-js-sdk#25a7c9e140652e13b1b874a6c2e6c20ec07f1a32":
   version "33.1.0"
-  resolved "https://codeload.github.com/matrix-org/matrix-js-sdk/tar.gz/238eea0ef5c82d0a11b8d5cc5c04104d6c94c4c1"
+  resolved "https://codeload.github.com/matrix-org/matrix-js-sdk/tar.gz/25a7c9e140652e13b1b874a6c2e6c20ec07f1a32"
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@matrix-org/matrix-sdk-crypto-wasm" "^6.0.0"


### PR DESCRIPTION
This will tell EC to prefix non-legacy state event keys with an underscore to avoid 403 errors.