### PR TITLE
Only show the expand button in spotlight layout

### DIFF
--- a/src/room/InCallView.tsx
+++ b/src/room/InCallView.tsx
@@ -285,11 +285,6 @@ export const InCallView: FC<InCallViewProps> = ({
     }
   }, [setGridMode]);
 
-  const toggleSpotlightExpanded = useCallback(
-    () => vm.toggleSpotlightExpanded(),
-    [vm],
-  );
-
   const Tile = useMemo(
     () =>
       forwardRef<
@@ -300,6 +295,9 @@ export const InCallView: FC<InCallViewProps> = ({
         ref,
       ) {
         const spotlightExpanded = useObservableEagerState(vm.spotlightExpanded);
+        const [onToggleExpanded] = useObservableEagerState(
+          vm.toggleSpotlightExpanded,
+        );
         const showSpeakingIndicatorsValue = useObservableEagerState(
           vm.showSpeakingIndicators,
         );
@@ -324,7 +322,7 @@ export const InCallView: FC<InCallViewProps> = ({
             vms={model.vms}
             maximised={model.maximised}
             expanded={spotlightExpanded}
-            onToggleExpanded={toggleSpotlightExpanded}
+            onToggleExpanded={onToggleExpanded}
             targetWidth={targetWidth}
             targetHeight={targetHeight}
             showIndicators={showSpotlightIndicatorsValue}
@@ -333,7 +331,7 @@ export const InCallView: FC<InCallViewProps> = ({
           />
         );
       }),
-    [vm, toggleSpotlightExpanded, openProfile],
+    [vm, openProfile],
   );
 
   const layouts = useMemo(() => {

--- a/src/state/CallViewModel.ts
+++ b/src/state/CallViewModel.ts
@@ -543,10 +543,6 @@ export class CallViewModel extends ViewModel {
       shareReplay(1),
     );
 
-  public toggleSpotlightExpanded(): void {
-    this.spotlightExpandedToggle.next();
-  }
-
   private readonly gridModeUserSelection = new Subject<GridMode>();
   /**
    * The layout mode of the media tile grid.
@@ -677,6 +673,25 @@ export class CallViewModel extends ViewModel {
   public showSpeakingIndicators: Observable<boolean> = this.layout.pipe(
     map((l) => l.type !== "one-on-one" && l.type !== "spotlight-expanded"),
     distinctUntilChanged(),
+    shareReplay(1),
+  );
+
+  // To work around https://github.com/crimx/observable-hooks/issues/131 we must
+  // wrap the emitted function here in a non-function wrapper type
+  public readonly toggleSpotlightExpanded: Observable<
+    readonly [(() => void) | null]
+  > = this.layout.pipe(
+    map(
+      (l) =>
+        l.type === "spotlight-landscape" || l.type === "spotlight-expanded",
+    ),
+    distinctUntilChanged(),
+    map(
+      (enabled) =>
+        [
+          enabled ? (): void => this.spotlightExpandedToggle.next() : null,
+        ] as const,
+    ),
     shareReplay(1),
   );
 


### PR DESCRIPTION
It has no effect in any layout other than spotlight, and we've decided to hide it rather than spending effort to make it do something.