### PR TITLE
Give tiles a minimum area rather than a minimum width and height

### DIFF
--- a/src/grid/SpotlightPortraitLayout.tsx
+++ b/src/grid/SpotlightPortraitLayout.tsx
@@ -75,7 +75,9 @@ export const makeSpotlightPortraitLayout: CallLayout<
     const { width } = useObservableEagerState(minBounds);
     const { gap, tileWidth, tileHeight } = arrangeTiles(
       width,
-      0,
+      // TODO: We pretend that the minimum height is the width, because the
+      // actual minimum height is difficult to calculate
+      width,
       model.grid.length,
     );
     const tileModels: GridTileModel[] = useMemo(


### PR DESCRIPTION
This seems to result in more sensible cropping and allocation of space across the board, in my testing.