### PR TITLE
Improve the layouts on small mobile calls

### DIFF
--- a/src/grid/CallLayout.ts
+++ b/src/grid/CallLayout.ts
@@ -95,7 +95,6 @@ export interface GridArrangement {
 
 const tileMaxAspectRatio = 17 / 9;
 const tileMinAspectRatio = 4 / 3;
-const tileMobileMinAspectRatio = 2 / 3;
 
 /**
  * Determine the ideal arrangement of tiles into a grid of a particular size.
@@ -138,15 +137,10 @@ export function arrangeTiles(
 
   // Impose a minimum and maximum aspect ratio on the tiles
   const tileAspectRatio = tileWidth / tileHeight;
-  // We enforce a different min aspect ratio in 1:1s on mobile
-  const minAspectRatio =
-    tileCount === 1 && width < 600
-      ? tileMobileMinAspectRatio
-      : tileMinAspectRatio;
   if (tileAspectRatio > tileMaxAspectRatio)
     tileWidth = tileHeight * tileMaxAspectRatio;
-  else if (tileAspectRatio < minAspectRatio)
-    tileHeight = tileWidth / minAspectRatio;
+  else if (tileAspectRatio < tileMinAspectRatio)
+    tileHeight = tileWidth / tileMinAspectRatio;
 
   return { tileWidth, tileHeight, gap, columns };
 }

--- a/src/grid/OneOnOneLayout.module.css
+++ b/src/grid/OneOnOneLayout.module.css
@@ -26,16 +26,9 @@ limitations under the License.
 
 .local {
   position: absolute;
-  inline-size: 135px;
-  block-size: 160px;
+  inline-size: 180px;
+  block-size: 135px;
   inset: var(--cpd-space-4x);
-}
-
-@media (min-width: 600px) {
-  .local {
-    inline-size: 170px;
-    block-size: 110px;
-  }
 }
 
 .spotlight {

--- a/src/grid/SpotlightExpandedLayout.module.css
+++ b/src/grid/SpotlightExpandedLayout.module.css
@@ -25,9 +25,16 @@ limitations under the License.
 
 .pip {
   position: absolute;
-  inline-size: 180px;
-  block-size: 135px;
+  inline-size: 135px;
+  block-size: 160px;
   inset: var(--cpd-space-4x);
+}
+
+@media (min-width: 600px) {
+  .pip {
+    inline-size: 180px;
+    block-size: 135px;
+  }
 }
 
 .pip[data-block-alignment="start"] {

--- a/src/room/InCallView.tsx
+++ b/src/room/InCallView.tsx
@@ -295,7 +295,7 @@ export const InCallView: FC<InCallViewProps> = ({
         ref,
       ) {
         const spotlightExpanded = useObservableEagerState(vm.spotlightExpanded);
-        const [onToggleExpanded] = useObservableEagerState(
+        const onToggleExpanded = useObservableEagerState(
           vm.toggleSpotlightExpanded,
         );
         const showSpeakingIndicatorsValue = useObservableEagerState(

--- a/src/state/CallViewModel.ts
+++ b/src/state/CallViewModel.ts
@@ -520,7 +520,7 @@ export class CallViewModel extends ViewModel {
       const height = window.innerHeight;
       const width = window.innerWidth;
       if (height <= 400 && width <= 340) return "pip";
-      if (width <= 660) return "narrow";
+      if (width <= 600) return "narrow";
       if (height <= 660) return "flat";
       return "normal";
     }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -6944,9 +6944,9 @@ object.values@^1.1.7:
     es-abstract "^1.22.1"
 
 observable-hooks@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/observable-hooks/-/observable-hooks-4.2.3.tgz#69e3353caafd7887ad9030bd440b053304e8d2d1"
-  integrity sha512-d6fYTIU+9sg1V+CT0GhgoE/ntjIqcy9DGaYGE6ELGVP4ojaWIEsaLvL/05hLOM+AL7aySN4DCTLvj6dDF9T8XA==
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/observable-hooks/-/observable-hooks-4.2.4.tgz#e1ee0f867e0f2216f79c1e13c58716fb50b410ec"
+  integrity sha512-FdTQgyw1h5bG/QHCBIqctdBSnv9VARJCEilgpV6L2qlw1yeLqFIwPm4U15dMtl5kDmNN0hSt+Nl6iYbLFwEcQA==
 
 oidc-client-ts@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
Due to an oversight of mine, https://github.com/element-hq/element-call/commit/244003763953db033b5e5350142b3f00b7c8910a actually removed the ability to see the one-on-one layout on mobile. This restores mobile one-on-one calls to working order and also avoids showing the spotlight tile unless there are more than a few participants.

Based on https://github.com/element-hq/element-call/pull/2512 and https://github.com/element-hq/element-call/pull/2511