### PR TITLE
More strongly prefer putting a remote speaker in the spotlight

### DIFF
--- a/src/state/CallViewModel.ts
+++ b/src/state/CallViewModel.ts
@@ -414,19 +414,23 @@ export class CallViewModel extends ViewModel {
             ),
       ),
       scan<(readonly [UserMedia, boolean])[], UserMedia, null>(
-        (prev, mediaItems) =>
+        (prev, mediaItems) => {
+          const stickyPrev = prev === null || prev.vm.local ? null : prev;
           // Decide who to spotlight:
           // If the previous speaker (not the local user) is still speaking,
           // stick with them rather than switching eagerly to someone else
-          (prev === null || prev.vm.local
-            ? null
-            : mediaItems.find(([m, s]) => m === prev && s)?.[0]) ??
-          // Otherwise, select any remote user who is speaking
-          mediaItems.find(([m, s]) => !m.vm.local && s)?.[0] ??
-          // Otherwise, stick with the person who was last speaking
-          prev ??
-          // Otherwise, spotlight the local user
-          mediaItems.find(([m]) => m.vm.local)![0],
+          return (
+            mediaItems.find(([m, s]) => m === stickyPrev && s)?.[0] ??
+            // Otherwise, select any remote user who is speaking
+            mediaItems.find(([m, s]) => !m.vm.local && s)?.[0] ??
+            // Otherwise, stick with the person who was last speaking
+            stickyPrev ??
+            // Otherwise, spotlight an arbitrary remote user
+            mediaItems.find(([m]) => !m.vm.local)?.[0] ??
+            // Otherwise, spotlight the local user
+            mediaItems.find(([m]) => m.vm.local)![0]
+          );
+        },
         null,
       ),
       distinctUntilChanged(),


### PR DESCRIPTION
If no one had spoken yet, we were still showing the local user in the spotlight. We should instead eagerly switch to showing an arbitrary remote participant in this case.