### PR TITLE
Add back some margins to the interface

### DIFF
--- a/src/grid/GridLayout.module.css
+++ b/src/grid/GridLayout.module.css
@@ -40,7 +40,8 @@ limitations under the License.
   position: absolute;
   inline-size: 404px;
   block-size: 233px;
-  inset: 0;
+  inset-block: 0;
+  inset-inline: var(--cpd-space-3x);
 }
 
 .fixed > .slot[data-block-alignment="start"] {

--- a/src/room/InCallView.module.css
+++ b/src/room/InCallView.module.css
@@ -49,6 +49,7 @@ limitations under the License.
 
 .header {
   position: sticky;
+  flex-shrink: 0;
   inset-block-start: 0;
   z-index: 1;
   background: linear-gradient(
@@ -56,6 +57,11 @@ limitations under the License.
     rgba(0, 0, 0, 0) 0%,
     var(--cpd-color-bg-canvas-default) 100%
   );
+}
+
+.header.filler {
+  block-size: var(--cpd-space-6x);
+  background: none;
 }
 
 .footer {

--- a/src/room/InCallView.tsx
+++ b/src/room/InCallView.tsx
@@ -496,24 +496,33 @@ export const InCallView: FC<InCallViewProps> = ({
 
   return (
     <div className={styles.inRoom} ref={containerRef}>
-      {!hideHeader && windowMode !== "pip" && windowMode !== "flat" && (
-        <Header className={styles.header} ref={headerRef}>
-          <LeftNav>
-            <RoomHeaderInfo
-              id={matrixInfo.roomId}
-              name={matrixInfo.roomName}
-              avatarUrl={matrixInfo.roomAvatar}
-              encrypted={matrixInfo.e2eeSystem.kind !== E2eeType.NONE}
-              participantCount={participantCount}
-            />
-          </LeftNav>
-          <RightNav>
-            {!reducedControls && showControls && onShareClick !== null && (
-              <InviteButton onClick={onShareClick} />
-            )}
-          </RightNav>
-        </Header>
-      )}
+      {windowMode !== "pip" &&
+        windowMode !== "flat" &&
+        (hideHeader ? (
+          // Cosmetic header to fill out space while still affecting the bounds
+          // of the grid
+          <div
+            className={classNames(styles.header, styles.filler)}
+            ref={headerRef}
+          />
+        ) : (
+          <Header className={styles.header} ref={headerRef}>
+            <LeftNav>
+              <RoomHeaderInfo
+                id={matrixInfo.roomId}
+                name={matrixInfo.roomName}
+                avatarUrl={matrixInfo.roomAvatar}
+                encrypted={matrixInfo.e2eeSystem.kind !== E2eeType.NONE}
+                participantCount={participantCount}
+              />
+            </LeftNav>
+            <RightNav>
+              {!reducedControls && showControls && onShareClick !== null && (
+                <InviteButton onClick={onShareClick} />
+              )}
+            </RightNav>
+          </Header>
+        ))}
       <RoomAudioRenderer />
       {renderContent()}
       {footer}


### PR DESCRIPTION
There were a couple of cases where the lack of margins after the new layout changes just looked odd. Specifically, when the header is hidden (as in embedded mode), there would be no margin at the top of the window. Also the floating tile would run directly up against the sides of the window.

After:
![Screenshot from 2024-08-01 16-32-59](https://github.com/user-attachments/assets/15ec4dae-296c-4fd9-9fcf-7f5d4585da11)
