### PR TITLE
Fix Renovate warning

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,10 @@
   "extends": ["config:base"],
   "packageRules": [
     {
-      "extends": ["group:allNonMajor", "schedule:weekly"]
+      "groupName": "all non-major dependencies",
+      "groupSlug": "all-minor-patch",
+      "matchUpdateTypes": ["minor", "patch"],
+      "extends": ["schedule:weekly"]
     },
     {
       "groupName": "GitHub Actions",


### PR DESCRIPTION
Apparently Renovate doesn't really like it when you use a `group:` preset inside `packageRules`, instead of at the top level of the config. We do want to apply `schedule:weekly` only to the "all non-major dependencies" group though, so we need to write the group definition out by hand.