### PR TITLE
Fix a crash when the duplicate tiles option is empty

### DIFF
--- a/src/settings/SettingsModal.tsx
+++ b/src/settings/SettingsModal.tsx
@@ -254,7 +254,8 @@ export const SettingsModal: FC<Props> = ({
           value={duplicateTiles.toString()}
           onChange={useCallback(
             (event: ChangeEvent<HTMLInputElement>): void => {
-              setDuplicateTiles(event.target.valueAsNumber);
+              const value = event.target.valueAsNumber;
+              setDuplicateTiles(Number.isNaN(value) ? 0 : value);
             },
             [setDuplicateTiles],
           )}


### PR DESCRIPTION
We need to handle the case where the value is NaN because the field is empty.