### PR TITLE
Update js-sdk to use non-legacy calls if found

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "i18next-http-backend": "^2.0.0",
     "livekit-client": "^2.0.2",
     "lodash": "^4.17.21",
-    "matrix-js-sdk": "github:matrix-org/matrix-js-sdk#0fe53876ec555482bbeb086fd4dec8de7b2e21eb",
+    "matrix-js-sdk": "github:matrix-org/matrix-js-sdk#9176d3a671114be97ee7a42155a6d40a233384f1",
     "matrix-widget-api": "^1.8.2",
     "normalize.css": "^8.0.1",
     "observable-hooks": "^4.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6632,9 +6632,9 @@ matrix-events-sdk@0.0.1:
   resolved "https://registry.yarnpkg.com/matrix-events-sdk/-/matrix-events-sdk-0.0.1.tgz#c8c38911e2cb29023b0bbac8d6f32e0de2c957dd"
   integrity sha512-1QEOsXO+bhyCroIe2/A5OwaxHvBm7EsSQ46DEDn8RBIfQwN5HWBpFvyWWR4QY0KHPPnnJdI99wgRiAl7Ad5qaA==
 
-"matrix-js-sdk@github:matrix-org/matrix-js-sdk#0fe53876ec555482bbeb086fd4dec8de7b2e21eb":
-  version "34.0.0"
-  resolved "https://codeload.github.com/matrix-org/matrix-js-sdk/tar.gz/0fe53876ec555482bbeb086fd4dec8de7b2e21eb"
+"matrix-js-sdk@github:matrix-org/matrix-js-sdk#9176d3a671114be97ee7a42155a6d40a233384f1":
+  version "34.2.0"
+  resolved "https://codeload.github.com/matrix-org/matrix-js-sdk/tar.gz/9176d3a671114be97ee7a42155a6d40a233384f1"
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@matrix-org/matrix-sdk-crypto-wasm" "^7.0.0"


### PR DESCRIPTION
Pulls in matrix-org/matrix-js-sdk#4337