### PR TITLE
Don't show local media on top of itself

### DIFF
--- a/src/state/CallViewModel.ts
+++ b/src/state/CallViewModel.ts
@@ -488,11 +488,17 @@ export class CallViewModel extends ViewModel {
         ? ([of(screenShares.map((m) => m.vm)), this.spotlightSpeaker] as const)
         : ([
             this.spotlightSpeaker.pipe(map((speaker) => [speaker!])),
-            this.localUserMedia.pipe(
-              switchMap((vm) =>
-                vm.alwaysShow.pipe(
-                  map((alwaysShow) => (alwaysShow ? vm : null)),
-                ),
+            this.spotlightSpeaker.pipe(
+              switchMap((speaker) =>
+                speaker.local
+                  ? of(null)
+                  : this.localUserMedia.pipe(
+                      switchMap((vm) =>
+                        vm.alwaysShow.pipe(
+                          map((alwaysShow) => (alwaysShow ? vm : null)),
+                        ),
+                      ),
+                    ),
               ),
             ),
           ] as const),


### PR DESCRIPTION
If you were the only one in the call, you could get a broken-looking view in which the local tile is shown in the spotlight, and it's also shown in the PiP. This is redundant.