### PR TITLE
Avoid T-shaped layouts in 4 person calls

### DIFF
--- a/src/grid/CallLayout.ts
+++ b/src/grid/CallLayout.ts
@@ -113,7 +113,7 @@ export function arrangeTiles(
   const tileArea = Math.pow(Math.sqrt(area) / 8 + 125, 2);
   const tilesPerPage = Math.min(tileCount, area / tileArea);
 
-  const columns = Math.min(
+  let columns = Math.min(
     // Don't create more columns than we have items for
     tilesPerPage,
     // The ideal number of columns is given by a packing of equally-sized
@@ -130,7 +130,11 @@ export function arrangeTiles(
   let rows = tilesPerPage / columns;
   // If all the tiles could fit on one page, we want to ensure that they do by
   // not leaving fractional rows hanging off the bottom
-  if (tilesPerPage === tileCount) rows = Math.ceil(rows);
+  if (tilesPerPage === tileCount) {
+    rows = Math.ceil(rows);
+    // We may now be able to fit the tiles into fewer columns
+    columns = Math.ceil(tileCount / rows);
+  }
 
   let tileWidth = (width - (columns + 1) * gap) / columns;
   let tileHeight = (minHeight - (rows - 1) * gap) / rows;


### PR DESCRIPTION
The code path for when all tiles can fit on screen was failing to realize that it could sometimes get by with fewer columns. This resulted in wasted space for 4 person calls at some window sizes.

Before:
![Screenshot 2024-08-08 at 12-50-34 Element Call](https://github.com/user-attachments/assets/e05d2688-3f35-4751-8de1-46ad5239907f)

After:
![Screenshot 2024-08-08 at 12-50-45 Element Call](https://github.com/user-attachments/assets/4a3bdd27-86db-4152-8dce-27e60faa7dcc)
