### PR TITLE
Show controls on tap/hover on small screens

### DIFF
--- a/src/room/InCallView.module.css
+++ b/src/room/InCallView.module.css
@@ -22,31 +22,6 @@ limitations under the License.
   overflow-y: auto;
 }
 
-.controlsOverlay {
-  position: relative;
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  overflow: auto;
-  overflow-inline: hidden;
-  /* There used to be a contain: strict here, but due to some bugs in Firefox,
-  this was causing the Z-ordering of modals to glitch out. It can be added back
-  if those issues appear to be resolved. */
-}
-
-.centerMessage {
-  display: flex;
-  flex: 1;
-  justify-content: center;
-  align-items: center;
-  flex-direction: column;
-}
-
-.centerMessage p {
-  display: block;
-  margin-bottom: 0;
-}
-
 .header {
   position: sticky;
   flex-shrink: 0;
@@ -80,6 +55,24 @@ limitations under the License.
     rgba(0, 0, 0, 0) 0%,
     var(--cpd-color-bg-canvas-default) 100%
   );
+}
+
+.footer.overlay {
+  position: absolute;
+  inset-block-end: 0;
+  inset-inline: 0;
+  opacity: 1;
+  transition: opacity 0.15s;
+}
+
+.footer.overlay.hidden {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.footer.overlay:has(:focus-visible) {
+  opacity: 1;
+  pointer-events: initial;
 }
 
 .logo {
@@ -118,21 +111,6 @@ limitations under the License.
   .buttons {
     gap: var(--cpd-space-4x);
   }
-}
-
-.footerThin {
-  padding-top: var(--cpd-space-3x);
-  padding-bottom: var(--cpd-space-5x);
-}
-
-.footerHidden {
-  display: none;
-}
-
-.footer.overlay {
-  position: absolute;
-  inset-block-end: 0;
-  inset-inline: 0;
 }
 
 .fixedGrid {

--- a/src/room/LayoutToggle.tsx
+++ b/src/room/LayoutToggle.tsx
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { ChangeEvent, FC, useCallback } from "react";
+import { ChangeEvent, FC, TouchEvent, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { Tooltip } from "@vector-im/compound-web";
 import {
@@ -31,9 +31,15 @@ interface Props {
   layout: Layout;
   setLayout: (layout: Layout) => void;
   className?: string;
+  onTouchEnd?: (e: TouchEvent) => void;
 }
 
-export const LayoutToggle: FC<Props> = ({ layout, setLayout, className }) => {
+export const LayoutToggle: FC<Props> = ({
+  layout,
+  setLayout,
+  className,
+  onTouchEnd,
+}) => {
   const { t } = useTranslation();
 
   const onChange = useCallback(
@@ -50,6 +56,7 @@ export const LayoutToggle: FC<Props> = ({ layout, setLayout, className }) => {
           value="spotlight"
           checked={layout === "spotlight"}
           onChange={onChange}
+          onTouchEnd={onTouchEnd}
         />
       </Tooltip>
       <SpotlightIcon aria-hidden width={24} height={24} />
@@ -60,6 +67,7 @@ export const LayoutToggle: FC<Props> = ({ layout, setLayout, className }) => {
           value="grid"
           checked={layout === "grid"}
           onChange={onChange}
+          onTouchEnd={onTouchEnd}
         />
       </Tooltip>
       <GridIcon aria-hidden width={24} height={24} />

--- a/src/state/CallViewModel.ts
+++ b/src/state/CallViewModel.ts
@@ -533,7 +533,7 @@ export class CallViewModel extends ViewModel {
       // Our layouts for flat windows are better at adapting to a small width
       // than our layouts for narrow windows are at adapting to a small height,
       // so we give "flat" precedence here
-      if (height <= 660) return "flat";
+      if (height <= 600) return "flat";
       if (width <= 600) return "narrow";
       return "normal";
     }),


### PR DESCRIPTION
This changes the mobile landscape view to automatically hide the controls, giving more visibility to the video underneath, and show them on tap/hover.