### PR TITLE
Fix long call names overflowing the interface

### DIFF
--- a/src/Header.module.css
+++ b/src/Header.module.css
@@ -90,6 +90,7 @@ limitations under the License.
 .nameLine {
   grid-area: name;
   flex-grow: 1;
+  min-width: 0;
   display: flex;
   align-items: center;
   gap: var(--cpd-space-1x);
@@ -97,8 +98,6 @@ limitations under the License.
 
 .nameLine > h1 {
   margin: 0;
-  /* XXX I can't actually get this ellipsis overflow to trigger, because
-  constraint propagation in a nested flexbox layout is a massive pain */
   overflow: hidden;
   text-overflow: ellipsis;
 }

--- a/src/room/InCallView.module.css
+++ b/src/room/InCallView.module.css
@@ -19,6 +19,7 @@ limitations under the License.
   flex-direction: column;
   height: 100%;
   width: 100%;
+  overflow-x: hidden;
   overflow-y: auto;
 }
 


### PR DESCRIPTION
|Before|After|
-|-
![Screen Shot 2024-08-16 at 15 19 03](https://github.com/user-attachments/assets/4e28a395-973f-4f89-8a55-51545a076952)|![Screen Shot 2024-08-16 at 15 18 47](https://github.com/user-attachments/assets/ccfa90f5-1c15-4684-88b3-3df1d7e2b3c7)