### PR TITLE
Add back keyboard toast tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@testing-library/user-event": "^14.5.1",
     "@types/content-type": "^1.1.5",
     "@types/grecaptcha": "^3.0.9",
+    "@types/jsdom": "^21.1.7",
     "@types/lodash": "^4.14.199",
     "@types/node": "^20.0.0",
     "@types/react-dom": "^18.3.0",

--- a/src/useCallViewKeyboardShortcuts.test.tsx
+++ b/src/useCallViewKeyboardShortcuts.test.tsx
@@ -22,6 +22,12 @@ import userEvent from "@testing-library/user-event";
 
 import { useCallViewKeyboardShortcuts } from "../src/useCallViewKeyboardShortcuts";
 
+// Test Explanation:
+// - The main objective is to test `useCallViewKeyboardShortcuts`.
+//   The TestComponent just wraps a button around that hook.
+// - We need to set userEvent to the `{document = window.document}` since we are testing the
+// `useCallViewKeyboardShortcuts` hook here. Which is listening to window.
+
 interface TestComponentProps {
   setMicrophoneMuted: (muted: boolean) => void;
   onButtonClick?: () => void;
@@ -40,24 +46,33 @@ const TestComponent: FC<TestComponentProps> = ({
   );
   return (
     <div ref={ref}>
-      <Button onClick={onButtonClick}>I'm a button</Button>
+      <Button onClick={onButtonClick}>TEST</Button>
     </div>
   );
 };
 
 test("spacebar unmutes", async () => {
-  const user = userEvent.setup();
+  const user = userEvent.setup({ document: window.document });
   let muted = true;
-  render(<TestComponent setMicrophoneMuted={(m) => (muted = m)} />);
+  render(
+    <TestComponent
+      onButtonClick={() => (muted = false)}
+      setMicrophoneMuted={(m) => {
+        muted = m;
+      }}
+    />,
+  );
 
   await user.keyboard("[Space>]");
   expect(muted).toBe(false);
   await user.keyboard("[/Space]");
+
   expect(muted).toBe(true);
 });
 
 test("spacebar prioritizes pressing a button", async () => {
-  const user = userEvent.setup();
+  const user = userEvent.setup({ document: window.document });
+
   const setMuted = vi.fn();
   const onClick = vi.fn();
   render(
@@ -71,7 +86,7 @@ test("spacebar prioritizes pressing a button", async () => {
 });
 
 test("unmuting happens in place of the default action", async () => {
-  const user = userEvent.setup();
+  const user = userEvent.setup({ document: window.document });
   const defaultPrevented = vi.fn();
   // In the real application, we mostly just want the spacebar shortcut to avoid
   // scrolling the page. But to test that here in JSDOM, we need some kind of

--- a/src/useCallViewKeyboardShortcuts.test.tsx
+++ b/src/useCallViewKeyboardShortcuts.test.tsx
@@ -25,7 +25,7 @@ import { useCallViewKeyboardShortcuts } from "../src/useCallViewKeyboardShortcut
 // Test Explanation:
 // - The main objective is to test `useCallViewKeyboardShortcuts`.
 //   The TestComponent just wraps a button around that hook.
-// - We need to set userEvent to the `{document = window.document}` since we are testing the
+// - We need to set `userEvent` to the `{document = window.document}` since we are testing the
 // `useCallViewKeyboardShortcuts` hook here. Which is listening to window.
 
 interface TestComponentProps {

--- a/src/vitest.setup.ts
+++ b/src/vitest.setup.ts
@@ -13,13 +13,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
 import "global-jsdom/register";
-
+import globalJsdom from "global-jsdom";
 import i18n from "i18next";
 import posthog from "posthog-js";
 import { initReactI18next } from "react-i18next";
-import { afterEach } from "vitest";
+import { afterEach, beforeEach } from "vitest";
 import { cleanup } from "@testing-library/react";
 
 import { Config } from "./config/Config";
@@ -36,4 +35,12 @@ i18n.use(initReactI18next).init({
 Config.initDefault();
 posthog.opt_out_capturing();
 
-afterEach(cleanup);
+// We need to cleanup the global jsDom
+// Otherwise we will run into issues with async input test overlapping and throwing.
+
+let cleanupJsDom: { (): void };
+beforeEach(() => (cleanupJsDom = globalJsdom()));
+afterEach(() => {
+  cleanupJsDom();
+  cleanup();
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2854,6 +2854,15 @@
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.11.tgz#56588b17ae8f50c53983a524fc3cc47437969d64"
   integrity sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==
 
+"@types/jsdom@^21.1.7":
+  version "21.1.7"
+  resolved "https://registry.yarnpkg.com/@types/jsdom/-/jsdom-21.1.7.tgz#9edcb09e0b07ce876e7833922d3274149c898cfa"
+  integrity sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==
+  dependencies:
+    "@types/node" "*"
+    "@types/tough-cookie" "*"
+    parse5 "^7.0.0"
+
 "@types/json5@^0.0.29":
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
@@ -2868,6 +2877,13 @@
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"
   integrity sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==
+
+"@types/node@*":
+  version "22.5.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.5.1.tgz#de01dce265f6b99ed32b295962045d10b5b99560"
+  integrity sha512-KkHsxej0j9IW1KKOOAA/XBA0z08UFSrRQHErzEfA3Vgq57eXIMYboIlHJuYIfd+lwCQjtKqUu3UnmKbtUc9yRw==
+  dependencies:
+    undici-types "~6.19.2"
 
 "@types/node@>=13.7.0":
   version "22.1.0"
@@ -2939,6 +2955,11 @@
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@types/symlink-or-copy/-/symlink-or-copy-1.2.2.tgz#51b1c00b516a5774ada5d611e65eb123f988ef8d"
   integrity sha512-MQ1AnmTLOncwEf9IVU+B2e4Hchrku5N67NkgcAHW0p3sdzPe0FNMANxEm6OJUzPniEQGkeT3OROLlCwZJLWFZA==
+
+"@types/tough-cookie@*":
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.5.tgz#cb6e2a691b70cb177c6e3ae9c1d2e8b2ea8cd304"
+  integrity sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==
 
 "@types/uuid@10":
   version "10.0.0"


### PR DESCRIPTION
This test was removed because it failed in CI and we are still in the progress to find the difference between ci and local test runs.

Blocked by: https://github.com/element-hq/element-call/pull/2466