### PR TITLE
Remove shadow for layout switcher.

### DIFF
--- a/src/room/LayoutToggle.module.css
+++ b/src/room/LayoutToggle.module.css
@@ -19,7 +19,6 @@ limitations under the License.
   border: 1px solid var(--cpd-color-border-interactive-secondary);
   border-radius: var(--cpd-radius-pill-effect);
   background: var(--cpd-color-bg-canvas-default);
-  box-shadow: 0px 0px 40px 0px rgba(0, 0, 0, 0.5);
   display: flex;
   position: relative;
 }


### PR DESCRIPTION
So the layout switcher looks more aligned with the other buttons.

Now:
![Screenshot from 2024-08-29 15-16-14](https://github.com/user-attachments/assets/12c8454c-e59f-4671-8c01-d13c15c0450c)
Before:
![Screenshot from 2024-08-29 15-15-07](https://github.com/user-attachments/assets/c981fb31-c2df-4c22-bb20-7bddedc83ce4)
