### PR TITLE
Make js-sdk imports consistent

### DIFF
--- a/src/analytics/PosthogAnalytics.ts
+++ b/src/analytics/PosthogAnalytics.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 import posthog, { CaptureOptions, PostHog, Properties } from "posthog-js";
 import { logger } from "matrix-js-sdk/src/logger";
-import { MatrixClient } from "matrix-js-sdk";
+import { MatrixClient } from "matrix-js-sdk/src/matrix";
 import { Buffer } from "buffer";
 
 import { widget } from "../widget";

--- a/src/home/CallList.test.tsx
+++ b/src/home/CallList.test.tsx
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import { render, RenderResult } from "@testing-library/react";
-import { MatrixClient } from "matrix-js-sdk";
+import { MatrixClient } from "matrix-js-sdk/src/matrix";
 import { MemoryRouter } from "react-router-dom";
 import { describe, expect, it } from "vitest";
 

--- a/src/home/useGroupCallRooms.ts
+++ b/src/home/useGroupCallRooms.ts
@@ -18,7 +18,7 @@ import { MatrixClient } from "matrix-js-sdk/src/client";
 import { Room, RoomEvent } from "matrix-js-sdk/src/models/room";
 import { RoomMember } from "matrix-js-sdk/src/models/room-member";
 import { useState, useEffect } from "react";
-import { EventTimeline, EventType, JoinRule } from "matrix-js-sdk";
+import { EventTimeline, EventType, JoinRule } from "matrix-js-sdk/src/matrix";
 import { MatrixRTCSession } from "matrix-js-sdk/src/matrixrtc/MatrixRTCSession";
 import { MatrixRTCSessionManagerEvents } from "matrix-js-sdk/src/matrixrtc/MatrixRTCSessionManager";
 import { KnownMembership } from "matrix-js-sdk/src/types";

--- a/src/livekit/openIDSFU.ts
+++ b/src/livekit/openIDSFU.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { IOpenIDToken, MatrixClient } from "matrix-js-sdk";
+import { IOpenIDToken, MatrixClient } from "matrix-js-sdk/src/matrix";
 import { logger } from "matrix-js-sdk/src/logger";
 import { MatrixRTCSession } from "matrix-js-sdk/src/matrixrtc/MatrixRTCSession";
 import { useEffect, useState } from "react";

--- a/src/otel/OTelCall.ts
+++ b/src/otel/OTelCall.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import { Span } from "@opentelemetry/api";
-import { MatrixCall } from "matrix-js-sdk";
+import { MatrixCall } from "matrix-js-sdk/src/matrix";
 import { CallEvent } from "matrix-js-sdk/src/webrtc/call";
 import {
   TransceiverStats,

--- a/src/otel/OTelGroupCallMembership.ts
+++ b/src/otel/OTelGroupCallMembership.ts
@@ -20,7 +20,7 @@ import {
   MatrixClient,
   MatrixEvent,
   RoomMember,
-} from "matrix-js-sdk";
+} from "matrix-js-sdk/src/matrix";
 import { logger } from "matrix-js-sdk/src/logger";
 import {
   CallError,

--- a/src/room/GroupCallLoader.tsx
+++ b/src/room/GroupCallLoader.tsx
@@ -17,7 +17,7 @@ limitations under the License.
 import { useCallback } from "react";
 import { MatrixClient } from "matrix-js-sdk/src/client";
 import { useTranslation } from "react-i18next";
-import { MatrixError } from "matrix-js-sdk";
+import { MatrixError } from "matrix-js-sdk/src/matrix";
 import { useHistory } from "react-router-dom";
 import { Heading, Link, Text } from "@vector-im/compound-web";
 

--- a/src/room/InviteModal.tsx
+++ b/src/room/InviteModal.tsx
@@ -16,7 +16,7 @@ limitations under the License.
 
 import { FC, MouseEvent, useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Room } from "matrix-js-sdk";
+import { Room } from "matrix-js-sdk/src/matrix";
 import { Button, Text } from "@vector-im/compound-web";
 import {
   LinkIcon,

--- a/src/room/useLoadGroupCall.ts
+++ b/src/room/useLoadGroupCall.ts
@@ -26,7 +26,7 @@ import { SyncState } from "matrix-js-sdk/src/sync";
 import { MatrixRTCSession } from "matrix-js-sdk/src/matrixrtc/MatrixRTCSession";
 import { RoomEvent, Room } from "matrix-js-sdk/src/models/room";
 import { KnownMembership } from "matrix-js-sdk/src/types";
-import { JoinRule } from "matrix-js-sdk";
+import { JoinRule } from "matrix-js-sdk/src/matrix";
 import { useTranslation } from "react-i18next";
 
 import { widget } from "../widget";

--- a/src/settings/SettingsModal.tsx
+++ b/src/settings/SettingsModal.tsx
@@ -16,7 +16,7 @@ limitations under the License.
 
 import { ChangeEvent, FC, ReactNode, useCallback } from "react";
 import { Trans, useTranslation } from "react-i18next";
-import { MatrixClient } from "matrix-js-sdk";
+import { MatrixClient } from "matrix-js-sdk/src/matrix";
 import { Dropdown } from "@vector-im/compound-web";
 
 import { Modal } from "../Modal";

--- a/src/tile/SpotlightTile.tsx
+++ b/src/tile/SpotlightTile.tsx
@@ -35,7 +35,7 @@ import { useObservableEagerState } from "observable-hooks";
 import { useTranslation } from "react-i18next";
 import classNames from "classnames";
 import { TrackReferenceOrPlaceholder } from "@livekit/components-core";
-import { RoomMember } from "matrix-js-sdk";
+import { RoomMember } from "matrix-js-sdk/src/matrix";
 
 import { MediaView } from "./MediaView";
 import styles from "./SpotlightTile.module.css";


### PR DESCRIPTION
We need to be consistent about whether we import matrix-js-sdk from `src` or `lib`, otherwise we get two copies of matrix-js-sdk, and everything explodes.

This fixes a long-standing bug which meant that element-call couldn't be successfully built against release versions of matrix-js-sdk. That bug recently became more acute due to https://github.com/matrix-org/matrix-js-sdk/pull/4357, which brought non-release versions of matrix-js-sdk into line with release versions.