### PR TITLE
Fix (rust crypto): Adjust login procedures to account for rust crypto behaviour.

### DIFF
--- a/src/ClientContext.tsx
+++ b/src/ClientContext.tsx
@@ -379,19 +379,15 @@ async function loadClient(): Promise<InitResult | null> {
       } catch (err) {
         if (err instanceof MatrixError && err.errcode === "M_UNKNOWN_TOKEN") {
           // We can't use this session anymore, so let's log it out
-          try {
-            const client = await initClient(initClientParams, false); // Don't need the crypto store just to log out)
-            await client.logout(true);
-          } catch (err) {
-            logger.warn(
-              "The previous session was unable to login, and we couldn't log it out: " +
-                err,
-            );
-          }
+          logger.log(
+            "The session from local store is invalid; continuing without a client",
+          );
+          clearSession();
+          // returning null = "no client` pls register" (undefined = "loading" which is the current value when reaching this line)
+          return null;
         }
         throw err;
       }
-      /* eslint-enable camelcase */
     } catch (err) {
       clearSession();
       throw err;

--- a/src/auth/LoginPage.tsx
+++ b/src/auth/LoginPage.tsx
@@ -32,8 +32,8 @@ export const LoginPage: FC = () => {
   const { t } = useTranslation();
   usePageTitle(t("login_title"));
 
-  const { setClient } = useClient();
-  const login = useInteractiveLogin();
+  const { client, setClient } = useClient();
+  const login = useInteractiveLogin(client);
   const homeserver = Config.defaultHomeserverUrl(); // TODO: Make this configurable
   const usernameRef = useRef<HTMLInputElement>(null);
   const passwordRef = useRef<HTMLInputElement>(null);

--- a/src/utils/matrix.ts
+++ b/src/utils/matrix.ts
@@ -142,8 +142,6 @@ export async function initClient(
   // Start client store.
   // Note: The `client.store` is used to store things like sync results. It's independent of
   // the cryptostore, and uses a separate indexeddb database.
-
-  // start the client store (totally independent to the crypto store)
   try {
     await client.store.startup();
   } catch (error) {


### PR DESCRIPTION
 - If we have an invalid access token return `null` so that we get prompted with the registration (create call without being authenticated) view.
 - logout the guest user, before we try to login (interactive login with username and pwd)
 - clear (and await) the rust crypto store before we initialize it in case we do not want to restore a localstore session.