### PR TITLE
Make the test coverage target non-blocking

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -9,5 +9,7 @@ coverage:
         informational: true
     patch:
       default:
-        # Expect 80% coverage on all lines that a PR touches
+        # Encourage (but don't enforce) 80% coverage on all lines that a PR
+        # touches
         target: 80%
+        informational: true


### PR DESCRIPTION
Sadly Codecov doesn't give us a way to relax the coverage requirements for changes that touch very few lines of code, which has been an invaluable feature of SonarCloud. I suggest we make the check non-blocking.