### PR TITLE
Update matrix-js-sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "livekit-client": "^2.0.2",
     "lodash": "^4.17.21",
     "loglevel": "^1.9.1",
-    "matrix-js-sdk": "^v34.4.0",
+    "matrix-js-sdk": "matrix-org/matrix-js-sdk#169e8f86139111574a3738f8557c6fa4b2a199db",
     "matrix-widget-api": "^1.8.2",
     "normalize.css": "^8.0.1",
     "observable-hooks": "^4.2.3",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
     "resolveJsonModule": true,
     // Workaround for https://github.com/microsoft/TypeScript/issues/55132
     "useDefineForClassFields": false,
+    "allowImportingTsExtensions": true,
     "paths": {
       // These imports within @livekit/components-core and
       // @livekit/components-react are broken under the "bundler" module

--- a/yarn.lock
+++ b/yarn.lock
@@ -5950,10 +5950,9 @@ matrix-events-sdk@0.0.1:
   resolved "https://registry.yarnpkg.com/matrix-events-sdk/-/matrix-events-sdk-0.0.1.tgz#c8c38911e2cb29023b0bbac8d6f32e0de2c957dd"
   integrity sha512-1QEOsXO+bhyCroIe2/A5OwaxHvBm7EsSQ46DEDn8RBIfQwN5HWBpFvyWWR4QY0KHPPnnJdI99wgRiAl7Ad5qaA==
 
-matrix-js-sdk@^v34.4.0:
+matrix-js-sdk@matrix-org/matrix-js-sdk#169e8f86139111574a3738f8557c6fa4b2a199db:
   version "34.4.0"
-  resolved "https://registry.yarnpkg.com/matrix-js-sdk/-/matrix-js-sdk-34.4.0.tgz#ceb3403c92dbff3b37e776745a2997ee78fa1eac"
-  integrity sha512-bI5xJZS3/qhjPQqQL5HhOQ1iBvnHxiqhS2zgzk9SarEuXiH08wbVl9gAAuDqOYE3miNGs4WQQJ19MoaUEOnNwg==
+  resolved "https://codeload.github.com/matrix-org/matrix-js-sdk/tar.gz/169e8f86139111574a3738f8557c6fa4b2a199db"
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@matrix-org/matrix-sdk-crypto-wasm" "^7.0.0"


### PR DESCRIPTION
There's no particular change that we need to pull in, but I like to keep my linked copy of matrix-js-sdk up to date—a TypeScript config change is required by recent versions, so I'd like to update this now.