### PR TITLE
Test a few React components

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "vite": "^5.0.0",
     "vite-plugin-html-template": "^1.1.0",
     "vite-plugin-svgr": "^4.0.0",
-    "vitest": "^2.0.0"
+    "vitest": "^2.0.0",
+    "vitest-axe": "^1.0.0-pre.3"
   }
 }

--- a/public/locales/en-GB/app.json
+++ b/public/locales/en-GB/app.json
@@ -161,8 +161,8 @@
   "video_tile": {
     "always_show": "Always show",
     "change_fit_contain": "Fit to frame",
-    "exit_full_screen": "Exit full screen",
-    "full_screen": "Full screen",
+    "collapse": "Collapse",
+    "expand": "Expand",
     "mute_for_me": "Mute for me",
     "volume": "Volume"
   }

--- a/src/Header.test.tsx
+++ b/src/Header.test.tsx
@@ -1,0 +1,45 @@
+/*
+Copyright 2024 New Vector Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { expect, test, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { axe } from "vitest-axe";
+import { TooltipProvider } from "@vector-im/compound-web";
+
+import { RoomHeaderInfo } from "./Header";
+
+global.matchMedia = vi.fn().mockReturnValue({
+  matches: true,
+  addEventListener: () => {},
+  removeEventListener: () => {},
+});
+
+test("RoomHeaderInfo is accessible", async () => {
+  const { container } = render(
+    <TooltipProvider>
+      <RoomHeaderInfo
+        id="!a:example.org"
+        name="Mission Control"
+        avatarUrl=""
+        encrypted
+        participantCount={11}
+      />
+    </TooltipProvider>,
+  );
+  expect(await axe(container)).toHaveNoViolations();
+  // Check that the room name acts as a heading
+  screen.getByRole("heading", { name: "Mission Control" });
+});

--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -98,6 +98,8 @@ export const Modal: FC<Props> = ({
               styles.drawer,
               { [styles.tabbed]: tabbed },
             )}
+            // Suppress the warning about there being no description; the modal
+            // has an accessible title
             aria-describedby={undefined}
             {...rest}
           >
@@ -121,6 +123,8 @@ export const Modal: FC<Props> = ({
           <DialogOverlay
             className={classNames(overlayStyles.bg, overlayStyles.animate)}
           />
+          {/* Suppress the warning about there being no description; the modal
+          has an accessible title */}
           <DialogContent asChild aria-describedby={undefined} {...rest}>
             <Glass
               className={classNames(

--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -98,6 +98,7 @@ export const Modal: FC<Props> = ({
               styles.drawer,
               { [styles.tabbed]: tabbed },
             )}
+            aria-describedby={undefined}
             {...rest}
           >
             <div className={styles.content}>
@@ -120,7 +121,7 @@ export const Modal: FC<Props> = ({
           <DialogOverlay
             className={classNames(overlayStyles.bg, overlayStyles.animate)}
           />
-          <DialogContent asChild {...rest}>
+          <DialogContent asChild aria-describedby={undefined} {...rest}>
             <Glass
               className={classNames(
                 className,

--- a/src/Toast.test.tsx
+++ b/src/Toast.test.tsx
@@ -15,19 +15,12 @@ limitations under the License.
 */
 
 import { describe, expect, test, vi } from "vitest";
-import { render, configure } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { Toast } from "../src/Toast";
 import { withFakeTimers } from "./utils/test";
 
-configure({
-  defaultHidden: true,
-});
-
-// Test Explanation:
-// This test the toast. We need to use { document: window.document } because the toast listens
-// for user input on `window`.
 describe("Toast", () => {
   test("renders", () => {
     const { queryByRole } = render(
@@ -45,7 +38,7 @@ describe("Toast", () => {
   });
 
   test("dismisses when Esc is pressed", async () => {
-    const user = userEvent.setup({ document: window.document });
+    const user = userEvent.setup();
     const onDismiss = vi.fn();
     render(
       <Toast open={true} onDismiss={onDismiss}>
@@ -59,7 +52,7 @@ describe("Toast", () => {
   test("dismisses when background is clicked", async () => {
     const user = userEvent.setup();
     const onDismiss = vi.fn();
-    const { getByRole, unmount } = render(
+    const { getByRole } = render(
       <Toast open={true} onDismiss={onDismiss}>
         Hello world!
       </Toast>,
@@ -67,7 +60,6 @@ describe("Toast", () => {
     const background = getByRole("dialog").previousSibling! as Element;
     await user.click(background);
     expect(onDismiss).toHaveBeenCalled();
-    unmount();
   });
 
   test("dismisses itself after the specified timeout", () => {

--- a/src/input/StarRating.test.tsx
+++ b/src/input/StarRating.test.tsx
@@ -1,0 +1,29 @@
+/*
+Copyright 2024 New Vector Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only
+Please see LICENSE in the repository root for full details.
+*/
+
+import { test, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { axe } from "vitest-axe";
+import userEvent from "@testing-library/user-event";
+
+import { StarRatingInput } from "./StarRatingInput";
+
+test("StarRatingInput is accessible", async () => {
+  const user = userEvent.setup();
+  const onChange = vi.fn();
+  const { container } = render(
+    <StarRatingInput starCount={5} onChange={onChange} />,
+  );
+  expect(await axe(container)).toHaveNoViolations();
+  // Change the rating to 4 stars
+  await user.click(
+    (
+      await screen.findAllByRole("radio", { name: "star_rating_input_label" })
+    )[3],
+  );
+  expect(onChange).toBeCalledWith(4);
+});

--- a/src/room/EncryptionLock.tsx
+++ b/src/room/EncryptionLock.tsx
@@ -40,7 +40,6 @@ export const EncryptionLock: FC<Props> = ({ encrypted }) => {
         height={16}
         className={styles.lock}
         data-encrypted={encrypted}
-        aria-hidden
       />
     </Tooltip>
   );

--- a/src/room/InviteModal.test.tsx
+++ b/src/room/InviteModal.test.tsx
@@ -14,26 +14,31 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { expect, test } from "vitest";
 import { render, screen } from "@testing-library/react";
+import { expect, test, vi } from "vitest";
+import { Room } from "matrix-js-sdk/src/matrix";
 import { axe } from "vitest-axe";
-import { TooltipProvider } from "@vector-im/compound-web";
+import { BrowserRouter } from "react-router-dom";
+import userEvent from "@testing-library/user-event";
 
-import { RoomHeaderInfo } from "./Header";
+import { InviteModal } from "./InviteModal";
 
-test("RoomHeaderInfo is accessible", async () => {
+// Used by copy-to-clipboard
+window.prompt = (): null => null;
+
+test("InviteModal is accessible", async () => {
+  const user = userEvent.setup();
+  const room = {
+    roomId: "!a:example.org",
+    name: "Mission Control",
+  } as unknown as Room;
+  const onDismiss = vi.fn();
   const { container } = render(
-    <TooltipProvider>
-      <RoomHeaderInfo
-        id="!a:example.org"
-        name="Mission Control"
-        avatarUrl=""
-        encrypted
-        participantCount={11}
-      />
-    </TooltipProvider>,
+    <InviteModal room={room} open={true} onDismiss={onDismiss} />,
+    { wrapper: BrowserRouter },
   );
+
   expect(await axe(container)).toHaveNoViolations();
-  // Check that the room name acts as a heading
-  screen.getByRole("heading", { name: "Mission Control" });
+  await user.click(screen.getByRole("button", { name: "action.copy_link" }));
+  expect(onDismiss).toBeCalled();
 });

--- a/src/state/MediaViewModel.test.ts
+++ b/src/state/MediaViewModel.test.ts
@@ -81,14 +81,14 @@ test("toggle fit/contain for a participant's video", async () => {
 });
 
 test("local media remembers whether it should always be shown", async () => {
-  await withLocalMedia(async (vm) =>
+  await withLocalMedia({}, async (vm) =>
     withTestScheduler(({ expectObservable, schedule }) => {
       schedule("-a|", { a: () => vm.setAlwaysShow(false) });
       expectObservable(vm.alwaysShow).toBe("ab", { a: true, b: false });
     }),
   );
   // Next local media should start out *not* always shown
-  await withLocalMedia(async (vm) =>
+  await withLocalMedia({}, async (vm) =>
     withTestScheduler(({ expectObservable, schedule }) => {
       schedule("-a|", { a: () => vm.setAlwaysShow(true) });
       expectObservable(vm.alwaysShow).toBe("ab", { a: false, b: true });

--- a/src/state/MediaViewModel.test.ts
+++ b/src/state/MediaViewModel.test.ts
@@ -14,52 +14,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { RoomMember } from "matrix-js-sdk/src/matrix";
 import { expect, test, vi } from "vitest";
-import { LocalParticipant, RemoteParticipant } from "livekit-client";
 
 import {
-  LocalUserMediaViewModel,
-  RemoteUserMediaViewModel,
-} from "./MediaViewModel";
-import { withTestScheduler } from "../utils/test";
+  withLocalMedia,
+  withRemoteMedia,
+  withTestScheduler,
+} from "../utils/test";
 
-function withLocal(continuation: (vm: LocalUserMediaViewModel) => void): void {
-  const member = {} as unknown as RoomMember;
-  const vm = new LocalUserMediaViewModel(
-    "a",
-    member,
-    {} as unknown as LocalParticipant,
-    true,
-  );
-  try {
-    continuation(vm);
-  } finally {
-    vm.destroy();
-  }
-}
-
-function withRemote(
-  participant: Partial<RemoteParticipant>,
-  continuation: (vm: RemoteUserMediaViewModel) => void,
-): void {
-  const member = {} as unknown as RoomMember;
-  const vm = new RemoteUserMediaViewModel(
-    "a",
-    member,
-    { setVolume() {}, ...participant } as RemoteParticipant,
-    true,
-  );
-  try {
-    continuation(vm);
-  } finally {
-    vm.destroy();
-  }
-}
-
-test("set a participant's volume", () => {
+test("set a participant's volume", async () => {
   const setVolumeSpy = vi.fn();
-  withRemote({ setVolume: setVolumeSpy }, (vm) =>
+  await withRemoteMedia({}, { setVolume: setVolumeSpy }, async (vm) =>
     withTestScheduler(({ expectObservable, schedule }) => {
       schedule("-a|", {
         a() {
@@ -72,9 +37,9 @@ test("set a participant's volume", () => {
   );
 });
 
-test("mute and unmute a participant", () => {
+test("mute and unmute a participant", async () => {
   const setVolumeSpy = vi.fn();
-  withRemote({ setVolume: setVolumeSpy }, (vm) =>
+  await withRemoteMedia({}, { setVolume: setVolumeSpy }, async (vm) =>
     withTestScheduler(({ expectObservable, schedule }) => {
       schedule("-abc|", {
         a() {
@@ -99,8 +64,8 @@ test("mute and unmute a participant", () => {
   );
 });
 
-test("toggle fit/contain for a participant's video", () => {
-  withRemote({}, (vm) =>
+test("toggle fit/contain for a participant's video", async () => {
+  await withRemoteMedia({}, {}, async (vm) =>
     withTestScheduler(({ expectObservable, schedule }) => {
       schedule("-ab|", {
         a: () => vm.toggleFitContain(),
@@ -115,15 +80,15 @@ test("toggle fit/contain for a participant's video", () => {
   );
 });
 
-test("local media remembers whether it should always be shown", () => {
-  withLocal((vm) =>
+test("local media remembers whether it should always be shown", async () => {
+  await withLocalMedia(async (vm) =>
     withTestScheduler(({ expectObservable, schedule }) => {
       schedule("-a|", { a: () => vm.setAlwaysShow(false) });
       expectObservable(vm.alwaysShow).toBe("ab", { a: true, b: false });
     }),
   );
   // Next local media should start out *not* always shown
-  withLocal((vm) =>
+  await withLocalMedia(async (vm) =>
     withTestScheduler(({ expectObservable, schedule }) => {
       schedule("-a|", { a: () => vm.setAlwaysShow(true) });
       expectObservable(vm.alwaysShow).toBe("ab", { a: false, b: true });

--- a/src/tile/GridTile.test.tsx
+++ b/src/tile/GridTile.test.tsx
@@ -1,0 +1,52 @@
+/*
+Copyright 2024 New Vector Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { RemoteTrackPublication } from "livekit-client";
+import { test, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { axe } from "vitest-axe";
+
+import { GridTile } from "./GridTile";
+import { withRemoteMedia } from "../utils/test";
+
+test("GridTile is accessible", async () => {
+  await withRemoteMedia(
+    {
+      rawDisplayName: "Alice",
+      getMxcAvatarUrl: () => "mxc://adfsg",
+    },
+    {
+      setVolume() {},
+      getTrackPublication: () =>
+        ({}) as Partial<RemoteTrackPublication> as RemoteTrackPublication,
+    },
+    async (vm) => {
+      const { container } = render(
+        <GridTile
+          vm={vm}
+          onOpenProfile={() => {}}
+          targetWidth={300}
+          targetHeight={200}
+          showVideo
+          showSpeakingIndicators
+        />,
+      );
+      expect(await axe(container)).toHaveNoViolations();
+      // Name should be visible
+      screen.getByText("Alice");
+    },
+  );
+});

--- a/src/tile/MediaView.tsx
+++ b/src/tile/MediaView.tsx
@@ -110,7 +110,6 @@ export const MediaView = forwardRef<HTMLDivElement, Props>(
                   width={20}
                   height={20}
                   className={styles.errorIcon}
-                  aria-hidden
                 />
               </Tooltip>
             )}

--- a/src/tile/SpotlightTile.test.tsx
+++ b/src/tile/SpotlightTile.test.tsx
@@ -14,13 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { RemoteTrackPublication } from "livekit-client";
-import { test, expect } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { test, expect, vi } from "vitest";
+import { isInaccessible, render, screen } from "@testing-library/react";
 import { axe } from "vitest-axe";
+import userEvent from "@testing-library/user-event";
 
 import { SpotlightTile } from "./SpotlightTile";
-import { withRemoteMedia } from "../utils/test";
+import { withLocalMedia, withRemoteMedia } from "../utils/test";
 
 global.IntersectionObserver = class MockIntersectionObserver {
   public observe(): void {}
@@ -33,25 +33,50 @@ test("SpotlightTile is accessible", async () => {
       rawDisplayName: "Alice",
       getMxcAvatarUrl: () => "mxc://adfsg",
     },
-    {
-      getTrackPublication: () =>
-        ({}) as Partial<RemoteTrackPublication> as RemoteTrackPublication,
-    },
-    async (vm) => {
-      const { container } = render(
-        <SpotlightTile
-          vms={[vm]}
-          targetWidth={300}
-          targetHeight={200}
-          maximised={false}
-          expanded={false}
-          onToggleExpanded={() => {}}
-          showIndicators
-        />,
+    {},
+    async (vm1) => {
+      await withLocalMedia(
+        {
+          rawDisplayName: "Bob",
+          getMxcAvatarUrl: () => "mxc://dlskf",
+        },
+        async (vm2) => {
+          const user = userEvent.setup();
+          const toggleExpanded = vi.fn();
+          const { container } = render(
+            <SpotlightTile
+              vms={[vm1, vm2]}
+              targetWidth={300}
+              targetHeight={200}
+              maximised={false}
+              expanded={false}
+              onToggleExpanded={toggleExpanded}
+              showIndicators
+            />,
+          );
+
+          expect(await axe(container)).toHaveNoViolations();
+          // Alice should be in the spotlight, with her name and avatar on the
+          // first page
+          screen.getByText("Alice");
+          const aliceAvatar = screen.getByRole("img");
+          expect(screen.queryByRole("button", { name: "common.back" })).toBe(
+            null,
+          );
+          // Bob should be out of the spotlight, and therefore invisible
+          expect(isInaccessible(screen.getByText("Bob"))).toBe(true);
+          // Now navigate to Bob
+          await user.click(screen.getByRole("button", { name: "common.next" }));
+          screen.getByText("Bob");
+          expect(screen.getByRole("img")).not.toBe(aliceAvatar);
+          expect(isInaccessible(screen.getByText("Alice"))).toBe(true);
+          // Can toggle whether the tile is expanded
+          await user.click(
+            screen.getByRole("button", { name: "video_tile.expand" }),
+          );
+          expect(toggleExpanded).toHaveBeenCalled();
+        },
       );
-      expect(await axe(container)).toHaveNoViolations();
-      // Name should be visible
-      screen.getByText("Alice");
     },
   );
 });

--- a/src/tile/SpotlightTile.test.tsx
+++ b/src/tile/SpotlightTile.test.tsx
@@ -1,0 +1,57 @@
+/*
+Copyright 2024 New Vector Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { RemoteTrackPublication } from "livekit-client";
+import { test, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { axe } from "vitest-axe";
+
+import { SpotlightTile } from "./SpotlightTile";
+import { withRemoteMedia } from "../utils/test";
+
+global.IntersectionObserver = class MockIntersectionObserver {
+  public observe(): void {}
+  public unobserve(): void {}
+} as unknown as typeof IntersectionObserver;
+
+test("SpotlightTile is accessible", async () => {
+  await withRemoteMedia(
+    {
+      rawDisplayName: "Alice",
+      getMxcAvatarUrl: () => "mxc://adfsg",
+    },
+    {
+      getTrackPublication: () =>
+        ({}) as Partial<RemoteTrackPublication> as RemoteTrackPublication,
+    },
+    async (vm) => {
+      const { container } = render(
+        <SpotlightTile
+          vms={[vm]}
+          targetWidth={300}
+          targetHeight={200}
+          maximised={false}
+          expanded={false}
+          onToggleExpanded={() => {}}
+          showIndicators
+        />,
+      );
+      expect(await axe(container)).toHaveNoViolations();
+      // Name should be visible
+      screen.getByText("Alice");
+    },
+  );
+});

--- a/src/tile/SpotlightTile.tsx
+++ b/src/tile/SpotlightTile.tsx
@@ -61,6 +61,7 @@ interface SpotlightItemBaseProps {
   member: RoomMember | undefined;
   unencryptedWarning: boolean;
   displayName: string;
+  "aria-hidden"?: boolean;
 }
 
 interface SpotlightUserMediaItemBaseProps extends SpotlightItemBaseProps {
@@ -118,10 +119,21 @@ interface SpotlightItemProps {
    * Whether this item should act as a scroll snapping point.
    */
   snap: boolean;
+  "aria-hidden"?: boolean;
 }
 
 const SpotlightItem = forwardRef<HTMLDivElement, SpotlightItemProps>(
-  ({ vm, targetWidth, targetHeight, intersectionObserver, snap }, theirRef) => {
+  (
+    {
+      vm,
+      targetWidth,
+      targetHeight,
+      intersectionObserver,
+      snap,
+      "aria-hidden": ariaHidden,
+    },
+    theirRef,
+  ) => {
     const ourRef = useRef<HTMLDivElement | null>(null);
     const ref = useMergedRefs(ourRef, theirRef);
     const displayName = useDisplayName(vm);
@@ -153,6 +165,7 @@ const SpotlightItem = forwardRef<HTMLDivElement, SpotlightItemProps>(
       member: vm.member,
       unencryptedWarning,
       displayName,
+      "aria-hidden": ariaHidden,
     };
 
     return vm instanceof ScreenShareViewModel ? (
@@ -280,7 +293,12 @@ export const SpotlightTile = forwardRef<HTMLDivElement, Props>(
               targetWidth={targetWidth}
               targetHeight={targetHeight}
               intersectionObserver={intersectionObserver}
+              // This is how we get the container to scroll to the right media
+              // when the previous/next buttons are clicked: we temporarily
+              // remove all scroll snap points except for just the one media
+              // that we want to bring into view
               snap={scrollToId === null || scrollToId === vm.id}
+              aria-hidden={(scrollToId ?? visibleId) !== vm.id}
             />
           ))}
         </div>
@@ -288,9 +306,7 @@ export const SpotlightTile = forwardRef<HTMLDivElement, Props>(
           <button
             className={classNames(styles.expand)}
             aria-label={
-              expanded
-                ? t("video_tile.full_screen")
-                : t("video_tile.exit_full_screen")
+              expanded ? t("video_tile.collapse") : t("video_tile.expand")
             }
             onClick={onToggleExpanded}
           >

--- a/src/useCallViewKeyboardShortcuts.test.tsx
+++ b/src/useCallViewKeyboardShortcuts.test.tsx
@@ -25,8 +25,6 @@ import { useCallViewKeyboardShortcuts } from "../src/useCallViewKeyboardShortcut
 // Test Explanation:
 // - The main objective is to test `useCallViewKeyboardShortcuts`.
 //   The TestComponent just wraps a button around that hook.
-// - We need to set `userEvent` to the `{document = window.document}` since we are testing the
-// `useCallViewKeyboardShortcuts` hook here. Which is listening to window.
 
 interface TestComponentProps {
   setMicrophoneMuted: (muted: boolean) => void;
@@ -52,7 +50,7 @@ const TestComponent: FC<TestComponentProps> = ({
 };
 
 test("spacebar unmutes", async () => {
-  const user = userEvent.setup({ document: window.document });
+  const user = userEvent.setup();
   let muted = true;
   render(
     <TestComponent
@@ -71,7 +69,7 @@ test("spacebar unmutes", async () => {
 });
 
 test("spacebar prioritizes pressing a button", async () => {
-  const user = userEvent.setup({ document: window.document });
+  const user = userEvent.setup();
 
   const setMuted = vi.fn();
   const onClick = vi.fn();
@@ -86,7 +84,7 @@ test("spacebar prioritizes pressing a button", async () => {
 });
 
 test("unmuting happens in place of the default action", async () => {
-  const user = userEvent.setup({ document: window.document });
+  const user = userEvent.setup();
   const defaultPrevented = vi.fn();
   // In the real application, we mostly just want the spacebar shortcut to avoid
   // scrolling the page. But to test that here in JSDOM, we need some kind of

--- a/src/utils/test.ts
+++ b/src/utils/test.ts
@@ -17,7 +17,12 @@ import { map } from "rxjs";
 import { RunHelpers, TestScheduler } from "rxjs/testing";
 import { expect, vi } from "vitest";
 import { RoomMember } from "matrix-js-sdk/src/matrix";
-import { LocalParticipant, RemoteParticipant } from "livekit-client";
+import {
+  LocalParticipant,
+  LocalTrackPublication,
+  RemoteParticipant,
+  RemoteTrackPublication,
+} from "livekit-client";
 
 import {
   LocalUserMediaViewModel,
@@ -66,14 +71,47 @@ export function withTestScheduler(
   );
 }
 
+function mockMember(member: Partial<RoomMember>): RoomMember {
+  return {
+    on() {
+      return this;
+    },
+    off() {
+      return this;
+    },
+    addListener() {
+      return this;
+    },
+    removeListener() {
+      return this;
+    },
+    ...member,
+  } as RoomMember;
+}
+
 export async function withLocalMedia(
+  member: Partial<RoomMember>,
   continuation: (vm: LocalUserMediaViewModel) => Promise<void>,
 ): Promise<void> {
-  const member = {} as unknown as RoomMember;
   const vm = new LocalUserMediaViewModel(
-    "a",
-    member,
-    {} as Partial<LocalParticipant> as LocalParticipant,
+    "local",
+    mockMember(member),
+    {
+      getTrackPublication: () =>
+        ({}) as Partial<LocalTrackPublication> as LocalTrackPublication,
+      on() {
+        return this as LocalParticipant;
+      },
+      off() {
+        return this as LocalParticipant;
+      },
+      addListener() {
+        return this as LocalParticipant;
+      },
+      removeListener() {
+        return this as LocalParticipant;
+      },
+    } as Partial<LocalParticipant> as LocalParticipant,
     true,
   );
   try {
@@ -89,24 +127,12 @@ export async function withRemoteMedia(
   continuation: (vm: RemoteUserMediaViewModel) => Promise<void>,
 ): Promise<void> {
   const vm = new RemoteUserMediaViewModel(
-    "a",
-    {
-      on() {
-        return this;
-      },
-      off() {
-        return this;
-      },
-      addListener() {
-        return this;
-      },
-      removeListener() {
-        return this;
-      },
-      ...member,
-    } as RoomMember,
+    "remote",
+    mockMember(member),
     {
       setVolume() {},
+      getTrackPublication: () =>
+        ({}) as Partial<RemoteTrackPublication> as RemoteTrackPublication,
       on() {
         return this;
       },

--- a/src/utils/test.ts
+++ b/src/utils/test.ts
@@ -16,6 +16,13 @@ limitations under the License.
 import { map } from "rxjs";
 import { RunHelpers, TestScheduler } from "rxjs/testing";
 import { expect, vi } from "vitest";
+import { RoomMember } from "matrix-js-sdk/src/matrix";
+import { LocalParticipant, RemoteParticipant } from "livekit-client";
+
+import {
+  LocalUserMediaViewModel,
+  RemoteUserMediaViewModel,
+} from "../state/MediaViewModel";
 
 export function withFakeTimers(continuation: () => void): void {
   vi.useFakeTimers();
@@ -57,4 +64,68 @@ export function withTestScheduler(
       },
     }),
   );
+}
+
+export async function withLocalMedia(
+  continuation: (vm: LocalUserMediaViewModel) => Promise<void>,
+): Promise<void> {
+  const member = {} as unknown as RoomMember;
+  const vm = new LocalUserMediaViewModel(
+    "a",
+    member,
+    {} as Partial<LocalParticipant> as LocalParticipant,
+    true,
+  );
+  try {
+    await continuation(vm);
+  } finally {
+    vm.destroy();
+  }
+}
+
+export async function withRemoteMedia(
+  member: Partial<RoomMember>,
+  participant: Partial<RemoteParticipant>,
+  continuation: (vm: RemoteUserMediaViewModel) => Promise<void>,
+): Promise<void> {
+  const vm = new RemoteUserMediaViewModel(
+    "a",
+    {
+      on() {
+        return this;
+      },
+      off() {
+        return this;
+      },
+      addListener() {
+        return this;
+      },
+      removeListener() {
+        return this;
+      },
+      ...member,
+    } as RoomMember,
+    {
+      setVolume() {},
+      on() {
+        return this;
+      },
+      off() {
+        return this;
+      },
+      addListener() {
+        return this;
+      },
+      removeListener() {
+        return this;
+      },
+      ...participant,
+    } as RemoteParticipant,
+    true,
+  );
+  try {
+    await continuation(vm);
+  } finally {
+    vm.destroy();
+  }
 }

--- a/src/vitest.setup.ts
+++ b/src/vitest.setup.ts
@@ -37,3 +37,11 @@ Config.initDefault();
 posthog.opt_out_capturing();
 
 afterEach(cleanup);
+
+// Used by a lot of components
+window.matchMedia = global.matchMedia = (): MediaQueryList =>
+  ({
+    matches: false,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  }) as Partial<MediaQueryList> as MediaQueryList;

--- a/src/vitest.setup.ts
+++ b/src/vitest.setup.ts
@@ -13,13 +13,14 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 import "global-jsdom/register";
-import globalJsdom from "global-jsdom";
 import i18n from "i18next";
 import posthog from "posthog-js";
 import { initReactI18next } from "react-i18next";
-import { afterEach, beforeEach } from "vitest";
+import { afterEach } from "vitest";
 import { cleanup } from "@testing-library/react";
+import "vitest-axe/extend-expect";
 
 import { Config } from "./config/Config";
 
@@ -35,12 +36,4 @@ i18n.use(initReactI18next).init({
 Config.initDefault();
 posthog.opt_out_capturing();
 
-// We need to cleanup the global jsDom
-// Otherwise we will run into issues with async input test overlapping and throwing.
-
-let cleanupJsDom: { (): void };
-beforeEach(() => (cleanupJsDom = globalJsdom()));
-afterEach(() => {
-  cleanupJsDom();
-  cleanup();
-});
+afterEach(cleanup);

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -16,6 +16,7 @@ export default defineConfig((configEnv) =>
         coverage: {
           reporter: ["html", "json"],
           include: ["src/"],
+          exclude: ["src/**/*.{d,test}.{ts,tsx}", "src/utils/test.ts"],
         },
       },
     }),

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -12,7 +12,6 @@ export default defineConfig((configEnv) =>
             classNameStrategy: "non-scoped",
           },
         },
-        isolate: false,
         setupFiles: ["src/vitest.setup.ts"],
         coverage: {
           reporter: ["html", "json"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -3088,9 +3088,9 @@
   integrity sha512-PtQMG7kDzwtjw/fLKD63uWP5rJ8cgWc/aXarfEzxYUf9ceWxBajnYOBI2jDqtE3WIUe9uTVBzNEvmOBG/VIgTA==
 
 "@vector-im/compound-web@^6.0.0":
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/@vector-im/compound-web/-/compound-web-6.1.1.tgz#872ec411fce600358812fe6c868b2521b57a9a9f"
-  integrity sha512-13cw8XFtt0oqGbUS9bPlvikZoJxrU+zZoziZGE+1Xv6h4JwNHIBB8CvqVOoUfEhta4U1BHOClgV1XD/YzbZXdA==
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/@vector-im/compound-web/-/compound-web-6.1.2.tgz#3f8bbd69f2b06a2b8dd12c68df813356e5486074"
+  integrity sha512-kWOcprUsGGrGPRT9lPE3tnyGYWzNEIQSZ57BT/vMx9NX4QqT/Dpq0VhkBKm8W583NoYtxDOgSWWkvFQhyHVkWw==
   dependencies:
     "@floating-ui/react" "^0.26.9"
     "@radix-ui/react-context-menu" "^2.1.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3441,6 +3441,11 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
+axe-core@^4.7.2:
+  version "4.10.0"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.10.0.tgz#d9e56ab0147278272739a000880196cdfe113b59"
+  integrity sha512-Mr2ZakwQ7XUAjp7pAwQWRhhK8mQQ6JAaNWSjmjxil0R8BPioMtQsTLOolGYkji1rcL++3dCqZA3zWqpT+9Ew6g==
+
 axe-core@^4.9.1:
   version "4.9.1"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.9.1.tgz#fcd0f4496dad09e0c899b44f6c4bb7848da912ae"
@@ -3676,6 +3681,11 @@ chalk@^4.0.0, chalk@^4.1.0:
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
+
+chalk@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.3.0.tgz#67c20a7ebef70e7f3970a01f90fa210cb6860385"
+  integrity sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==
 
 check-error@^2.1.1:
   version "2.1.1"
@@ -5838,6 +5848,11 @@ locate-path@^6.0.0:
   integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
   dependencies:
     p-locate "^5.0.0"
+
+lodash-es@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
+  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
 
 lodash.debounce@^4.0.8:
   version "4.0.8"
@@ -8212,6 +8227,15 @@ vite@^5.0.0:
     rollup "^4.20.0"
   optionalDependencies:
     fsevents "~2.3.3"
+
+vitest-axe@^1.0.0-pre.3:
+  version "1.0.0-pre.3"
+  resolved "https://registry.yarnpkg.com/vitest-axe/-/vitest-axe-1.0.0-pre.3.tgz#0ea646c4ebe21c9b7ffb9ff3d6dff60b1c5a6124"
+  integrity sha512-vrsyixV225vMe0vGZV0aZjOYez2Pan5MxIx2RqnYnpbbRrUN2lJpQS9ong6dfF5a7BfQenR0LOD6hei3IQIPSw==
+  dependencies:
+    axe-core "^4.7.2"
+    chalk "^5.3.0"
+    lodash-es "^4.17.21"
 
 vitest@^2.0.0:
   version "2.0.5"


### PR DESCRIPTION
Since so much of this code base is made up React components, we do need to test them, and I wanted to see how easy it would be to get some automated accessibility tests with [axe](https://github.com/dequelabs/axe-core/) up and running. Along the way I discovered the reason why we were seeing funny errors in our tests (it was because I had turned off Vitest's test isolation option), and the tests I wrote also caught a [real accessibility issue](https://github.com/element-hq/compound-web/pull/246) in Compound Web.