### PR TITLE
Include the hostname of where EC is running in rageshakes

### DIFF
--- a/src/settings/submit-rageshake.ts
+++ b/src/settings/submit-rageshake.ts
@@ -181,6 +181,7 @@ export function useSubmitRageshake(): {
         body.append("installed_pwa", "false");
         body.append("touch_input", touchInput);
         body.append("call_backend", "livekit");
+        body.append("hostname", window.location.hostname);
 
         if (client) {
           const userId = client.getUserId()!;


### PR DESCRIPTION
Or, are we excluding this for privacy reasons? I would be surprised if so given that hostnames are included in other places along with the full Matrix ID.