### PR TITLE
Diagnose the missing room members situation

### DIFF
--- a/src/room/GroupCallView.tsx
+++ b/src/room/GroupCallView.tsx
@@ -85,6 +85,14 @@ export const GroupCallView: FC<Props> = ({
     };
   }, [rtcSession]);
 
+  useEffect(() => {
+    // Sanity check the room object
+    if (client.getRoom(rtcSession.room.roomId) !== rtcSession.room)
+      logger.warn(
+        `We've ended up with multiple rooms for the same ID (${rtcSession.room.roomId}). This indicates a bug in the group call loading code, and may lead to incomplete room state.`,
+      );
+  }, [client, rtcSession.room]);
+
   const { displayName, avatarUrl } = useProfile(client);
   const roomName = useRoomName(rtcSession.room);
   const roomAvatar = useRoomAvatar(rtcSession.room);

--- a/src/state/CallViewModel.ts
+++ b/src/state/CallViewModel.ts
@@ -16,7 +16,11 @@ import {
   ParticipantEvent,
   RemoteParticipant,
 } from "livekit-client";
-import { Room as MatrixRoom, RoomMember } from "matrix-js-sdk/src/matrix";
+import {
+  Room as MatrixRoom,
+  RoomMember,
+  RoomStateEvent,
+} from "matrix-js-sdk/src/matrix";
 import {
   EMPTY,
   Observable,
@@ -321,6 +325,8 @@ export class CallViewModel extends ViewModel {
     this.remoteParticipants,
     observeParticipantMedia(this.livekitRoom.localParticipant),
     duplicateTiles.value,
+    // Also react to changes in the list of members
+    fromEvent(this.matrixRoom, RoomStateEvent.Update).pipe(startWith(null)),
   ]).pipe(
     scan(
       (


### PR DESCRIPTION
We have reports from certain users that their client mistakenly thinks that people aren't in the room, displaying them as ghosts. These users are also reporting that the room name is missing. So, this sounds like there might be multiple room objects for the same room ID. Let's add a warning and a little more reactivity in order to help diagnose the situation.