### PR TITLE
Give user feedback if the rageshake submission failed

### DIFF
--- a/src/settings/FeedbackSettingsTab.tsx
+++ b/src/settings/FeedbackSettingsTab.tsx
@@ -66,9 +66,7 @@ export const FeedbackSettingsTab: FC<Props> = ({ roomId }) => {
             disabled={sending || sent}
           />
         </FieldRow>
-        {sent ? (
-          <Body> {t("settings.feedback_tab_thank_you")}</Body>
-        ) : (
+        {!sent && (
           <FieldRow>
             <InputField
               id="sendLogs"
@@ -77,16 +75,15 @@ export const FeedbackSettingsTab: FC<Props> = ({ roomId }) => {
               type="checkbox"
               defaultChecked
             />
-            {error && (
-              <FieldRow>
-                <ErrorMessage error={error} />
-              </FieldRow>
-            )}
             <Button type="submit" disabled={sending}>
               {sending ? t("submitting") : t("action.submit")}
             </Button>
           </FieldRow>
         )}
+        <FieldRow>
+          {error && <ErrorMessage error={error} />}
+          {sent && <Body> {t("settings.feedback_tab_thank_you")}</Body>}
+        </FieldRow>
       </form>
     </div>
   );

--- a/src/settings/submit-rageshake.ts
+++ b/src/settings/submit-rageshake.ts
@@ -270,10 +270,16 @@ export function useSubmitRageshake(): {
           );
         }
 
-        await fetch(Config.get().rageshake!.submit_url, {
+        const res = await fetch(Config.get().rageshake!.submit_url, {
           method: "POST",
           body,
         });
+
+        if (res.status !== 200) {
+          throw new Error(
+            `Failed to submit feedback: receive HTTP ${res.status} ${res.statusText}`,
+          );
+        }
 
         setState({ sending: false, sent: true, error: undefined });
       } catch (error) {


### PR DESCRIPTION
Otherwise it silently swallows errors like 50x.

The design isn't nice and the user might need to scroll to see the whole message.

<img width="541" alt="image" src="https://github.com/user-attachments/assets/39073327-ff1d-453b-9add-4c5d32da558e">

n.b. the screenshot doesn't show the wording but does show the revised location of the error message.