### PR TITLE
Make the links on the log in page visually consistent

### DIFF
--- a/src/auth/LoginPage.module.css
+++ b/src/auth/LoginPage.module.css
@@ -64,15 +64,6 @@ Please see LICENSE in the repository root for full details.
   flex-direction: column;
   justify-content: flex-end;
   align-items: center;
-}
-
-.authLinks {
   margin-bottom: 100px;
   font-size: var(--font-size-body);
-}
-
-.authLinks a {
-  color: var(--cpd-color-text-action-accent);
-  text-decoration: none;
-  font-weight: normal;
 }

--- a/src/auth/LoginPage.tsx
+++ b/src/auth/LoginPage.tsx
@@ -6,7 +6,7 @@ Please see LICENSE in the repository root for full details.
 */
 
 import { FC, FormEvent, useCallback, useRef, useState } from "react";
-import { useHistory, useLocation, Link } from "react-router-dom";
+import { useHistory, useLocation } from "react-router-dom";
 import { Trans, useTranslation } from "react-i18next";
 import { Button } from "@vector-im/compound-web";
 
@@ -18,6 +18,7 @@ import { useInteractiveLogin } from "./useInteractiveLogin";
 import { usePageTitle } from "../usePageTitle";
 import { PosthogAnalytics } from "../analytics/PosthogAnalytics";
 import { Config } from "../config/Config";
+import { Link } from "../button/Link";
 
 export const LoginPage: FC = () => {
   const { t } = useTranslation();


### PR DESCRIPTION
Timo was totally right in his previous review of my typography component work that these didn't have the right styling. I just didn't notice!

Before|After
-|-
![Screenshot from 2024-09-19 12-11-02](https://github.com/user-attachments/assets/8bcfd54d-1aa3-4a5b-bafe-3bacc1421204)|![Screenshot from 2024-09-19 12-10-40](https://github.com/user-attachments/assets/e4f1e47c-89ce-43ce-a364-a5f5e4e93ea3)