### PR TITLE
Set LiveKit keyring size to 256

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "i18next-parser": "^9.0.0",
     "jsdom": "^25.0.0",
     "knip": "^5.27.2",
-    "livekit-client": "^2.0.2",
+    "livekit-client": "^2.5.7",
     "lodash": "^4.17.21",
     "loglevel": "^1.9.1",
     "matrix-js-sdk": "matrix-org/matrix-js-sdk#baa6d135065637c9769c61325c69709d3618f5f1",

--- a/src/e2ee/matrixKeyProvider.ts
+++ b/src/e2ee/matrixKeyProvider.ts
@@ -16,7 +16,7 @@ export class MatrixKeyProvider extends BaseKeyProvider {
   private rtcSession?: MatrixRTCSession;
 
   public constructor() {
-    super({ ratchetWindowSize: 0 });
+    super({ ratchetWindowSize: 0, keyringSize: 256 });
   }
 
   public setRTCSession(rtcSession: MatrixRTCSession): void {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5741,7 +5741,7 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
-livekit-client@^2.0.2:
+livekit-client@^2.5.7:
   version "2.5.7"
   resolved "https://registry.yarnpkg.com/livekit-client/-/livekit-client-2.5.7.tgz#0a091a20b0c77ec4ad07d3116680ec3d4625444c"
   integrity sha512-g15/e9J9eZStQM4B7dgUP7eLAKbqJYh37n8IkR9n0M4/1ZxkyPgVvxkaooPNxp9C0Ri6cefN5uHNbyyXWUJOVw==


### PR DESCRIPTION
The default is 16 which doesn't match what we expect.

We will need to upgrade the LiveKit client before this merges because we need https://github.com/livekit/client-sdk-js/pull/1268.