### PR TITLE
Don't cause the local tile to disappear when joining

### DIFF
--- a/src/state/CallViewModel.test.ts
+++ b/src/state/CallViewModel.test.ts
@@ -199,7 +199,7 @@ test("participants are retained during a focus switch", () => {
             a: {
               type: "grid",
               spotlight: undefined,
-              grid: [":0", `${aliceId}:0`, `${bobId}:0`],
+              grid: ["local:0", `${aliceId}:0`, `${bobId}:0`],
             },
           },
         );
@@ -243,12 +243,12 @@ test("screen sharing activates spotlight layout", () => {
             a: {
               type: "grid",
               spotlight: undefined,
-              grid: [":0", `${aliceId}:0`, `${bobId}:0`],
+              grid: ["local:0", `${aliceId}:0`, `${bobId}:0`],
             },
             b: {
               type: "spotlight-landscape",
               spotlight: [`${aliceId}:0:screen-share`],
-              grid: [":0", `${aliceId}:0`, `${bobId}:0`],
+              grid: ["local:0", `${aliceId}:0`, `${bobId}:0`],
             },
             c: {
               type: "spotlight-landscape",
@@ -256,17 +256,17 @@ test("screen sharing activates spotlight layout", () => {
                 `${aliceId}:0:screen-share`,
                 `${bobId}:0:screen-share`,
               ],
-              grid: [":0", `${aliceId}:0`, `${bobId}:0`],
+              grid: ["local:0", `${aliceId}:0`, `${bobId}:0`],
             },
             d: {
               type: "spotlight-landscape",
               spotlight: [`${bobId}:0:screen-share`],
-              grid: [":0", `${aliceId}:0`, `${bobId}:0`],
+              grid: ["local:0", `${aliceId}:0`, `${bobId}:0`],
             },
             e: {
               type: "spotlight-landscape",
               spotlight: [`${aliceId}:0`],
-              grid: [":0", `${aliceId}:0`, `${bobId}:0`],
+              grid: ["local:0", `${aliceId}:0`, `${bobId}:0`],
             },
           },
         );

--- a/src/state/CallViewModel.ts
+++ b/src/state/CallViewModel.ts
@@ -335,8 +335,8 @@ export class CallViewModel extends ViewModel {
         const newItems = new Map(
           function* (this: CallViewModel): Iterable<[string, MediaItem]> {
             for (const p of [localParticipant, ...remoteParticipants]) {
-              const userMediaId = p === localParticipant ? "local" : p.identity;
-              const member = findMatrixMember(this.matrixRoom, userMediaId);
+              const id = p === localParticipant ? "local" : p.identity;
+              const member = findMatrixMember(this.matrixRoom, id);
               if (member === undefined)
                 logger.warn(
                   `Ruh, roh! No matrix member found for SFU participant '${p.identity}': creating g-g-g-ghost!`,
@@ -345,7 +345,7 @@ export class CallViewModel extends ViewModel {
               // Create as many tiles for this participant as called for by
               // the duplicateTiles option
               for (let i = 0; i < 1 + duplicateTiles; i++) {
-                const userMediaId = `${p.identity}:${i}`;
+                const userMediaId = `${id}:${i}`;
                 yield [
                   userMediaId,
                   prevItems.get(userMediaId) ??


### PR DESCRIPTION
Before you're connected to the SFU the local participant object will have the empty string as its ID. This changes to your actual ID once you've connected. Apparently I tried to fix this by forcing the local ID to always be the string 'local' but then I just forgot to use it correctly :upside_down_face: 