### PR TITLE
Bump js-sdk for MatrixRTC fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "livekit-client": "^2.5.7",
     "lodash": "^4.17.21",
     "loglevel": "^1.9.1",
-    "matrix-js-sdk": "^34.7.0",
+    "matrix-js-sdk": "matrix-org/matrix-js-sdk#0a29063bc9e61ee70ca43820d4bb91f6a27f1237",
     "matrix-widget-api": "^1.8.2",
     "normalize.css": "^8.0.1",
     "observable-hooks": "^4.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5896,10 +5896,9 @@ matrix-events-sdk@0.0.1:
   resolved "https://registry.yarnpkg.com/matrix-events-sdk/-/matrix-events-sdk-0.0.1.tgz#c8c38911e2cb29023b0bbac8d6f32e0de2c957dd"
   integrity sha512-1QEOsXO+bhyCroIe2/A5OwaxHvBm7EsSQ46DEDn8RBIfQwN5HWBpFvyWWR4QY0KHPPnnJdI99wgRiAl7Ad5qaA==
 
-matrix-js-sdk@^34.7.0:
-  version "34.7.0"
-  resolved "https://registry.yarnpkg.com/matrix-js-sdk/-/matrix-js-sdk-34.7.0.tgz#243e4eacbedd98a1096135a75765756cda910b7b"
-  integrity sha512-epauE/ZwksDyadm+0vg+g1keRUo600H/b1MzDZbaIrCY9fELzq3fIWctq9IxMQE/EEPe9jjLiNDooGJT5JJ2Ag==
+matrix-js-sdk@matrix-org/matrix-js-sdk#0a29063bc9e61ee70ca43820d4bb91f6a27f1237:
+  version "34.9.0"
+  resolved "https://codeload.github.com/matrix-org/matrix-js-sdk/tar.gz/0a29063bc9e61ee70ca43820d4bb91f6a27f1237"
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@matrix-org/matrix-sdk-crypto-wasm" "^9.0.0"


### PR DESCRIPTION
Full diff https://github.com/matrix-org/matrix-js-sdk/compare/v34.7.0...0a29063bc9e61ee70ca43820d4bb91f6a27f1237

Relevant PRs included:

- Do not rotate MatrixRTC media encryption key when a new member joins a session #4472
- Refactor/simplify Promises in MatrixRTCSession #4466
- Prepare delayed call leave events more reliably #4447
- Fix DelayedEventInfo type #4446
- Fix MatrixRTC sender key wrapping #4441