### PR TITLE
Remove duplicate media devices from the list

### DIFF
--- a/src/livekit/MediaDevicesContext.tsx
+++ b/src/livekit/MediaDevicesContext.tsx
@@ -97,7 +97,11 @@ function useMediaDevice(
     }
 
     return {
-      available: available ?? [],
+      available: available
+        ? // Sometimes browsers (particularly Firefox) can return multiple
+          // device entries for the exact same device ID; deduplicate them
+          [...new Map(available.map((d) => [d.deviceId, d])).values()]
+        : [],
       selectedId: alwaysDefault ? undefined : devId,
       select,
     };


### PR DESCRIPTION
Somehow on my system Firefox always manages to create multiple entries for my webcam. This was an easy enough thing to fix.