### PR TITLE
Update the strings on the join as guest screen

### DIFF
--- a/public/locales/en-GB/app.json
+++ b/public/locales/en-GB/app.json
@@ -91,6 +91,7 @@
   "layout_spotlight_label": "Spotlight",
   "lobby": {
     "ask_to_join": "Ask to join call",
+    "join_as_guest": "Join as guest",
     "join_button": "Join call",
     "leave_button": "Back to recents",
     "waiting_for_invite": "Request sent"
@@ -128,8 +129,8 @@
   "register_confirm_password_label": "Confirm password",
   "register_heading": "Create your account",
   "return_home_button": "Return to home screen",
-  "room_auth_view_eula_caption": "By clicking \"Join call now\", you agree to our <2>End User Licensing Agreement (EULA)</2>",
-  "room_auth_view_join_button": "Join call now",
+  "room_auth_view_continue_button": "Continue",
+  "room_auth_view_eula_caption": "By clicking \"Continue\", you agree to our <2>End User Licensing Agreement (EULA)</2>",
   "screenshare_button_label": "Share screen",
   "settings": {
     "developer_settings_label": "Developer Settings",

--- a/src/room/RoomAuthView.tsx
+++ b/src/room/RoomAuthView.tsx
@@ -64,7 +64,7 @@ export const RoomAuthView: FC = () => {
       <div className={styles.container}>
         <main className={styles.main}>
           <Heading size="xl" weight="semibold" className={styles.headline}>
-            {t("lobby.join_button")}
+            {t("lobby.join_as_guest")}
           </Heading>
           <Form className={styles.form} onSubmit={onSubmit}>
             <FieldRow>
@@ -98,7 +98,9 @@ export const RoomAuthView: FC = () => {
               disabled={loading}
               data-testid="joincall_joincall"
             >
-              {loading ? t("common.loading") : t("room_auth_view_join_button")}
+              {loading
+                ? t("common.loading")
+                : t("room_auth_view_continue_button")}
             </Button>
             <div id={recaptchaId} />
           </Form>


### PR DESCRIPTION
Hugh pointed out that the button labeled "Join call now" on this screen is misleading, because it does not join you to the call but rather send you to the lobby. Meanwhile, the designs call for this screen to use the words "Join as guest" and "Continue", so let's go with that.