### PR TITLE
Fix lobby disappearing when using a lower 550 width window on Firefox.

### DIFF
--- a/src/room/VideoPreview.module.css
+++ b/src/room/VideoPreview.module.css
@@ -66,6 +66,7 @@ video.mirror {
     margin-inline: 0;
     border-radius: 0;
     block-size: 100%;
+    width: 100%;
   }
 
   .buttonBar {


### PR DESCRIPTION
This can happen if the user is in embedded mode and uses the right panel chat + a large room list.

Happens only on Firefox.
