### PR TITLE
Ensure reactions from the same user across multiple devices shows in the correct Tile

### DIFF
--- a/src/button/ReactionToggleButton.test.tsx
+++ b/src/button/ReactionToggleButton.test.tsx
@@ -83,7 +83,7 @@ test("Can raise hand", async () => {
   expect(container).toMatchSnapshot();
 });
 
-test("Can lower hand", async () => {
+test.only("Can lower hand", async () => {
   const user = userEvent.setup();
   const room = new MockRoom(memberUserIdAlice);
   const rtcSession = new MockRTCSession(room, membership);

--- a/src/button/ReactionToggleButton.tsx
+++ b/src/button/ReactionToggleButton.tsx
@@ -223,7 +223,6 @@ export function ReactionToggleButton({
   const { t } = useTranslation();
   const { raisedHands, lowerHand, reactions } = useReactions();
   const [busy, setBusy] = useState(false);
-  const userId = client.getUserId()!;
   const memberships = useMatrixRTCSessionMemberships(rtcSession);
   const [showReactionsMenu, setShowReactionsMenu] = useState(false);
   const [errorText, setErrorText] = useState<string>();
@@ -237,6 +236,8 @@ export function ReactionToggleButton({
       ),
     [memberships],
   )?.eventId;
+
+  console.log(memberships);
 
   useEffect(() => {
     // Clear whenever the reactions menu state changes.

--- a/src/tile/GridTile.tsx
+++ b/src/tile/GridTile.tsx
@@ -112,9 +112,14 @@ const UserMediaTile = forwardRef<HTMLDivElement, UserMediaTileProps>(
       </>
     );
 
-    const handRaised: Date | undefined = raisedHands[vm.member?.userId ?? ""];
+    console.log(vm.member);
+
+    console.log(vm.member?.events.member?.getId(), raisedHands, reactions);
+
+    const handRaised: Date | undefined =
+      raisedHands[vm.member?.events.member?.getId() ?? ""];
     const currentReaction: ReactionOption | undefined =
-      reactions[vm.member?.userId ?? ""];
+      reactions[vm.member?.events.member?.getId() ?? ""];
     const raisedHandOnClick =
       vm.local && handRaised ? (): void => void lowerHand() : undefined;
 

--- a/src/useReactions.test.tsx
+++ b/src/useReactions.test.tsx
@@ -21,6 +21,7 @@ import {
 
 const memberUserIdAlice = "@alice:example.org";
 const memberEventAlice = "$membership-alice:example.org";
+const memberEventAlice2 = "$membership-alice2:example.org";
 const memberUserIdBob = "@bob:example.org";
 const memberEventBob = "$membership-bob:example.org";
 
@@ -28,6 +29,8 @@ const membership: Record<string, string> = {
   [memberEventAlice]: memberUserIdAlice,
   [memberEventBob]: memberUserIdBob,
   "$membership-charlie:example.org": "@charlie:example.org",
+  // Second device
+  [memberEventAlice2]: memberEventAlice,
 };
 
 /**
@@ -42,9 +45,9 @@ const TestComponent: FC = () => {
   return (
     <div>
       <ul>
-        {Object.entries(raisedHands).map(([userId, date]) => (
-          <li key={userId}>
-            <span>{userId}</span>
+        {Object.entries(raisedHands).map(([membershipEventId, date]) => (
+          <li key={membershipEventId}>
+            <span>{membershipEventId}</span>
             <time>{date.getTime()}</time>
           </li>
         ))}
@@ -169,5 +172,18 @@ describe("useReactions", () => {
     );
     await act(() => room.testSendHandRaise(memberEventAlice, memberUserIdBob));
     expect(queryByRole("list")?.children).to.have.lengthOf(0);
+  });
+  test("handles multiple membership event reactions for the same sender", () => {
+    const room = new MockRoom(memberUserIdAlice, [
+      createHandRaisedReaction(memberEventAlice, membership),
+      createHandRaisedReaction(memberEventAlice2, membership),
+    ]);
+    const rtcSession = new MockRTCSession(room, membership);
+    const { queryByRole } = render(
+      <TestReactionsWrapper rtcSession={rtcSession}>
+        <TestComponent />
+      </TestReactionsWrapper>,
+    );
+    expect(queryByRole("list")?.children).to.have.lengthOf(2);
   });
 });

--- a/src/useReactions.tsx
+++ b/src/useReactions.tsx
@@ -199,6 +199,8 @@ export const ReactionsProvider = ({
       if (event.getType() === ElementCallReactionEventType) {
         const content: ECallReactionEventContent = event.getContent();
 
+        console.log(latestMemberships, content);
+
         const membershipEventId = content?.["m.relates_to"]?.event_id;
         // Check to see if this reaction was made to a membership event (and the
         // sender of the reaction matches the membership)
@@ -318,19 +320,22 @@ export const ReactionsProvider = ({
     latestRaisedHands,
   ]);
 
-  const myMembershipEventId = useMemo(
-    () =>
-      memberships.find(
-        (m) =>
-          clientState?.state === "valid" &&
-          m.sender === clientState.authenticated?.client.getUserId() &&
-          m.deviceId === clientState.authenticated?.client.getDeviceId(),
-      ),
-    [memberships],
-  )?.eventId;
+  const myMembershipEventId = useMemo(() => {
+    console.log(
+      room.client.getUserId(),
+      room.client.getDeviceId(),
+      memberships,
+    );
+    return memberships.find(
+      (m) =>
+        m.sender === room.client.getUserId() &&
+        m.deviceId === room.client.getDeviceId(),
+    );
+  }, [memberships, room])?.eventId;
 
   const lowerHand = useCallback(async () => {
     if (!myMembershipEventId || !raisedHands[myMembershipEventId]) {
+      logger.warn(`No membership event for us!`, myMembershipEventId);
       return;
     }
     const myReactionId = raisedHands[myMembershipEventId].reactionEventId;

--- a/src/utils/testReactions.tsx
+++ b/src/utils/testReactions.tsx
@@ -45,6 +45,7 @@ export class MockRTCSession extends EventEmitter {
   public memberships: {
     sender: string;
     eventId: string;
+    deviceId: string;
     createdTs: () => Date;
   }[];
 
@@ -56,6 +57,7 @@ export class MockRTCSession extends EventEmitter {
     this.memberships = Object.entries(membership).map(([eventId, sender]) => ({
       sender,
       eventId,
+      deviceId: randomUUID(),
       createdTs: (): Date => new Date(),
     }));
   }
@@ -69,6 +71,7 @@ export class MockRTCSession extends EventEmitter {
     this.memberships.push({
       sender,
       eventId: `!fake-${randomUUID()}:event`,
+      deviceId: randomUUID(),
       createdTs: (): Date => new Date(),
     });
     this.emit(MatrixRTCSessionEvent.MembershipsChanged);
@@ -118,6 +121,7 @@ export class MockRoom extends EventEmitter {
 
   public constructor(
     private readonly ownUserId: string,
+    private readonly ownDeviceId: string,
     private readonly existingRelations: MatrixEvent[] = [],
   ) {
     super();
@@ -126,6 +130,7 @@ export class MockRoom extends EventEmitter {
   public get client(): MatrixClient {
     return {
       getUserId: (): string => this.ownUserId,
+      getDeviceId: (): string => this.ownDeviceId,
       sendEvent: async (
         ...props: Parameters<MatrixClient["sendEvent"]>
       ): ReturnType<MatrixClient["sendEvent"]> => {

--- a/src/utils/testReactions.tsx
+++ b/src/utils/testReactions.tsx
@@ -41,6 +41,8 @@ export const TestReactionsWrapper = ({
   );
 };
 
+const OWN_DEVICE_ID = "OWN_DEVICE";
+
 export class MockRTCSession extends EventEmitter {
   public memberships: {
     sender: string;
@@ -54,12 +56,14 @@ export class MockRTCSession extends EventEmitter {
     membership: Record<string, string>,
   ) {
     super();
-    this.memberships = Object.entries(membership).map(([eventId, sender]) => ({
-      sender,
-      eventId,
-      deviceId: randomUUID(),
-      createdTs: (): Date => new Date(),
-    }));
+    this.memberships = Object.entries(membership).map(
+      ([eventId, sender], index) => ({
+        sender,
+        eventId,
+        deviceId: index === 0 ? OWN_DEVICE_ID : randomUUID(),
+        createdTs: (): Date => new Date(),
+      }),
+    );
   }
 
   public testRemoveMember(userId: string): void {
@@ -121,7 +125,6 @@ export class MockRoom extends EventEmitter {
 
   public constructor(
     private readonly ownUserId: string,
-    private readonly ownDeviceId: string,
     private readonly existingRelations: MatrixEvent[] = [],
   ) {
     super();
@@ -130,7 +133,7 @@ export class MockRoom extends EventEmitter {
   public get client(): MatrixClient {
     return {
       getUserId: (): string => this.ownUserId,
-      getDeviceId: (): string => this.ownDeviceId,
+      getDeviceId: (): string => OWN_DEVICE_ID,
       sendEvent: async (
         ...props: Parameters<MatrixClient["sendEvent"]>
       ): ReturnType<MatrixClient["sendEvent"]> => {


### PR DESCRIPTION
This problem occurs because we mapped raised hand and reactions based upon the user's user ID. However this isn't unique and so when a reaction is sent from one device, it appears on multiple tiles.

This refactors so we use membership event IDs instead, however this isn't working yet because I haven't found a way to ID the correct GridTile for the right user.

This is going to need #2701 to work so we can hook off the membership event ID correctly.