### PR TITLE
Bump matrix-js-sdk and matrix-widget-api

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "livekit-client": "^2.5.7",
     "lodash": "^4.17.21",
     "loglevel": "^1.9.1",
-    "matrix-js-sdk": "matrix-org/matrix-js-sdk#623b40177a71a2b719762bebe51528f3d8c8ca9e",
+    "matrix-js-sdk": "matrix-org/matrix-js-sdk#6971e7bebaad643c233e5057da7a0d42441c0789",
     "matrix-widget-api": "^1.8.2",
     "normalize.css": "^8.0.1",
     "observable-hooks": "^4.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5999,9 +5999,9 @@ matrix-events-sdk@0.0.1:
   resolved "https://registry.yarnpkg.com/matrix-events-sdk/-/matrix-events-sdk-0.0.1.tgz#c8c38911e2cb29023b0bbac8d6f32e0de2c957dd"
   integrity sha512-1QEOsXO+bhyCroIe2/A5OwaxHvBm7EsSQ46DEDn8RBIfQwN5HWBpFvyWWR4QY0KHPPnnJdI99wgRiAl7Ad5qaA==
 
-matrix-js-sdk@matrix-org/matrix-js-sdk#623b40177a71a2b719762bebe51528f3d8c8ca9e:
+matrix-js-sdk@matrix-org/matrix-js-sdk#6971e7bebaad643c233e5057da7a0d42441c0789:
   version "34.10.0"
-  resolved "https://codeload.github.com/matrix-org/matrix-js-sdk/tar.gz/623b40177a71a2b719762bebe51528f3d8c8ca9e"
+  resolved "https://codeload.github.com/matrix-org/matrix-js-sdk/tar.gz/6971e7bebaad643c233e5057da7a0d42441c0789"
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@matrix-org/matrix-sdk-crypto-wasm" "^9.0.0"
@@ -6019,10 +6019,10 @@ matrix-js-sdk@matrix-org/matrix-js-sdk#623b40177a71a2b719762bebe51528f3d8c8ca9e:
     unhomoglyph "^1.0.6"
     uuid "11"
 
-matrix-widget-api@^1.8.2:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/matrix-widget-api/-/matrix-widget-api-1.9.0.tgz#884136b405bd3c56e4ea285095c9e01ec52b6b1f"
-  integrity sha512-au8mqralNDqrEvaVAkU37bXOb8I9SCe+ACdPk11QWw58FKstVq31q2wRz+qWA6J+42KJ6s1DggWbG/S3fEs3jw==
+matrix-widget-api@^1.10.0, matrix-widget-api@^1.8.2:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/matrix-widget-api/-/matrix-widget-api-1.10.0.tgz#d31ea073a5871a1fb1a511ef900b0c125a37bf55"
+  integrity sha512-rkAJ29briYV7TJnfBVLVSKtpeBrBju15JZFSDP6wj8YdbCu1bdmlplJayQ+vYaw1x4fzI49Q+Nz3E85s46sRDw==
   dependencies:
     "@types/events" "^3.0.0"
     events "^3.2.0"


### PR DESCRIPTION
This bumps matrix-js-sdk to a preview branch that includes https://github.com/matrix-org/matrix-js-sdk/pull/4498 and https://github.com/matrix-org/matrix-js-sdk/pull/4494, and matrix-widget-api to 1.10.0.