### PR TITLE
Small improvements for reaction rendering

### DIFF
--- a/src/button/ReactionToggleButton.module.css
+++ b/src/button/ReactionToggleButton.module.css
@@ -46,6 +46,16 @@
   border-radius: var(--cpd-radius-pill-effect);
 }
 
+@media (max-width: 800px) {
+  .reactionButton {
+    padding: 1em;
+    font-size: 1em;
+    width: 1em;
+    height: 1em;
+    min-block-size: unset;
+  }
+}
+
 .verticalSeperator {
   background-color: var(--cpd-color-gray-800);
   width: 1px;

--- a/src/room/InCallView.module.css
+++ b/src/room/InCallView.module.css
@@ -94,19 +94,7 @@ Please see LICENSE in the repository root for full details.
   justify-self: end;
 }
 
-@media (max-width: 660px) {
-  .footer {
-    grid-template-areas: ". buttons buttons buttons .";
-  }
 
-  .logo {
-    display: none;
-  }
-
-  .layout {
-    display: none !important;
-  }
-}
 
 @media (max-width: 370px) {
   .raiseHand {
@@ -179,49 +167,4 @@ Please see LICENSE in the repository root for full details.
 .tile.maximised {
   position: relative;
   flex-grow: 1;
-}
-
-.floatingReaction {
-  position: relative;
-  display: inline;
-  z-index: 2;
-  font-size: 32pt;
-  /* Reactions are "active" for 3 seconds (as per REACTION_ACTIVE_TIME_MS), give a bit more time for it to fade out. */
-  animation-duration: 4s;
-  animation-name: reaction-up;
-  width: fit-content;
-  pointer-events: none;
-}
-
-@keyframes reaction-up {
-  from {
-    opacity: 1;
-    translate: 100vw 0;
-    scale: 200%;
-  }
-
-  to {
-    opacity: 0;
-    translate: 100vw -100vh;
-    scale: 100%;
-  }
-}
-
-@media (prefers-reduced-motion) {
-  @keyframes reaction-up-reduced {
-    from {
-      opacity: 1;
-    }
-
-    to {
-      opacity: 0;
-    }
-  }
-
-  .floatingReaction {
-    font-size: 48pt;
-    animation-name: reaction-up-reduced;
-    top: calc(-50vh + (48pt / 2));
-    left: calc(50vw - (48pt / 2)) !important;
-  }
 }

--- a/src/room/InCallView.module.css
+++ b/src/room/InCallView.module.css
@@ -94,8 +94,6 @@ Please see LICENSE in the repository root for full details.
   justify-self: end;
 }
 
-
-
 @media (max-width: 370px) {
   .raiseHand {
     display: none;

--- a/src/room/InCallView.tsx
+++ b/src/room/InCallView.tsx
@@ -87,9 +87,9 @@ import { ReactionsAudioRenderer } from "./ReactionAudioRenderer";
 import { useSwitchCamera } from "./useSwitchCamera";
 import {
   soundEffectVolumeSetting,
-  showReactions,
   useSetting,
 } from "../settings/settings";
+import { ReactionsOverlay } from "./ReactionsOverlay";
 
 const canScreenshare = "getDisplayMedia" in (navigator.mediaDevices ?? {});
 
@@ -185,26 +185,13 @@ export const InCallView: FC<InCallViewProps> = ({
   connState,
   onShareClick,
 }) => {
-  const [shouldShowReactions] = useSetting(showReactions);
   const [soundEffectVolume] = useSetting(soundEffectVolumeSetting);
-  const { supportsReactions, raisedHands, reactions } = useReactions();
+  const { supportsReactions, raisedHands } = useReactions();
   const raisedHandCount = useMemo(
     () => Object.keys(raisedHands).length,
     [raisedHands],
   );
   const previousRaisedHandCount = useDeferredValue(raisedHandCount);
-
-  const reactionsIcons = useMemo(
-    () =>
-      shouldShowReactions
-        ? Object.entries(reactions).map(([sender, { emoji }]) => ({
-            sender,
-            emoji,
-            startX: -Math.ceil(Math.random() * 50) - 25,
-          }))
-        : [],
-    [shouldShowReactions, reactions],
-  );
 
   useWakeLock();
 
@@ -689,15 +676,7 @@ export const InCallView: FC<InCallViewProps> = ({
         <source src={handSoundMp3} type="audio/mpeg" />
       </audio>
       <ReactionsAudioRenderer />
-      {reactionsIcons.map(({ sender, emoji, startX }) => (
-        <span
-          style={{ left: `${startX}vw` }}
-          className={styles.floatingReaction}
-          key={sender}
-        >
-          {emoji}
-        </span>
-      ))}
+      <ReactionsOverlay />
       {footer}
       {layout.type !== "pip" && (
         <>

--- a/src/room/InCallView.tsx
+++ b/src/room/InCallView.tsx
@@ -85,10 +85,7 @@ import handSoundOgg from "../sound/raise_hand.ogg?url";
 import handSoundMp3 from "../sound/raise_hand.mp3?url";
 import { ReactionsAudioRenderer } from "./ReactionAudioRenderer";
 import { useSwitchCamera } from "./useSwitchCamera";
-import {
-  soundEffectVolumeSetting,
-  useSetting,
-} from "../settings/settings";
+import { soundEffectVolumeSetting, useSetting } from "../settings/settings";
 import { ReactionsOverlay } from "./ReactionsOverlay";
 
 const canScreenshare = "getDisplayMedia" in (navigator.mediaDevices ?? {});

--- a/src/room/ReactionsOverlay.module.css
+++ b/src/room/ReactionsOverlay.module.css
@@ -1,0 +1,54 @@
+.container {
+  position: absolute;
+  display: inline;
+  z-index: 2;
+  pointer-events: none;
+  width: 100vw;
+  height: 100vh;
+  left: 0;
+  top: 0;
+}
+
+.reaction {
+  font-size: 32pt;
+  /* Reactions are "active" for 3 seconds (as per REACTION_ACTIVE_TIME_MS), give a bit more time for it to fade out. */
+  animation-duration: 4s;
+  animation-name: reaction-up;
+  width: fit-content;
+  position: relative;
+  top: 80vh;
+}
+
+@keyframes reaction-up {
+  from {
+    opacity: 1;
+    translate: 0 0;
+    scale: 200%;
+    top: 80vh;
+  }
+
+  to {
+    top: 0;
+    opacity: 0;
+    scale: 100%;
+  }
+}
+
+@media (prefers-reduced-motion) {
+  @keyframes reaction-up-reduced {
+    from {
+      opacity: 1;
+    }
+
+    to {
+      opacity: 0;
+    }
+  }
+
+  .reaction {
+    font-size: 48pt;
+    animation-name: reaction-up-reduced;
+    top: calc(-50vh + (48pt / 2));
+    left: calc(50vw - (48pt / 2)) !important;
+  }
+}

--- a/src/room/ReactionsOverlay.test.tsx
+++ b/src/room/ReactionsOverlay.test.tsx
@@ -9,17 +9,15 @@ import { render } from "@testing-library/react";
 import { expect, test } from "vitest";
 import { TooltipProvider } from "@vector-im/compound-web";
 import { act, ReactNode } from "react";
+import { afterEach } from "node:test";
 
 import {
   MockRoom,
   MockRTCSession,
   TestReactionsWrapper,
 } from "../utils/testReactions";
-import {
-  showReactions,
-} from "../settings/settings";
+import { showReactions } from "../settings/settings";
 import { ReactionsOverlay } from "./ReactionsOverlay";
-import { afterEach } from "node:test";
 import { ReactionSet } from "../reactions";
 
 const memberUserIdAlice = "@alice:example.org";
@@ -49,7 +47,6 @@ function TestComponent({
   );
 }
 
-
 afterEach(() => {
   showReactions.setValue(showReactions.defaultValue);
 });
@@ -61,51 +58,51 @@ test("defaults to showing no reactions", () => {
     membership,
   );
   const { container } = render(<TestComponent rtcSession={rtcSession} />);
-  expect(container.getElementsByTagName("span")).toHaveLength(
-    0
-  );
+  expect(container.getElementsByTagName("span")).toHaveLength(0);
 });
 
 test("shows a reaction when sent", () => {
   showReactions.setValue(true);
   const reaction = ReactionSet[0];
   const room = new MockRoom(memberUserIdAlice);
-  const rtcSession = new MockRTCSession(
-    room,
-    membership,
-  );
+  const rtcSession = new MockRTCSession(room, membership);
   const { getByRole } = render(<TestComponent rtcSession={rtcSession} />);
-  act(() => room.testSendReaction(memberEventAlice, reaction, membership));
-  const span = getByRole('presentation');
-  expect(getByRole('presentation')).toBeTruthy();
+  act(() => {
+    room.testSendReaction(memberEventAlice, reaction, membership);
+  });
+  const span = getByRole("presentation");
+  expect(getByRole("presentation")).toBeTruthy();
   expect(span.innerHTML).toEqual(reaction.emoji);
 });
 
 test("shows two of the same reaction when sent", () => {
   showReactions.setValue(true);
+  const reaction = ReactionSet[0];
   const room = new MockRoom(memberUserIdAlice);
-  const rtcSession = new MockRTCSession(
-    room,
-    membership,
-  );
+  const rtcSession = new MockRTCSession(room, membership);
   const { getAllByRole } = render(<TestComponent rtcSession={rtcSession} />);
-  act(() => room.testSendReaction(memberEventAlice, ReactionSet[0], membership));
-  act(() => room.testSendReaction(memberEventBob, ReactionSet[0], membership));
-  expect(getAllByRole('presentation')).toHaveLength(2);
+  act(() => {
+    room.testSendReaction(memberEventAlice, reaction, membership);
+  });
+  act(() => {
+    room.testSendReaction(memberEventBob, reaction, membership);
+  });
+  expect(getAllByRole("presentation")).toHaveLength(2);
 });
 
 test("shows two different reactions when sent", () => {
   showReactions.setValue(true);
   const room = new MockRoom(memberUserIdAlice);
-  const rtcSession = new MockRTCSession(
-    room,
-    membership,
-  );
+  const rtcSession = new MockRTCSession(room, membership);
   const [reactionA, reactionB] = ReactionSet;
   const { getAllByRole } = render(<TestComponent rtcSession={rtcSession} />);
-  act(() => room.testSendReaction(memberEventAlice, reactionA, membership));
-  act(() => room.testSendReaction(memberEventBob, reactionB, membership));
-  const [reactionElementA, reactionElementB] = getAllByRole('presentation');
+  act(() => {
+    room.testSendReaction(memberEventAlice, reactionA, membership);
+  });
+  act(() => {
+    room.testSendReaction(memberEventBob, reactionB, membership);
+  });
+  const [reactionElementA, reactionElementB] = getAllByRole("presentation");
   expect(reactionElementA.innerHTML).toEqual(reactionA.emoji);
   expect(reactionElementB.innerHTML).toEqual(reactionB.emoji);
 });
@@ -114,13 +111,10 @@ test("hides reactions when reaction animations are disabled", () => {
   showReactions.setValue(false);
   const reaction = ReactionSet[0];
   const room = new MockRoom(memberUserIdAlice);
-  const rtcSession = new MockRTCSession(
-    room,
-    membership,
-  );
-  act(() => room.testSendReaction(memberEventAlice, reaction, membership));
+  const rtcSession = new MockRTCSession(room, membership);
+  act(() => {
+    room.testSendReaction(memberEventAlice, reaction, membership);
+  });
   const { container } = render(<TestComponent rtcSession={rtcSession} />);
-  expect(container.getElementsByTagName("span")).toHaveLength(
-    0
-  );
+  expect(container.getElementsByTagName("span")).toHaveLength(0);
 });

--- a/src/room/ReactionsOverlay.test.tsx
+++ b/src/room/ReactionsOverlay.test.tsx
@@ -1,0 +1,126 @@
+/*
+Copyright 2024 New Vector Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only
+Please see LICENSE in the repository root for full details.
+*/
+
+import { render } from "@testing-library/react";
+import { expect, test } from "vitest";
+import { TooltipProvider } from "@vector-im/compound-web";
+import { act, ReactNode } from "react";
+
+import {
+  MockRoom,
+  MockRTCSession,
+  TestReactionsWrapper,
+} from "../utils/testReactions";
+import {
+  showReactions,
+} from "../settings/settings";
+import { ReactionsOverlay } from "./ReactionsOverlay";
+import { afterEach } from "node:test";
+import { ReactionSet } from "../reactions";
+
+const memberUserIdAlice = "@alice:example.org";
+const memberUserIdBob = "@bob:example.org";
+const memberUserIdCharlie = "@charlie:example.org";
+const memberEventAlice = "$membership-alice:example.org";
+const memberEventBob = "$membership-bob:example.org";
+const memberEventCharlie = "$membership-charlie:example.org";
+
+const membership: Record<string, string> = {
+  [memberEventAlice]: memberUserIdAlice,
+  [memberEventBob]: memberUserIdBob,
+  [memberEventCharlie]: memberUserIdCharlie,
+};
+
+function TestComponent({
+  rtcSession,
+}: {
+  rtcSession: MockRTCSession;
+}): ReactNode {
+  return (
+    <TooltipProvider>
+      <TestReactionsWrapper rtcSession={rtcSession}>
+        <ReactionsOverlay />
+      </TestReactionsWrapper>
+    </TooltipProvider>
+  );
+}
+
+
+afterEach(() => {
+  showReactions.setValue(showReactions.defaultValue);
+});
+
+test("defaults to showing no reactions", () => {
+  showReactions.setValue(true);
+  const rtcSession = new MockRTCSession(
+    new MockRoom(memberUserIdAlice),
+    membership,
+  );
+  const { container } = render(<TestComponent rtcSession={rtcSession} />);
+  expect(container.getElementsByTagName("span")).toHaveLength(
+    0
+  );
+});
+
+test("shows a reaction when sent", () => {
+  showReactions.setValue(true);
+  const reaction = ReactionSet[0];
+  const room = new MockRoom(memberUserIdAlice);
+  const rtcSession = new MockRTCSession(
+    room,
+    membership,
+  );
+  const { getByRole } = render(<TestComponent rtcSession={rtcSession} />);
+  act(() => room.testSendReaction(memberEventAlice, reaction, membership));
+  const span = getByRole('presentation');
+  expect(getByRole('presentation')).toBeTruthy();
+  expect(span.innerHTML).toEqual(reaction.emoji);
+});
+
+test("shows two of the same reaction when sent", () => {
+  showReactions.setValue(true);
+  const room = new MockRoom(memberUserIdAlice);
+  const rtcSession = new MockRTCSession(
+    room,
+    membership,
+  );
+  const { getAllByRole } = render(<TestComponent rtcSession={rtcSession} />);
+  act(() => room.testSendReaction(memberEventAlice, ReactionSet[0], membership));
+  act(() => room.testSendReaction(memberEventBob, ReactionSet[0], membership));
+  expect(getAllByRole('presentation')).toHaveLength(2);
+});
+
+test("shows two different reactions when sent", () => {
+  showReactions.setValue(true);
+  const room = new MockRoom(memberUserIdAlice);
+  const rtcSession = new MockRTCSession(
+    room,
+    membership,
+  );
+  const [reactionA, reactionB] = ReactionSet;
+  const { getAllByRole } = render(<TestComponent rtcSession={rtcSession} />);
+  act(() => room.testSendReaction(memberEventAlice, reactionA, membership));
+  act(() => room.testSendReaction(memberEventBob, reactionB, membership));
+  const [reactionElementA, reactionElementB] = getAllByRole('presentation');
+  expect(reactionElementA.innerHTML).toEqual(reactionA.emoji);
+  expect(reactionElementB.innerHTML).toEqual(reactionB.emoji);
+});
+
+test("hides reactions when reaction animations are disabled", () => {
+  showReactions.setValue(false);
+  const reaction = ReactionSet[0];
+  const room = new MockRoom(memberUserIdAlice);
+  const rtcSession = new MockRTCSession(
+    room,
+    membership,
+  );
+  act(() => room.testSendReaction(memberEventAlice, reaction, membership));
+  const { container } = render(<TestComponent rtcSession={rtcSession} />);
+  expect(container.getElementsByTagName("span")).toHaveLength(
+    0
+  );
+});

--- a/src/room/ReactionsOverlay.tsx
+++ b/src/room/ReactionsOverlay.tsx
@@ -1,0 +1,50 @@
+/*
+Copyright 2024 New Vector Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only
+Please see LICENSE in the repository root for full details.
+*/
+
+import { ReactNode, useMemo } from "react";
+
+import { useReactions } from "../useReactions";
+import {
+  showReactions as showReactionsSetting,
+  useSetting,
+} from "../settings/settings";
+import styles from "./ReactionsOverlay.module.css";
+
+export function ReactionsOverlay(): ReactNode {
+  const { reactions } = useReactions();
+  const [showReactions] = useSetting(showReactionsSetting);
+  const reactionsIcons = useMemo(
+    () =>
+      showReactions
+        ? Object.entries(reactions).map(([sender, { emoji }]) => ({
+            sender,
+            emoji,
+            startX: Math.ceil(Math.random() * 80) + 10,
+          }))
+        : [],
+    [showReactions, reactions],
+  );
+
+  return (
+    <div className={styles.container}>
+      {reactionsIcons.map(({ sender, emoji, startX }) => (
+        <span
+          // Reactions effects are considered presentation elements. The reaction
+          // is also present on the sender's tile, which assistive technology can
+          // read from instead.
+          role="presentation"
+          style={{ left: `${startX}vw` }}
+          className={styles.reaction}
+          // A sender can only send one emoji at a time.
+          key={sender}
+        >
+          {emoji}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/src/useReactions.tsx
+++ b/src/useReactions.tsx
@@ -62,7 +62,7 @@ interface RaisedHandInfo {
   time: Date;
 }
 
-const REACTION_ACTIVE_TIME_MS = 90000;
+const REACTION_ACTIVE_TIME_MS = 3000;
 
 export const useReactions = (): ReactionsContextType => {
   const context = useContext(ReactionsContext);

--- a/src/useReactions.tsx
+++ b/src/useReactions.tsx
@@ -62,7 +62,7 @@ interface RaisedHandInfo {
   time: Date;
 }
 
-const REACTION_ACTIVE_TIME_MS = 3000;
+const REACTION_ACTIVE_TIME_MS = 90000;
 
 export const useReactions = (): ReactionsContextType => {
   const context = useContext(ReactionsContext);


### PR DESCRIPTION
This fixes:

- Reactions bumping the layout in 1:1 view. The reactions are now in a container component.
- Reaction buttons should now scale down on smaller viewports.

This also should bump the test coverage a smidge, as this tests reaction rendering in the new class.