### PR TITLE
Explicitly bump matrix-widget-api

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "lodash": "^4.17.21",
     "loglevel": "^1.9.1",
     "matrix-js-sdk": "matrix-org/matrix-js-sdk#fcb69b16ad8d170c67ea844f83543d467bbd7707",
-    "matrix-widget-api": "^1.8.2",
+    "matrix-widget-api": "^1.10.0",
     "normalize.css": "^8.0.1",
     "observable-hooks": "^4.2.3",
     "pako": "^2.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6019,7 +6019,7 @@ matrix-js-sdk@matrix-org/matrix-js-sdk#fcb69b16ad8d170c67ea844f83543d467bbd7707:
     unhomoglyph "^1.0.6"
     uuid "11"
 
-matrix-widget-api@^1.8.2:
+matrix-widget-api@^1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/matrix-widget-api/-/matrix-widget-api-1.10.0.tgz#d31ea073a5871a1fb1a511ef900b0c125a37bf55"
   integrity sha512-rkAJ29briYV7TJnfBVLVSKtpeBrBju15JZFSDP6wj8YdbCu1bdmlplJayQ+vYaw1x4fzI49Q+Nz3E85s46sRDw==


### PR DESCRIPTION
Was already present in yarn.lock