### PR TITLE
Bump matrix-js-sdk for MSC4222 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "livekit-client": "^2.5.7",
     "lodash": "^4.17.21",
     "loglevel": "^1.9.1",
-    "matrix-js-sdk": "matrix-org/matrix-js-sdk#fcb69b16ad8d170c67ea844f83543d467bbd7707",
+    "matrix-js-sdk": "matrix-org/matrix-js-sdk#8e9a04cdec0f88fc876bbbf406db55b0677f005d",
     "matrix-widget-api": "^1.10.0",
     "normalize.css": "^8.0.1",
     "observable-hooks": "^4.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6017,9 +6017,9 @@ matrix-events-sdk@0.0.1:
   resolved "https://registry.yarnpkg.com/matrix-events-sdk/-/matrix-events-sdk-0.0.1.tgz#c8c38911e2cb29023b0bbac8d6f32e0de2c957dd"
   integrity sha512-1QEOsXO+bhyCroIe2/A5OwaxHvBm7EsSQ46DEDn8RBIfQwN5HWBpFvyWWR4QY0KHPPnnJdI99wgRiAl7Ad5qaA==
 
-matrix-js-sdk@matrix-org/matrix-js-sdk#fcb69b16ad8d170c67ea844f83543d467bbd7707:
+matrix-js-sdk@matrix-org/matrix-js-sdk#8e9a04cdec0f88fc876bbbf406db55b0677f005d:
   version "34.10.0"
-  resolved "https://codeload.github.com/matrix-org/matrix-js-sdk/tar.gz/fcb69b16ad8d170c67ea844f83543d467bbd7707"
+  resolved "https://codeload.github.com/matrix-org/matrix-js-sdk/tar.gz/8e9a04cdec0f88fc876bbbf406db55b0677f005d"
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@matrix-org/matrix-sdk-crypto-wasm" "^9.0.0"


### PR DESCRIPTION
This bumps matrix-js-sdk to a branch https://github.com/matrix-org/matrix-js-sdk/tree/element-call-nov-preview that includes

- https://github.com/matrix-org/matrix-js-sdk/pull/4487
- https://github.com/matrix-org/matrix-js-sdk/pull/4498 (which is what the commit ref was pointing to previously as of https://github.com/element-hq/element-call/pull/2756)

in addition to everything we've gotten merged so far into develop. A smoke test indicates that the MSC4222 support appears to be working fine.