### PR TITLE
Decrypt potential reaction events before checking their type

### DIFF
--- a/src/useReactions.tsx
+++ b/src/useReactions.tsx
@@ -195,11 +195,12 @@ export const ReactionsProvider = ({
       // Skip any event without a sender or event ID.
       if (!sender || !reactionEventId) return;
 
+      room.client
+        .decryptEventIfNeeded(event)
+        .catch((e) => logger.warn(`Failed to decrypt ${event.getId()}`, e));
+      if (event.isBeingDecrypted() || event.isDecryptionFailure()) return;
+
       if (event.getType() === ElementCallReactionEventType) {
-        room.client
-          .decryptEventIfNeeded(event)
-          .catch((e) => logger.warn(`Failed to decrypt ${event.getId()}`, e));
-        if (event.isBeingDecrypted() || event.isDecryptionFailure()) return;
         const content: ECallReactionEventContent = event.getContent();
 
         const membershipEventId = content?.["m.relates_to"]?.event_id;


### PR DESCRIPTION
By rights, this fix I had made to decrypt reaction events shouldn't have appeared successful, because I was requiring the event to have a certain type before asking matrix-js-sdk to decrypt it, and you can't know an event's type before it's decrypted. Probably what was happening is that another code path was requesting the events to be decrypted so that this mistake didn't matter.