### PR TITLE
Sound effect volume adjustment & tooltip

### DIFF
--- a/src/Slider.tsx
+++ b/src/Slider.tsx
@@ -10,6 +10,7 @@ import { Root, Track, Range, Thumb } from "@radix-ui/react-slider";
 import classNames from "classnames";
 
 import styles from "./Slider.module.css";
+import { Tooltip } from "@vector-im/compound-web";
 
 interface Props {
   className?: string;
@@ -66,7 +67,10 @@ export const Slider: FC<Props> = ({
       <Track className={styles.track}>
         <Range className={styles.highlight} />
       </Track>
-      <Thumb className={styles.handle} aria-label={label} />
+      {/* Note: This is expected not to be visible on mobile.*/}
+      <Tooltip placement="top" label={Math.round(value * 100).toString() + "%"}>
+        <Thumb className={styles.handle} aria-label={label} />
+      </Tooltip>
     </Root>
   );
 };

--- a/src/Slider.tsx
+++ b/src/Slider.tsx
@@ -8,9 +8,9 @@ Please see LICENSE in the repository root for full details.
 import { FC, useCallback } from "react";
 import { Root, Track, Range, Thumb } from "@radix-ui/react-slider";
 import classNames from "classnames";
+import { Tooltip } from "@vector-im/compound-web";
 
 import styles from "./Slider.module.css";
-import { Tooltip } from "@vector-im/compound-web";
 
 interface Props {
   className?: string;

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -102,7 +102,7 @@ export const playReactionsSound = new Setting<boolean>(
 
 export const soundEffectVolumeSetting = new Setting<number>(
   "sound-effect-volume",
-  1,
+  0.5,
 );
 
 export const alwaysShowSelf = new Setting<boolean>("always-show-self", true);


### PR DESCRIPTION
Fixes #2760 

This should reduce the noise of sound effects by default, and adds a tooltip to sliders which means you can actually gauge how loud the volume is.