### PR TITLE
Backfill hand raised events once client has synced.

### DIFF
--- a/src/useReactions.test.tsx
+++ b/src/useReactions.test.tsx
@@ -5,7 +5,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 Please see LICENSE in the repository root for full details.
 */
 
-import { render } from "@testing-library/react";
+import { findByRole, getByRole, render } from "@testing-library/react";
 import { act, FC } from "react";
 import { describe, expect, test } from "vitest";
 import { RoomEvent } from "matrix-js-sdk/src/matrix";
@@ -43,7 +43,7 @@ const TestComponent: FC = () => {
     <div>
       <ul>
         {Object.entries(raisedHands).map(([userId, date]) => (
-          <li key={userId}>
+          <li role="listitem" key={userId}>
             <span>{userId}</span>
             <time>{date.getTime()}</time>
           </li>
@@ -106,12 +106,12 @@ describe("useReactions", () => {
       createHandRaisedReaction(memberEventAlice, membership),
     ]);
     const rtcSession = new MockRTCSession(room, membership);
-    const { queryByRole } = render(
+    const { findByRole } = render(
       <TestReactionsWrapper rtcSession={rtcSession}>
         <TestComponent />
       </TestReactionsWrapper>,
     );
-    expect(queryByRole("list")?.children).to.have.lengthOf(1);
+    expect(findByRole("listitem")).toBeTruthy();
   });
   // If the membership event changes for a user, we want to remove
   // the raised hand event.
@@ -120,12 +120,12 @@ describe("useReactions", () => {
       createHandRaisedReaction(memberEventAlice, membership),
     ]);
     const rtcSession = new MockRTCSession(room, membership);
-    const { queryByRole } = render(
+    const { findByRole, queryByRole } = render(
       <TestReactionsWrapper rtcSession={rtcSession}>
         <TestComponent />
       </TestReactionsWrapper>,
     );
-    expect(queryByRole("list")?.children).to.have.lengthOf(1);
+    expect(findByRole("listitem")).toBeTruthy();
     act(() => rtcSession.testRemoveMember(memberUserIdAlice));
     expect(queryByRole("list")?.children).to.have.lengthOf(0);
   });
@@ -134,12 +134,12 @@ describe("useReactions", () => {
       createHandRaisedReaction(memberEventAlice, membership),
     ]);
     const rtcSession = new MockRTCSession(room, membership);
-    const { queryByRole } = render(
+    const { queryByRole, findByRole } = render(
       <TestReactionsWrapper rtcSession={rtcSession}>
         <TestComponent />
       </TestReactionsWrapper>,
     );
-    expect(queryByRole("list")?.children).to.have.lengthOf(1);
+    expect(findByRole("listitem")).toBeTruthy();
     // Simulate leaving and rejoining
     act(() => {
       rtcSession.testRemoveMember(memberUserIdAlice);

--- a/src/useReactions.tsx
+++ b/src/useReactions.tsx
@@ -143,7 +143,6 @@ export const ReactionsProvider = ({
         );
         allEvents = res.chunk.map((e) => new MatrixEvent(e));
       }
-
       return allEvents.find(
         (reaction) =>
           reaction.event.sender === expectedSender &&

--- a/src/useReactions.tsx
+++ b/src/useReactions.tsx
@@ -133,7 +133,7 @@ export const ReactionsProvider = ({
         EventType.Reaction,
       );
       let allEvents = relations?.getRelations() ?? [];
-      // We might not have synced this far.
+      // If we found no relations for this event, fetch via fetchRelations.
       if (allEvents.length === 0) {
         const res = await room.client.fetchRelations(
           room.roomId,

--- a/src/utils/testReactions.tsx
+++ b/src/utils/testReactions.tsx
@@ -139,6 +139,7 @@ export class MockRoom extends EventEmitter {
         return Promise.resolve({ event_id: randomUUID() });
       },
       decryptEventIfNeeded: async () => {},
+      fetchRelations: async () => Promise.resolve({ chunk: [] }),
       on() {
         return this;
       },


### PR DESCRIPTION
~~I *think* there is a race here where we might try to fetch reactions before the local state of the room has been synced, leading to missing hand raised reactions on newly joining clients to the room.~~

The easier solution here is to call `fetchRelations` on the client once we are ready, which will fetch any events in the case that we can't find the reaction we expect.