### PR TITLE
Load the Intl.Segmenter and Intl.DurationFormat polyfills only if needed

### DIFF
--- a/src/@types/global.d.ts
+++ b/src/@types/global.d.ts
@@ -6,6 +6,7 @@ Please see LICENSE in the repository root for full details.
 */
 
 import "matrix-js-sdk/src/@types/global";
+import type { DurationFormat as PolyfillDurationFormat } from "@formatjs/intl-durationformat";
 import { Controls } from "../controls";
 
 declare global {
@@ -22,5 +23,10 @@ declare global {
   interface HTMLElement {
     // Safari only supports this prefixed, so tell the type system about it
     webkitRequestFullscreen: () => void;
+  }
+
+  namespace Intl {
+    // Add DurationFormat as part of the Intl namespace because we polyfill it
+    const DurationFormat: typeof PolyfillDurationFormat;
   }
 }

--- a/src/initializer.test.ts
+++ b/src/initializer.test.ts
@@ -9,9 +9,9 @@ import { expect, test } from "vitest";
 
 import { Initializer } from "../src/initializer";
 
-test("initBeforeReact sets font family from URL param", () => {
+test("initBeforeReact sets font family from URL param", async () => {
   window.location.hash = "#?font=DejaVu Sans";
-  Initializer.initBeforeReact();
+  await Initializer.initBeforeReact();
   expect(
     getComputedStyle(document.documentElement).getPropertyValue(
       "--font-family",
@@ -19,9 +19,9 @@ test("initBeforeReact sets font family from URL param", () => {
   ).toBe('"DejaVu Sans"');
 });
 
-test("initBeforeReact sets font scale from URL param", () => {
+test("initBeforeReact sets font scale from URL param", async () => {
   window.location.hash = "#?fontScale=1.2";
-  Initializer.initBeforeReact();
+  await Initializer.initBeforeReact();
   expect(
     getComputedStyle(document.documentElement).getPropertyValue("--font-scale"),
   ).toBe("1.2");

--- a/src/initializer.tsx
+++ b/src/initializer.tsx
@@ -12,6 +12,7 @@ import Backend from "i18next-http-backend";
 import * as Sentry from "@sentry/react";
 import { logger } from "matrix-js-sdk/src/logger";
 import { shouldPolyfill as shouldPolyfillSegmenter } from "@formatjs/intl-segmenter/should-polyfill";
+import { shouldPolyfill as shouldPolyfillDurationFormat } from "@formatjs/intl-durationformat/should-polyfill";
 
 import { getUrlParams } from "./UrlParams";
 import { Config } from "./config/Config";
@@ -43,9 +44,16 @@ export class Initializer {
   }
 
   public static async initBeforeReact(): Promise<void> {
+    const polyfills: Promise<unknown>[] = [];
     if (shouldPolyfillSegmenter()) {
-      await import("@formatjs/intl-segmenter/polyfill-force");
+      polyfills.push(import("@formatjs/intl-segmenter/polyfill-force"));
     }
+
+    if (shouldPolyfillDurationFormat()) {
+      polyfills.push(import("@formatjs/intl-durationformat/polyfill-force"));
+    }
+
+    await Promise.all(polyfills);
 
     //i18n
     const languageDetector = new LanguageDetector();

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -20,7 +20,6 @@ import {
   setLogExtension as setLKLogExtension,
   setLogLevel as setLKLogLevel,
 } from "livekit-client";
-import "@formatjs/intl-durationformat/polyfill";
 
 import { App } from "./App";
 import { init as initRageshake } from "./settings/rageshake";

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -20,7 +20,6 @@ import {
   setLogExtension as setLKLogExtension,
   setLogLevel as setLKLogLevel,
 } from "livekit-client";
-import "@formatjs/intl-segmenter/polyfill";
 import "@formatjs/intl-durationformat/polyfill";
 
 import { App } from "./App";
@@ -57,12 +56,17 @@ if (fatalError !== null) {
   throw fatalError; // Stop the app early
 }
 
-Initializer.initBeforeReact();
+Initializer.initBeforeReact()
+  .then(() => {
+    const history = createBrowserHistory();
 
-const history = createBrowserHistory();
-
-root.render(
-  <StrictMode>
-    <App history={history} />
-  </StrictMode>,
-);
+    root.render(
+      <StrictMode>
+        <App history={history} />
+      </StrictMode>,
+    );
+  })
+  .catch((e) => {
+    logger.error("Failed to initialize app", e);
+    root.render(e.message);
+  });

--- a/src/reactions/RaisedHandIndicator.tsx
+++ b/src/reactions/RaisedHandIndicator.tsx
@@ -12,12 +12,11 @@ import {
   useEffect,
   useState,
 } from "react";
-import { DurationFormat } from "@formatjs/intl-durationformat";
 import { useTranslation } from "react-i18next";
 
 import { ReactionIndicator } from "./ReactionIndicator";
 
-const durationFormatter = new DurationFormat(undefined, {
+const durationFormatter = new Intl.DurationFormat(undefined, {
   minutesDisplay: "always",
   secondsDisplay: "always",
   hoursDisplay: "auto",

--- a/src/reactions/RaisedHandIndicator.tsx
+++ b/src/reactions/RaisedHandIndicator.tsx
@@ -11,17 +11,11 @@ import {
   useCallback,
   useEffect,
   useState,
+  useMemo,
 } from "react";
 import { useTranslation } from "react-i18next";
 
 import { ReactionIndicator } from "./ReactionIndicator";
-
-const durationFormatter = new Intl.DurationFormat(undefined, {
-  minutesDisplay: "always",
-  secondsDisplay: "always",
-  hoursDisplay: "auto",
-  style: "digital",
-});
 
 export function RaisedHandIndicator({
   raisedHandTime,
@@ -36,6 +30,17 @@ export function RaisedHandIndicator({
 }): ReactNode {
   const { t } = useTranslation();
   const [raisedHandDuration, setRaisedHandDuration] = useState("");
+
+  const durationFormatter = useMemo(
+    () =>
+      new Intl.DurationFormat(undefined, {
+        minutesDisplay: "always",
+        secondsDisplay: "always",
+        hoursDisplay: "auto",
+        style: "digital",
+      }),
+    [],
+  );
 
   const clickCallback = useCallback<MouseEventHandler<HTMLButtonElement>>(
     (event) => {
@@ -68,7 +73,7 @@ export function RaisedHandIndicator({
     calculateTime();
     const to = setInterval(calculateTime, 1000);
     return (): void => clearInterval(to);
-  }, [setRaisedHandDuration, raisedHandTime, showTimer]);
+  }, [setRaisedHandDuration, raisedHandTime, showTimer, durationFormatter]);
 
   if (!raisedHandTime) {
     return;

--- a/src/vitest.setup.ts
+++ b/src/vitest.setup.ts
@@ -16,6 +16,7 @@ import { cleanup } from "@testing-library/react";
 import "vitest-axe/extend-expect";
 import { logger } from "matrix-js-sdk/src/logger";
 
+import EN_GB from "../public/locales/en-GB/app.json";
 import { Config } from "./config/Config";
 
 // Bare-minimum i18n config
@@ -24,6 +25,13 @@ i18n
   .init({
     lng: "en-GB",
     fallbackLng: "en-GB",
+    supportedLngs: ["en-GB"],
+    // We embed the translations, so that it never needs to fetch
+    resources: {
+      "en-GB": {
+        app: EN_GB,
+      },
+    },
     interpolation: {
       escapeValue: false, // React has built-in XSS protections
     },

--- a/src/vitest.setup.ts
+++ b/src/vitest.setup.ts
@@ -6,6 +6,8 @@ Please see LICENSE in the repository root for full details.
 */
 
 import "global-jsdom/register";
+import "@formatjs/intl-durationformat/polyfill";
+import "@formatjs/intl-segmenter/polyfill";
 import i18n from "i18next";
 import posthog from "posthog-js";
 import { initReactI18next } from "react-i18next";


### PR DESCRIPTION
This removes around 200Kb of the main bundle.

It will still load the polyfill if needed (notably the previous Firefox ESR), but skips on modern browsers.
