### PR TITLE
Send 'Vary: Content-Encoding' header from nginx

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -4,6 +4,7 @@ server {
 
     root   /app;
     gzip_static on;
+    gzip_vary on;
 
     location / {
         try_files $uri $uri/ /index.html;


### PR DESCRIPTION
Looks like it's not the default. This makes it so that nginx sends `Vary: Accept-Encoding` header to the client.
If we don't do this, Cloudflare will cache the first response with that particular encoding, and not care about the subsequent responses.
