### PR TITLE
Pre-fetch the config.json to improve startup time

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -8,7 +8,7 @@ server {
 
     location / {
         try_files $uri $uri/ /index.html;
-        add_header Cache-Control "no-store, no-cache, must-revalidate";
+        add_header Cache-Control "public, max-age=30, stale-while-revalidate=30";
     }
 
     # assets can be cached because they have hashed filenames

--- a/public/index.html
+++ b/public/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="favicon.png" />
+    <link rel="preload" href="/config.json" as="fetch" />
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1.0, maximum-scale=1.0"

--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -28,11 +28,11 @@ export class Config {
       const internalInstance = new Config();
       Config.internalInstance = internalInstance;
 
-      Config.internalInstance.initPromise = downloadConfig(
-        "../config.json",
-      ).then((config) => {
-        internalInstance.config = merge({}, DEFAULT_CONFIG, config);
-      });
+      Config.internalInstance.initPromise = downloadConfig("/config.json").then(
+        (config) => {
+          internalInstance.config = merge({}, DEFAULT_CONFIG, config);
+        },
+      );
     }
     return Config.internalInstance.initPromise;
   }
@@ -74,11 +74,7 @@ async function downloadConfig(
   configJsonFilename: string,
 ): Promise<ConfigOptions> {
   const url = new URL(configJsonFilename, window.location.href);
-  url.searchParams.set("cachebuster", Date.now().toString());
-  const res = await fetch(url, {
-    cache: "no-cache",
-    method: "GET",
-  });
+  const res = await fetch(url);
 
   if (!res.ok || res.status === 404 || res.status === 0) {
     // Lack of a config isn't an error, we should just use the defaults.


### PR DESCRIPTION
This does three things:

 - remove the ?cachebuster from the config URL, we instead rely on having correct cache headers
 - add a link rel=preload for the config file in the index.html
 - adjust the default cache-control to use a 'stale-while-revalidate' strategy. This way, the CDN and the browser will cache the index.html and the config.json for a short time, ensuring that we always get the latest version, but still allowing us to pre-fetch the config file.

The difference is most noticeable when the assets are already cached by the browser, as loading the app is basically two requests away: one for the index.html, which immediately triggers the preload, so we don't have to wait for the JS to be parsed and executed for that.

Comparison waterfall with the app already cached in both cases:

<img width="1030" alt="image" src="https://github.com/user-attachments/assets/f325f9eb-8de1-4cda-bedd-c79d96bd55ac">

Notice how the config.json is loaded way earlier, and therefore unblocks loading of other resources
