### PR TITLE
Remove redundant distinctUntilChanged

### DIFF
--- a/src/state/CallViewModel.ts
+++ b/src/state/CallViewModel.ts
@@ -260,7 +260,6 @@ class UserMedia {
         ),
       ),
       startWith(false),
-      distinctUntilChanged(),
       // Make this Observable hot so that the timers don't reset when you
       // resubscribe
       this.scope.state(),


### PR DESCRIPTION
Because this.scope.state() does this for us anyhow.