### PR TITLE
Rxjs subjects should not be exposed

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -37,6 +37,7 @@ module.exports = {
     "@typescript-eslint/promise-function-async": "error",
     "@typescript-eslint/require-await": "error",
     "@typescript-eslint/await-thenable": "error",
+    "rxjs/no-exposed-subjects": "error",
   },
   settings: {
     react: {


### PR DESCRIPTION
This rule will encourage us to do the right thing and better abstract.

See https://github.com/cartant/eslint-plugin-rxjs/blob/main/docs/rules/no-exposed-subjects.md