### PR TITLE
Disambiguate between types of "member"

### DIFF
--- a/src/state/CallViewModel.test.ts
+++ b/src/state/CallViewModel.test.ts
@@ -30,7 +30,7 @@ import {
   mockLivekitRoom,
   mockLocalParticipant,
   mockMatrixRoom,
-  mockMember,
+  mockMatrixRoomMember,
   mockRemoteParticipant,
   withTestScheduler,
 } from "../utils/test";
@@ -42,10 +42,10 @@ import { E2eeType } from "../e2ee/e2eeType";
 
 vi.mock("@livekit/components-core");
 
-const alice = mockMember({ userId: "@alice:example.org" });
-const bob = mockMember({ userId: "@bob:example.org" });
-const carol = mockMember({ userId: "@carol:example.org" });
-const dave = mockMember({ userId: "@dave:example.org" });
+const alice = mockMatrixRoomMember({ userId: "@alice:example.org" });
+const bob = mockMatrixRoomMember({ userId: "@bob:example.org" });
+const carol = mockMatrixRoomMember({ userId: "@carol:example.org" });
+const dave = mockMatrixRoomMember({ userId: "@dave:example.org" });
 
 const aliceId = `${alice.userId}:AAAA`;
 const bobId = `${bob.userId}:BBBB`;

--- a/src/state/CallViewModel.ts
+++ b/src/state/CallViewModel.ts
@@ -307,7 +307,7 @@ class ScreenShare {
 
 type MediaItem = UserMedia | ScreenShare;
 
-function findMatrixMember(
+function findMatrixRoomMember(
   room: MatrixRoom,
   id: string,
 ): RoomMember | undefined {
@@ -419,7 +419,7 @@ export class CallViewModel extends ViewModel {
           function* (this: CallViewModel): Iterable<[string, MediaItem]> {
             for (const p of [localParticipant, ...remoteParticipants]) {
               const id = p === localParticipant ? "local" : p.identity;
-              const member = findMatrixMember(this.matrixRoom, id);
+              const member = findMatrixRoomMember(this.matrixRoom, id);
               if (member === undefined)
                 logger.warn(
                   `Ruh, roh! No matrix member found for SFU participant '${p.identity}': creating g-g-g-ghost!`,

--- a/src/utils/test.ts
+++ b/src/utils/test.ts
@@ -99,7 +99,7 @@ function mockEmitter<T>(): EmitterMock<T> {
 // Maybe it'd be good to move this to matrix-js-sdk? Our testing needs are
 // rather simple, but if one util to mock a member is good enough for us, maybe
 // it's useful for matrix-js-sdk consumers in general.
-export function mockMember(member: Partial<RoomMember>): RoomMember {
+export function mockMatrixRoomMember(member: Partial<RoomMember>): RoomMember {
   return { ...mockEmitter(), ...member } as RoomMember;
 }
 
@@ -149,7 +149,7 @@ export async function withLocalMedia(
   const localParticipant = mockLocalParticipant({});
   const vm = new LocalUserMediaViewModel(
     "local",
-    mockMember(member),
+    mockMatrixRoomMember(member),
     localParticipant,
     {
       kind: E2eeType.PER_PARTICIPANT,
@@ -184,7 +184,7 @@ export async function withRemoteMedia(
   const remoteParticipant = mockRemoteParticipant(participant);
   const vm = new RemoteUserMediaViewModel(
     "remote",
-    mockMember(member),
+    mockMatrixRoomMember(member),
     remoteParticipant,
     {
       kind: E2eeType.PER_PARTICIPANT,


### PR DESCRIPTION
We have Matrix room members and MatrixRTC session memberships. Livekit also has rooms.

So, this attempts to make it more obvious as to what type you are referring to.