### PR TITLE
Don't trigger keyboard shortcuts if modifiers are held

### DIFF
--- a/src/useCallViewKeyboardShortcuts.test.tsx
+++ b/src/useCallViewKeyboardShortcuts.test.tsx
@@ -93,6 +93,16 @@ test("reactions can be sent via keyboard presses", async () => {
   }
 });
 
+test("reaction is not sent when modifier key is held", async () => {
+  const user = userEvent.setup();
+
+  const sendReaction = vi.fn();
+  render(<TestComponent sendReaction={sendReaction} />);
+
+  await user.keyboard("{Meta>}1{/Meta}");
+  expect(sendReaction).not.toHaveBeenCalled();
+});
+
 test("raised hand can be sent via keyboard presses", async () => {
   const user = userEvent.setup();
 

--- a/src/useCallViewKeyboardShortcuts.ts
+++ b/src/useCallViewKeyboardShortcuts.ts
@@ -43,6 +43,8 @@ export function useCallViewKeyboardShortcuts(
       (event: KeyboardEvent) => {
         if (focusElement.current === null) return;
         if (!mayReceiveKeyEvents(focusElement.current)) return;
+        if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey)
+          return;
 
         if (event.key === "m") {
           event.preventDefault();


### PR DESCRIPTION
None of these keyboard shortcuts expect modifier keys, so they should in fact expect the absence of modifiers.

Closes https://github.com/element-hq/element-call/issues/2824