### PR TITLE
Fix wrong hand raise margins in pip tile.

### DIFF
--- a/src/reactions/ReactionIndicator.module.css
+++ b/src/reactions/ReactionIndicator.module.css
@@ -1,6 +1,6 @@
 .reactionIndicatorWidget {
   display: flex;
-  /* background-color: var(--cpd-color-bg-subtle-primary); */
+  background-color: #00000050;
   border-radius: var(--cpd-radius-pill-effect);
   box-shadow: 0 0 var(--cpd-space-2x) #00000040;
   background: "ffffff40";
@@ -14,12 +14,15 @@
   margin-top: auto;
   margin-bottom: auto;
   width: 3em;
+  padding-right: var(--cpd-space-2x);
+  margin-left: calc(var(--cpd-space-2x) * -1);
 }
 
 .reactionIndicatorWidgetLarge > p {
   padding: var(--cpd-space-2x);
   padding-right: var(--cpd-space-4x);
   padding-left: 0;
+  margin-left: 0;
 }
 
 .reactionLarge {
@@ -31,13 +34,11 @@
 .reaction {
   margin: var(--cpd-space-1x);
   color: var(--cpd-color-icon-secondary);
-  /* background-color: var(--cpd-color-icon-secondary); */
   display: flex;
   align-items: center;
   border-radius: var(--cpd-radius-pill-effect);
   user-select: none;
   overflow: hidden;
-  /* box-shadow: var(--small-drop-shadow); */
   box-sizing: border-box;
   max-inline-size: 100%;
   max-width: fit-content;


### PR DESCRIPTION
This also darkens the background of the pill a bit to improve accessibility.

![image](https://github.com/user-attachments/assets/56cbc66d-d7bd-4b2d-b81c-6664e0beb6e4)

![Screenshot from 2024-11-27 21-23-20](https://github.com/user-attachments/assets/0ca5a876-b735-4d39-ae6b-88e2e96fd86a)
