### PR TITLE
Fix Cache-Control header for docker images

### DIFF
--- a/config/httpd.conf
+++ b/config/httpd.conf
@@ -5,7 +5,7 @@
 
     <Location "/">
         # disable cache entriely by default (apart from Etag which is accurate enough)
-        Header add Cache-Control "private no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0"
+        Header add Cache-Control "private, no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0"
         CacheDisable on
         ExpiresActive off
 


### PR DESCRIPTION
I don't know what clients would do at present, but `private` and `no-store` are distinct directives.