### PR TITLE
Wait for .well-known/matrix/client to load before determining MatrixRTC foci

### DIFF
--- a/src/rtcSessionHelper.test.ts
+++ b/src/rtcSessionHelper.test.ts
@@ -40,7 +40,7 @@ test("It joins the correct Session", async () => {
     room: {
       roomId: "roomId",
       client: {
-        getClientWellKnown: vi.fn().mockReturnValue(clientWellKnown),
+        waitForClientWellKnown: vi.fn().mockResolvedValue(clientWellKnown),
       },
     },
     memberships: [],

--- a/src/rtcSessionHelpers.ts
+++ b/src/rtcSessionHelpers.ts
@@ -44,8 +44,9 @@ async function makePreferredLivekitFoci(
   }
 
   // Prioritize the client well known over the configured sfu.
-  const wellKnownFoci =
-    rtcSession.room.client.getClientWellKnown()?.[FOCI_WK_KEY];
+  const wellKnownFoci = (
+    await rtcSession.room.client.waitForClientWellKnown()
+  )?.[FOCI_WK_KEY];
   if (Array.isArray(wellKnownFoci)) {
     preferredFoci.push(
       ...wellKnownFoci


### PR DESCRIPTION
Otherwise we might not be populating `foci_preferred` as expected.