### PR TITLE
Revert "Wait for .well-known/matrix/client to load before determining MatrixRTC foci"

### DIFF
--- a/src/rtcSessionHelper.test.ts
+++ b/src/rtcSessionHelper.test.ts
@@ -40,7 +40,7 @@ test("It joins the correct Session", async () => {
     room: {
       roomId: "roomId",
       client: {
-        waitForClientWellKnown: vi.fn().mockResolvedValue(clientWellKnown),
+        getClientWellKnown: vi.fn().mockReturnValue(clientWellKnown),
       },
     },
     memberships: [],

--- a/src/rtcSessionHelpers.ts
+++ b/src/rtcSessionHelpers.ts
@@ -44,9 +44,8 @@ async function makePreferredLivekitFoci(
   }
 
   // Prioritize the client well known over the configured sfu.
-  const wellKnownFoci = (
-    await rtcSession.room.client.waitForClientWellKnown()
-  )?.[FOCI_WK_KEY];
+  const wellKnownFoci =
+    rtcSession.room.client.getClientWellKnown()?.[FOCI_WK_KEY];
   if (Array.isArray(wellKnownFoci)) {
     preferredFoci.push(
       ...wellKnownFoci


### PR DESCRIPTION
Reverts element-hq/element-call#2901
This caused it to fail in widget mode. It is still the right thing we should do, but it needs more testing.
Since this breaks all `.dev` widget users we revert this until we find a way to get this working in widget mode.