### PR TITLE
Bump matrix-js-sdk for bundle improvements

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1961,10 +1961,10 @@
   dependencies:
     "@bufbuild/protobuf" "^1.10.0"
 
-"@matrix-org/matrix-sdk-crypto-wasm@^11.0.0":
-  version "11.0.0"
-  resolved "https://registry.yarnpkg.com/@matrix-org/matrix-sdk-crypto-wasm/-/matrix-sdk-crypto-wasm-11.0.0.tgz#c49a1a0d1e367d3c00a2144a4ab23caee0b1eec2"
-  integrity sha512-a7NUH8Kjc8hwzNCPpkOGXoceFqWJiWvA8OskXeDrKyODJuDz4yKrZ/nvgaVRfQe45Ab5UC1ZXYqaME+ChlJuqg==
+"@matrix-org/matrix-sdk-crypto-wasm@^12.0.0":
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/@matrix-org/matrix-sdk-crypto-wasm/-/matrix-sdk-crypto-wasm-12.0.0.tgz#e3a5150ccbb21d5e98ee3882e7057b9f17fb962a"
+  integrity sha512-nkkXAxUIk9UTso4TbU6Bgqsv/rJShXQXRx0ti/W+AWXHJ2HoH4sL5LsXkc7a8yYGn8tyXqxGPsYA1UeHqLwm0Q==
 
 "@matrix-org/olm@3.2.15":
   version "3.2.15"
@@ -6568,10 +6568,10 @@ matrix-events-sdk@0.0.1:
 
 matrix-js-sdk@matrix-org/matrix-js-sdk#develop:
   version "34.13.0"
-  resolved "https://codeload.github.com/matrix-org/matrix-js-sdk/tar.gz/d1de32ea2773df4c6f8a956678bbd19b6d022475"
+  resolved "https://codeload.github.com/matrix-org/matrix-js-sdk/tar.gz/e4182eb75227c283a18704727021e99ced72868d"
   dependencies:
     "@babel/runtime" "^7.12.5"
-    "@matrix-org/matrix-sdk-crypto-wasm" "^11.0.0"
+    "@matrix-org/matrix-sdk-crypto-wasm" "^12.0.0"
     "@matrix-org/olm" "3.2.15"
     another-json "^0.2.0"
     bs58 "^6.0.0"


### PR DESCRIPTION
Brings in updated version of matrix-sdk-crypto-wasm which helps to reduce bundle size and lazy loading.

Full diff https://github.com/matrix-org/matrix-js-sdk/compare/d1de32ea2773df4c6f8a956678bbd19b6d022475...e4182eb75227c283a18704727021e99ced72868d