### PR TITLE
Remember previous mute states when devices disappear and reappear

### DIFF
--- a/src/room/MuteStates.ts
+++ b/src/room/MuteStates.ts
@@ -57,8 +57,9 @@ function useMuteState(
   enabledByDefault: () => boolean,
 ): MuteState {
   const [enabled, setEnabled] = useReactiveState<boolean | undefined>(
+    // Determine the default value once devices are actually connected
     (prev) =>
-      device.available.size > 0 ? (prev ?? enabledByDefault()) : undefined,
+      prev ?? (device.available.size > 0 ? enabledByDefault() : undefined),
     [device],
   );
   return useMemo(


### PR DESCRIPTION
Actions such as opening the settings modal can cause the app to think that all media devices were just unplugged and then plugged back in. The app should remember the previous mute states in this case.

Closes https://github.com/element-hq/element-call/issues/2956