### PR TITLE
Prevent new devices from automatically starting unmuted in call

### DIFF
--- a/src/room/GroupCallView.test.tsx
+++ b/src/room/GroupCallView.test.tsx
@@ -118,6 +118,7 @@ function createGroupCallView(widget: WidgetHelpers | null): {
         skipLobby={false}
         hideHeader={true}
         rtcSession={rtcSession as unknown as MatrixRTCSession}
+        isJoined
         muteStates={muteState}
         widget={widget}
       />

--- a/src/room/GroupCallView.tsx
+++ b/src/room/GroupCallView.tsx
@@ -46,7 +46,6 @@ import {
 } from "../livekit/MediaDevicesContext";
 import { useMatrixRTCSessionMemberships } from "../useMatrixRTCSessionMemberships";
 import { enterRTCSession, leaveRTCSession } from "../rtcSessionHelpers";
-import { useMatrixRTCSessionJoinState } from "../useMatrixRTCSessionJoinState";
 import { useRoomEncryptionSystem } from "../e2ee/sharedKeyManagement";
 import { useRoomAvatar } from "./useRoomAvatar";
 import { useRoomName } from "./useRoomName";
@@ -74,6 +73,7 @@ interface Props {
   skipLobby: boolean;
   hideHeader: boolean;
   rtcSession: MatrixRTCSession;
+  isJoined: boolean;
   muteStates: MuteStates;
   widget: WidgetHelpers | null;
 }
@@ -86,11 +86,11 @@ export const GroupCallView: FC<Props> = ({
   skipLobby,
   hideHeader,
   rtcSession,
+  isJoined,
   muteStates,
   widget,
 }) => {
   const memberships = useMatrixRTCSessionMemberships(rtcSession);
-  const isJoined = useMatrixRTCSessionJoinState(rtcSession);
   const leaveSoundContext = useLatest(
     useAudioContext({
       sounds: callEventAudioSounds,

--- a/src/room/MuteStates.ts
+++ b/src/room/MuteStates.ts
@@ -74,17 +74,17 @@ function useMuteState(
   );
 }
 
-export function useMuteStates(): MuteStates {
+export function useMuteStates(isJoined: boolean): MuteStates {
   const devices = useMediaDevices();
 
   const { skipLobby } = useUrlParams();
 
   const audio = useMuteState(devices.audioInput, () => {
-    return Config.get().media_devices.enable_audio && !skipLobby;
+    return Config.get().media_devices.enable_audio && !skipLobby && !isJoined;
   });
   const video = useMuteState(
     devices.videoInput,
-    () => Config.get().media_devices.enable_video && !skipLobby,
+    () => Config.get().media_devices.enable_video && !skipLobby && !isJoined,
   );
 
   useEffect(() => {

--- a/src/room/RoomPage.tsx
+++ b/src/room/RoomPage.tsx
@@ -40,6 +40,7 @@ import { useOptInAnalytics } from "../settings/settings";
 import { Config } from "../config/Config";
 import { Link } from "../button/Link";
 import { ErrorView } from "../ErrorView";
+import { useMatrixRTCSessionJoinState } from "../useMatrixRTCSessionJoinState";
 
 export const RoomPage: FC = () => {
   const {
@@ -66,7 +67,10 @@ export const RoomPage: FC = () => {
   const { avatarUrl, displayName: userDisplayName } = useProfile(client);
 
   const groupCallState = useLoadGroupCall(client, roomIdOrAlias, viaServers);
-  const muteStates = useMuteStates();
+  const isJoined = useMatrixRTCSessionJoinState(
+    groupCallState.kind === "loaded" ? groupCallState.rtcSession : undefined,
+  );
+  const muteStates = useMuteStates(isJoined);
 
   useEffect(() => {
     // If we've finished loading, are not already authed and we've been given a display name as
@@ -111,6 +115,7 @@ export const RoomPage: FC = () => {
             widget={widget}
             client={client!}
             rtcSession={groupCallState.rtcSession}
+            isJoined={isJoined}
             isPasswordlessUser={passwordlessUser}
             confineToRoom={confineToRoom}
             preload={preload}


### PR DESCRIPTION
If the user plugs in a new media device mid-call, we don't want to enable it without user input.

Closes https://github.com/element-hq/element-call/issues/2958