### PR TITLE
Do run build workflow/action in CI when GHA workflows change

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,12 +6,14 @@ on:
       - opened
       - labeled
     paths-ignore:
-      - ".github/**"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/CODEOWNERS"
       - "docs/**"
   push:
     branches: [livekit, full-mesh]
     paths-ignore:
-      - ".github/**"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/CODEOWNERS"
       - "docs/**"
 jobs:
   build_element_call:


### PR DESCRIPTION
I'm not sure what was originally intended to be excluded. It seems to have been introduced by https://github.com/element-hq/element-call/commit/c578bcaf9143c384b3e05e14aba9ba96ee258ceb 🤷 