### PR TITLE
Fix screenshare displayname displaying as [👻]

### DIFF
--- a/src/state/CallViewModel.ts
+++ b/src/state/CallViewModel.ts
@@ -602,7 +602,7 @@ export class CallViewModel extends ViewModel {
                         this.encryptionSystem,
                         this.livekitRoom,
                         this.memberDisplaynames$.pipe(
-                          map((m) => m.get(livekitParticipantId) ?? "[👻]"),
+                          map((m) => m.get(matrixIdentifier) ?? "[👻]"),
                         ),
                       ),
                   ];


### PR DESCRIPTION
I think this must have gotten missed during one of my refactors.