### PR TITLE
Resolve version clash in matrix-widget-api dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "lodash-es": "^4.17.21",
     "loglevel": "^1.9.1",
     "matrix-js-sdk": "^36.1.0",
-    "matrix-widget-api": "1.10.0",
+    "matrix-widget-api": "1.11.0",
     "normalize.css": "^8.0.1",
     "observable-hooks": "^4.2.3",
     "pako": "^2.0.4",
@@ -120,6 +120,6 @@
     "vitest-axe": "^1.0.0-pre.3"
   },
   "resolutions": {
-    "matrix-widget-api": "1.10.0"
+    "matrix-widget-api": "1.11.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "lodash-es": "^4.17.21",
     "loglevel": "^1.9.1",
     "matrix-js-sdk": "^36.1.0",
-    "matrix-widget-api": "^1.10.0",
+    "matrix-widget-api": "1.11.0",
     "normalize.css": "^8.0.1",
     "observable-hooks": "^4.2.3",
     "pako": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -118,5 +118,8 @@
     "vite-plugin-svgr": "^4.0.0",
     "vitest": "^3.0.0",
     "vitest-axe": "^1.0.0-pre.3"
+  },
+  "resolutions": {
+    "matrix-widget-api": "1.10.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "lodash-es": "^4.17.21",
     "loglevel": "^1.9.1",
     "matrix-js-sdk": "^36.1.0",
-    "matrix-widget-api": "1.11.0",
+    "matrix-widget-api": "1.10.0",
     "normalize.css": "^8.0.1",
     "observable-hooks": "^4.2.3",
     "pako": "^2.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6338,18 +6338,18 @@ matrix-js-sdk@^36.1.0:
     unhomoglyph "^1.0.6"
     uuid "11"
 
-matrix-widget-api@^1.10.0:
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/matrix-widget-api/-/matrix-widget-api-1.13.0.tgz#40344b264b08d6d98ab9d547a41eb74dd6d8c3f7"
-  integrity sha512-+LrvwkR1izL4h2euX8PDrvG/3PZZDEd6As+lmnR3jAVwbFJtU5iTnwmZGnCca9ddngCvXvAHkcpJBEPyPTZneQ==
+matrix-widget-api@1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/matrix-widget-api/-/matrix-widget-api-1.10.0.tgz#d31ea073a5871a1fb1a511ef900b0c125a37bf55"
+  integrity sha512-rkAJ29briYV7TJnfBVLVSKtpeBrBju15JZFSDP6wj8YdbCu1bdmlplJayQ+vYaw1x4fzI49Q+Nz3E85s46sRDw==
   dependencies:
     "@types/events" "^3.0.0"
     events "^3.2.0"
 
-matrix-widget-api@^1.11.0:
-  version "1.13.1"
-  resolved "https://registry.yarnpkg.com/matrix-widget-api/-/matrix-widget-api-1.13.1.tgz#5b1caeed2fc58148bcd2984e0546d2d06a1713ad"
-  integrity sha512-mkOHUVzaN018TCbObfGOSaMW2GoUxOfcxNNlTVx5/HeMk3OSQPQM0C9oEME5Liiv/dBUoSrEB64V8wF7e/gb1w==
+matrix-widget-api@^1.10.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/matrix-widget-api/-/matrix-widget-api-1.13.0.tgz#40344b264b08d6d98ab9d547a41eb74dd6d8c3f7"
+  integrity sha512-+LrvwkR1izL4h2euX8PDrvG/3PZZDEd6As+lmnR3jAVwbFJtU5iTnwmZGnCca9ddngCvXvAHkcpJBEPyPTZneQ==
   dependencies:
     "@types/events" "^3.0.0"
     events "^3.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6338,10 +6338,10 @@ matrix-js-sdk@^36.1.0:
     unhomoglyph "^1.0.6"
     uuid "11"
 
-matrix-widget-api@1.10.0, matrix-widget-api@^1.10.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/matrix-widget-api/-/matrix-widget-api-1.10.0.tgz#d31ea073a5871a1fb1a511ef900b0c125a37bf55"
-  integrity sha512-rkAJ29briYV7TJnfBVLVSKtpeBrBju15JZFSDP6wj8YdbCu1bdmlplJayQ+vYaw1x4fzI49Q+Nz3E85s46sRDw==
+matrix-widget-api@1.11.0, matrix-widget-api@^1.10.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/matrix-widget-api/-/matrix-widget-api-1.11.0.tgz#2f548b11a7c0df789d5d4fdb5cc9ef7af8aef3da"
+  integrity sha512-ED/9hrJqDWVLeED0g1uJnYRhINh3ZTquwurdM+Hc8wLVJIQ8G/r7A7z74NC+8bBIHQ1Jo7i1Uq5CoJp/TzFYrA==
   dependencies:
     "@types/events" "^3.0.0"
     events "^3.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6346,6 +6346,14 @@ matrix-widget-api@^1.10.0:
     "@types/events" "^3.0.0"
     events "^3.2.0"
 
+matrix-widget-api@^1.11.0:
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/matrix-widget-api/-/matrix-widget-api-1.13.1.tgz#5b1caeed2fc58148bcd2984e0546d2d06a1713ad"
+  integrity sha512-mkOHUVzaN018TCbObfGOSaMW2GoUxOfcxNNlTVx5/HeMk3OSQPQM0C9oEME5Liiv/dBUoSrEB64V8wF7e/gb1w==
+  dependencies:
+    "@types/events" "^3.0.0"
+    events "^3.2.0"
+
 merge2@^1.3.0, merge2@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6338,18 +6338,10 @@ matrix-js-sdk@^36.1.0:
     unhomoglyph "^1.0.6"
     uuid "11"
 
-matrix-widget-api@1.10.0:
+matrix-widget-api@1.10.0, matrix-widget-api@^1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/matrix-widget-api/-/matrix-widget-api-1.10.0.tgz#d31ea073a5871a1fb1a511ef900b0c125a37bf55"
   integrity sha512-rkAJ29briYV7TJnfBVLVSKtpeBrBju15JZFSDP6wj8YdbCu1bdmlplJayQ+vYaw1x4fzI49Q+Nz3E85s46sRDw==
-  dependencies:
-    "@types/events" "^3.0.0"
-    events "^3.2.0"
-
-matrix-widget-api@^1.10.0:
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/matrix-widget-api/-/matrix-widget-api-1.13.0.tgz#40344b264b08d6d98ab9d547a41eb74dd6d8c3f7"
-  integrity sha512-+LrvwkR1izL4h2euX8PDrvG/3PZZDEd6As+lmnR3jAVwbFJtU5iTnwmZGnCca9ddngCvXvAHkcpJBEPyPTZneQ==
   dependencies:
     "@types/events" "^3.0.0"
     events "^3.2.0"


### PR DESCRIPTION
https://github.com/element-hq/element-call/pull/2967 introduced a version clash in our usage of matrix-widget-api and ended up running two version of matrix-widget-api.

We fix this by pinning matrix-widget-api to a version that matrix-js-sdk can use. Specifically v1.11.0