### PR TITLE
Remove version resolution for "matrix-widget-api"

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "lodash-es": "^4.17.21",
     "loglevel": "^1.9.1",
     "matrix-js-sdk": "^36.1.0",
-    "matrix-widget-api": "1.11.0",
+    "matrix-widget-api": "^1.13.1",
     "normalize.css": "^8.0.1",
     "observable-hooks": "^4.2.3",
     "pako": "^2.0.4",
@@ -118,8 +118,5 @@
     "vite-plugin-svgr": "^4.0.0",
     "vitest": "^3.0.0",
     "vitest-axe": "^1.0.0-pre.3"
-  },
-  "resolutions": {
-    "matrix-widget-api": "1.11.0"
   }
 }


### PR DESCRIPTION
This resolution was done because of: https://github.com/element-hq/element-call/pull/2967#issuecomment-2635728948 (broken es because it advocated the `UPDATE_STATE` widget-api version.

In the longer term we dont need it.

This can be merged only after we use a js-sdk version that is compatible with the `UPDATE_STATE` widget capaibility.

Blocked on: https://github.com/matrix-org/matrix-js-sdk/pull/4662