### PR TITLE
Bump JS SDK to temp version without my membership

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "livekit-client": "^2.5.7",
     "lodash-es": "^4.17.21",
     "loglevel": "^1.9.1",
-    "matrix-js-sdk": "^36.1.0",
+    "matrix-js-sdk": "github:matrix-org/matrix-js-sdk#2ce2bbc053803c258ebd9cb0bf8aad180d826075",
     "matrix-widget-api": "1.11.0",
     "normalize.css": "^8.0.1",
     "observable-hooks": "^4.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1763,10 +1763,10 @@
   dependencies:
     "@bufbuild/protobuf" "^1.10.0"
 
-"@matrix-org/matrix-sdk-crypto-wasm@^12.1.0":
-  version "12.1.0"
-  resolved "https://registry.yarnpkg.com/@matrix-org/matrix-sdk-crypto-wasm/-/matrix-sdk-crypto-wasm-12.1.0.tgz#2aef64eab2d30c0a1ace9c0fe876f53aa2949f14"
-  integrity sha512-NhJFu/8FOGjnW7mDssRUzaMSwXrYOcCqgAjZyAw9KQ9unNADKEi7KoIKe7GtrG2PWtm36y2bUf+hB8vhSY6Wdw==
+"@matrix-org/matrix-sdk-crypto-wasm@^13.0.0":
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/@matrix-org/matrix-sdk-crypto-wasm/-/matrix-sdk-crypto-wasm-13.0.0.tgz#658bed951e4c8a06a6dd545575a79cf32022d4ba"
+  integrity sha512-2gtpjnxL42sdJAgkwitpMMI4cw7Gcjf5sW0MXoe+OAlXPlxIzyM+06F5JJ8ENvBeHkuV2RqtFIRrh8i90HLsMw==
 
 "@matrix-org/olm@3.2.15":
   version "3.2.15"
@@ -6317,13 +6317,12 @@ matrix-events-sdk@0.0.1:
   resolved "https://registry.yarnpkg.com/matrix-events-sdk/-/matrix-events-sdk-0.0.1.tgz#c8c38911e2cb29023b0bbac8d6f32e0de2c957dd"
   integrity sha512-1QEOsXO+bhyCroIe2/A5OwaxHvBm7EsSQ46DEDn8RBIfQwN5HWBpFvyWWR4QY0KHPPnnJdI99wgRiAl7Ad5qaA==
 
-matrix-js-sdk@^36.1.0:
+"matrix-js-sdk@github:matrix-org/matrix-js-sdk#2ce2bbc053803c258ebd9cb0bf8aad180d826075":
   version "36.1.0"
-  resolved "https://registry.yarnpkg.com/matrix-js-sdk/-/matrix-js-sdk-36.1.0.tgz#3685a85c0c1adf4e2c3622bce76c11430963f23d"
-  integrity sha512-KNPswMSAGKDxBybJedxRpWadaRes9paxmjTCUsQT8t1Jg3ZENraAt6ynIaxh6PxazAH9D5ly6EYKHaLMLbZ1Dg==
+  resolved "https://codeload.github.com/matrix-org/matrix-js-sdk/tar.gz/2ce2bbc053803c258ebd9cb0bf8aad180d826075"
   dependencies:
     "@babel/runtime" "^7.12.5"
-    "@matrix-org/matrix-sdk-crypto-wasm" "^12.1.0"
+    "@matrix-org/matrix-sdk-crypto-wasm" "^13.0.0"
     "@matrix-org/olm" "3.2.15"
     another-json "^0.2.0"
     bs58 "^6.0.0"


### PR DESCRIPTION
resending.

Full diff: https://github.com/matrix-org/matrix-js-sdk/compare/v36.1.0...2ce2bbc053803c258ebd9cb0bf8aad180d826075