### PR TITLE
Actually hide the header on error pages

### DIFF
--- a/src/FullScreenView.tsx
+++ b/src/FullScreenView.tsx
@@ -30,10 +30,14 @@ export const FullScreenView: FC<FullScreenViewProps> = ({
   const { hideHeader } = useUrlParams();
   return (
     <div className={classNames(styles.page, className)}>
-      <Header>
-        <LeftNav>{!hideHeader && <HeaderLogo />}</LeftNav>
-        <RightNav />
-      </Header>
+      {!hideHeader && (
+        <Header>
+          <LeftNav>
+            <HeaderLogo />
+          </LeftNav>
+          <RightNav />
+        </Header>
+      )}
       <div className={styles.container}>
         <div className={styles.content}>{children}</div>
       </div>


### PR DESCRIPTION
Currently, if you set `hideHeader` to true, you get a big empty \<header\> on error pages which serves no purpose except to push the screen's content off center.