### PR TITLE
Prevent PRs with the X-Blocked label from being merged

### DIFF
--- a/.github/workflows/blocked.yaml
+++ b/.github/workflows/blocked.yaml
@@ -1,0 +1,17 @@
+name: Prevent blocked
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled]
+jobs:
+  prevent-blocked:
+    name: Prevent blocked
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Add notice
+        uses: actions/github-script@v7
+        if: contains(github.event.pull_request.labels.*.name, 'X-Blocked')
+        with:
+          script: |
+            core.setFailed("PR has been labeled with X-Blocked; it cannot be merged.");


### PR DESCRIPTION
Copied from [matrix-js-sdk](https://github.com/matrix-org/matrix-js-sdk/blob/develop/.github/workflows/pull_request.yaml#L31)
For https://github.com/element-hq/voip-internal/issues/303