### PR TITLE
Patch for v0.7: Send a 'close' action when the widget is ready to close

### DIFF
--- a/src/rtcSessionHelpers.ts
+++ b/src/rtcSessionHelpers.ts
@@ -135,7 +135,20 @@ const widgetPostHangupProcedure = async (
   // We send the hangup event after the memberships have been updated
   // calling leaveRTCSession.
   // We need to wait because this makes the client hosting this widget killing the IFrame.
-  await widget.api.transport.send(ElementWidgetActions.HangupCall, {});
+  try {
+    await widget.api.transport.send(ElementWidgetActions.HangupCall, {});
+  } catch (e) {
+    logger.error("Failed to send hangup action", e);
+  }
+  // To make the hangup procedure behave more similarly to what future versions
+  // of Element Call will do, we additionally send a close action (even though
+  // we're not yet employing the distinction between 'hangup' and 'close' to
+  // display error screens)
+  try {
+    await widget.api.transport.send(ElementWidgetActions.Close, {});
+  } catch (e) {
+    logger.error("Failed to send close action", e);
+  }
 };
 
 export async function leaveRTCSession(

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -17,10 +17,11 @@ import { getUrlParams } from "./UrlParams";
 import { Config } from "./config/Config";
 import { ElementCallReactionEventType } from "./reactions";
 
-// Subset of the actions in matrix-react-sdk
+// Subset of the actions in element-web
 export enum ElementWidgetActions {
   JoinCall = "io.element.join",
   HangupCall = "im.vector.hangup",
+  Close = "io.element.close",
   TileLayout = "io.element.tile_layout",
   SpotlightLayout = "io.element.spotlight_layout",
   // This can be sent as from or to widget


### PR DESCRIPTION
This is a watered-down version of the changes in 832a5aaf5732aa6aaa07f9bacc741ddc961def0b which should be suitable as a patch to the v0.7 release series. It makes Element Call widgets send a 'close' action in addition to the original 'hangup' action, and nothing more.

The point is that we can then deploy this change to call.element.io with little effort so that clients are more immediately free to expect a 'close' action from Element Call (and thus we unblock https://github.com/element-hq/element-call/issues/2955 and https://github.com/element-hq/element-web/issues/29196).

For https://github.com/element-hq/voip-internal/issues/304