### PR TITLE
Send a 'join' action when entering the call

### DIFF
--- a/src/rtcSessionHelpers.ts
+++ b/src/rtcSessionHelpers.ts
@@ -124,6 +124,13 @@ export async function enterRTCSession(
       makeKeyDelay: matrixRtcSessionConfig?.key_rotation_on_leave_delay,
     },
   );
+  if (widget) {
+    try {
+      await widget.api.transport.send(ElementWidgetActions.JoinCall, {});
+    } catch (e) {
+      logger.error("Failed to send join action", e);
+    }
+  }
 }
 
 const widgetPostHangupProcedure = async (


### PR DESCRIPTION
Following https://github.com/element-hq/element-call/pull/3011, this is one more upgrade to the widget communication that I'd like to make within this release cycle.

The motivating issue is https://github.com/element-hq/element-web/issues/29429. Fundamentally, without a 'join' action, the only info Element Web can use to determine whether it's joined the call is whether a MatrixRTC membership exists. But membership state events can inaccurately represent the client's actual state (whether because delayed events aren't supported, or because the delayed event hasn't timed out yet), so I suggest we send a 'join' action here just as we do in the [Element Web Jitsi wrapper](https://github.com/element-hq/element-web/blob/e9a3625bd6e9a64f216e3caeabca66f48b649332/src/vector/jitsi/index.ts#L503) to let Element Web tap directly into the widget's local state. (This will need additional Element Web changes, but is certainly backwards compatible.)

If this sounds good, I would backport this change to the `release-v0.7.2` branch as well to simplify the rollout of the Element Web changes.