### PR TITLE
Backport "Send a 'join' action when entering the call" to v0.7

### DIFF
--- a/src/rtcSessionHelpers.ts
+++ b/src/rtcSessionHelpers.ts
@@ -116,6 +116,13 @@ export async function enterRTCSession(
       makeKeyDelay: matrixRtcSessionConfig?.key_rotation_on_leave_delay,
     },
   );
+  if (widget) {
+    try {
+      await widget.api.transport.send(ElementWidgetActions.JoinCall, {});
+    } catch (e) {
+      logger.error("Failed to send join action", e);
+    }
+  }
 }
 
 const widgetPostHangupProcedure = async (


### PR DESCRIPTION
This backports https://github.com/element-hq/element-call/pull/3055 to the [patch release](https://github.com/element-hq/voip-internal/issues/304), so that our clients (really just Element Web) are free to expect a 'join' action soon.