### PR TITLE
Backport "Avoid closing the widget in returnToLobby mode" to v0.7

### DIFF
--- a/src/rtcSessionHelpers.ts
+++ b/src/rtcSessionHelpers.ts
@@ -17,6 +17,7 @@ import {
 import { PosthogAnalytics } from "./analytics/PosthogAnalytics";
 import { Config } from "./config/Config";
 import { ElementWidgetActions, WidgetHelpers, widget } from "./widget";
+import { getUrlParams } from "./UrlParams";
 
 const FOCI_WK_KEY = "org.matrix.msc4143.rtc_foci";
 
@@ -144,10 +145,12 @@ const widgetPostHangupProcedure = async (
   // of Element Call will do, we additionally send a close action (even though
   // we're not yet employing the distinction between 'hangup' and 'close' to
   // display error screens)
-  try {
-    await widget.api.transport.send(ElementWidgetActions.Close, {});
-  } catch (e) {
-    logger.error("Failed to send close action", e);
+  if (!getUrlParams().returnToLobby) {
+    try {
+      await widget.api.transport.send(ElementWidgetActions.Close, {});
+    } catch (e) {
+      logger.error("Failed to send close action", e);
+    }
   }
 };
 


### PR DESCRIPTION
This is a manual backport of 28c45c61072126023381446877fb99c4c36fd8ac which makes the video room behavior consistent across the v0.7.2 patch release and development versions.