### PR TITLE
Reduce redundant calculations of display name map

### DIFF
--- a/src/state/CallViewModel.ts
+++ b/src/state/CallViewModel.ts
@@ -497,7 +497,6 @@ export class CallViewModel extends ViewModel {
       }
       return displaynameMap;
     }),
-    share(),
     this.scope.state(),
   );
 

--- a/src/state/CallViewModel.ts
+++ b/src/state/CallViewModel.ts
@@ -40,6 +40,7 @@ import {
   of,
   race,
   scan,
+  share,
   skip,
   startWith,
   switchAll,
@@ -496,6 +497,8 @@ export class CallViewModel extends ViewModel {
       }
       return displaynameMap;
     }),
+    share(),
+    this.scope.state(),
   );
 
   /**

--- a/src/state/CallViewModel.ts
+++ b/src/state/CallViewModel.ts
@@ -496,6 +496,9 @@ export class CallViewModel extends ViewModel {
       }
       return displaynameMap;
     }),
+    // it turns out that doing the disambiguation is quite expensive on Safari (10x slower than on Chrome/Firefox)
+    // this means it is important that we share() the result so that we don't do this work multiple times
+    // this is achieve through the state() operator:
     this.scope.state(),
   );
 

--- a/src/state/CallViewModel.ts
+++ b/src/state/CallViewModel.ts
@@ -40,7 +40,6 @@ import {
   of,
   race,
   scan,
-  share,
   skip,
   startWith,
   switchAll,

--- a/src/state/CallViewModel.ts
+++ b/src/state/CallViewModel.ts
@@ -496,9 +496,9 @@ export class CallViewModel extends ViewModel {
       }
       return displaynameMap;
     }),
-    // it turns out that doing the disambiguation is quite expensive on Safari (10x slower than on Chrome/Firefox)
-    // this means it is important that we share() the result so that we don't do this work multiple times
-    // this is achieve through the state() operator:
+    // It turns out that doing the disambiguation above is rather expensive on Safari (10x slower
+    // than on Chrome/Firefox). This means it is important that we share() the result so that we
+    // don't do this work more times than we need to. This is achieve through the state() operator:
     this.scope.state(),
   );
 


### PR DESCRIPTION
Simpler alternative to https://github.com/element-hq/element-call/pull/3060

Partial fix for: https://github.com/element-hq/voip-internal/issues/300

This means that we effectively "cache" the output of the `map()` section of `memberDisplaynames$` rather than recalculating it.