### PR TITLE
New Membership Manager js-sdk develop

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "livekit-client": "^2.5.7",
     "lodash-es": "^4.17.21",
     "loglevel": "^1.9.1",
-    "matrix-js-sdk": "github:matrix-org/matrix-js-sdk#47a7e4cff044e83fbb6aafd6700a3af707ef39cc",
+    "matrix-js-sdk": "github:matrix-org/matrix-js-sdk#develop",
     "matrix-widget-api": "1.11.0",
     "normalize.css": "^8.0.1",
     "observable-hooks": "^4.2.3",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "livekit-client": "^2.5.7",
     "lodash-es": "^4.17.21",
     "loglevel": "^1.9.1",
-    "matrix-js-sdk": "github:matrix-org/matrix-js-sdk#0cdb07544d9926cf0855a76ca5cc7dab253bdb24",
+    "matrix-js-sdk": "github:matrix-org/matrix-js-sdk#47a7e4cff044e83fbb6aafd6700a3af707ef39cc",
     "matrix-widget-api": "1.11.0",
     "normalize.css": "^8.0.1",
     "observable-hooks": "^4.2.3",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "strict": true,
     "noEmit": true,
     "noEmitOnError": true,
-    "experimentalDecorators": true,
+    "experimentalDecorators": false,
     "esModuleInterop": true,
     "noUnusedLocals": true,
     "moduleResolution": "bundler",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6334,9 +6334,9 @@ matrix-events-sdk@0.0.1:
   resolved "https://registry.yarnpkg.com/matrix-events-sdk/-/matrix-events-sdk-0.0.1.tgz#c8c38911e2cb29023b0bbac8d6f32e0de2c957dd"
   integrity sha512-1QEOsXO+bhyCroIe2/A5OwaxHvBm7EsSQ46DEDn8RBIfQwN5HWBpFvyWWR4QY0KHPPnnJdI99wgRiAl7Ad5qaA==
 
-"matrix-js-sdk@github:matrix-org/matrix-js-sdk#0cdb07544d9926cf0855a76ca5cc7dab253bdb24":
+"matrix-js-sdk@github:matrix-org/matrix-js-sdk#47a7e4cff044e83fbb6aafd6700a3af707ef39cc":
   version "37.0.0"
-  resolved "https://codeload.github.com/matrix-org/matrix-js-sdk/tar.gz/0cdb07544d9926cf0855a76ca5cc7dab253bdb24"
+  resolved "https://codeload.github.com/matrix-org/matrix-js-sdk/tar.gz/47a7e4cff044e83fbb6aafd6700a3af707ef39cc"
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@matrix-org/matrix-sdk-crypto-wasm" "^14.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6334,9 +6334,9 @@ matrix-events-sdk@0.0.1:
   resolved "https://registry.yarnpkg.com/matrix-events-sdk/-/matrix-events-sdk-0.0.1.tgz#c8c38911e2cb29023b0bbac8d6f32e0de2c957dd"
   integrity sha512-1QEOsXO+bhyCroIe2/A5OwaxHvBm7EsSQ46DEDn8RBIfQwN5HWBpFvyWWR4QY0KHPPnnJdI99wgRiAl7Ad5qaA==
 
-"matrix-js-sdk@github:matrix-org/matrix-js-sdk#47a7e4cff044e83fbb6aafd6700a3af707ef39cc":
-  version "37.0.0"
-  resolved "https://codeload.github.com/matrix-org/matrix-js-sdk/tar.gz/47a7e4cff044e83fbb6aafd6700a3af707ef39cc"
+"matrix-js-sdk@github:matrix-org/matrix-js-sdk#develop":
+  version "37.1.0"
+  resolved "https://codeload.github.com/matrix-org/matrix-js-sdk/tar.gz/9f9be701e7a8e85b5f749d0104138af36b0b82bd"
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@matrix-org/matrix-sdk-crypto-wasm" "^14.0.1"


### PR DESCRIPTION
Fixes: https://github.com/element-hq/voip-internal/issues/265
This PR collects all the changes we need to do to make EC compatible with the matrix-js-sdk develop branch. Currently it is not compatible and only works with  toger5/new-MembershipManager-v0.8.0-rc.1

Changes:
 - Set lint rule `experimentalDecorators` to `false` like in: https://github.com/matrix-org/matrix-js-sdk/commit/72b997d1f3d93f5754875fa873e32d6777b8bb0b