### PR TITLE
Rename built artifact name on v0.8.0 release branch for compatibility with Netlify PR preview

### DIFF
--- a/.github/workflows/build-and-publish-docker.yaml
+++ b/.github/workflows/build-and-publish-docker.yaml
@@ -30,7 +30,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ inputs.artifact_run_id }}
-          name: build-output
+          name: build-output-full
           path: dist
 
       - name: Log in to container registry

--- a/.github/workflows/build-element-call.yaml
+++ b/.github/workflows/build-element-call.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: Upload Artifact
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
         with:
-          name: build-output
+          name: build-output-full
           path: dist
           # We'll only use this in a triggered job, then we're done with it
           retention-days: 1

--- a/.github/workflows/deploy-to-netlify.yaml
+++ b/.github/workflows/deploy-to-netlify.yaml
@@ -50,7 +50,7 @@ jobs:
         with:
           github-token: ${{ secrets.ELEMENT_BOT_TOKEN }}
           run-id: ${{ inputs.artifact_run_id }}
-          name: build-output
+          name: build-output-full
           path: webapp
 
       - name: Add redirects file

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -38,7 +38,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id || github.run_id }}
-          name: build-output
+          name: build-output-full
           path: dist
       - name: Create Tarball
         env:


### PR DESCRIPTION
Fixes [#3107](https://github.com/element-hq/element-call/issues/3107) by updating the artifact name to be the same as on the `livekit` branch