### PR TITLE
Backport: Fix compilation error when trying to use SwiftPM embedded package

### DIFF
--- a/.github/workflows/publish-embedded-packages.yaml
+++ b/.github/workflows/publish-embedded-packages.yaml
@@ -164,6 +164,10 @@ jobs:
       - name: Copy files
         run: rsync -a --delete --exclude .git element-call/embedded/ios/ element-call-swift
 
+      - name: Test build
+        working-directory: element-call-swift
+        run: swift build
+
       - name: Get artifact version
         run: echo "ARTIFACT_VERSION=${VERSION:1}" >> "$GITHUB_ENV"
 

--- a/embedded/ios/Package.swift
+++ b/embedded/ios/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "EmbeddedElementCall",
-    platforms: [.iOS(.v17_6)],
+    platforms: [.iOS(.v17)],
     products: [
         .library(
             name: "EmbeddedElementCall",


### PR DESCRIPTION
Backport of https://github.com/element-hq/element-call/pull/3124 to the v0.9.0 release branch to fix https://github.com/element-hq/element-call/issues/3126.