### PR TITLE
Rename EULA to SSLA

### DIFF
--- a/config/config.devenv.json
+++ b/config/config.devenv.json
@@ -11,5 +11,5 @@
   "features": {
     "feature_use_device_session_member_events": true
   },
-  "eula": "https://static.element.io/legal/online-EULA.pdf"
+  "ssla": "https://static.element.io/legal/element-software-and-services-license-agreement-uk-1.pdf"
 }

--- a/config/config.sample.json
+++ b/config/config.sample.json
@@ -11,5 +11,5 @@
   "features": {
     "feature_use_device_session_member_events": true
   },
-  "eula": "https://static.element.io/legal/online-EULA.pdf"
+  "ssla": "https://static.element.io/legal/element-software-and-services-license-agreement-uk-1.pdf"
 }

--- a/locales/en/app.json
+++ b/locales/en/app.json
@@ -142,9 +142,9 @@
   "rageshake_sending": "Sending…",
   "rageshake_sending_logs": "Sending debug logs…",
   "rageshake_sent": "Thanks!",
-  "recaptcha_caption": "This site is protected by ReCAPTCHA and the Google <2>Privacy Policy</2> and <6>Terms of Service</6> apply.<9></9>By clicking \"Register\", you agree to our <12>End User Licensing Agreement (EULA)</12>",
   "recaptcha_dismissed": "Recaptcha dismissed",
   "recaptcha_not_loaded": "Recaptcha not loaded",
+  "recaptcha_ssla_caption": "This site is protected by ReCAPTCHA and the Google <2>Privacy Policy</2> and <6>Terms of Service</6> apply.<9></9>By clicking \"Register\", you agree to our <12>Software and Services License Agreement (SSLA)</12>",
   "register": {
     "passwords_must_match": "Passwords must match",
     "registering": "Registering…"
@@ -154,7 +154,7 @@
   "register_heading": "Create your account",
   "return_home_button": "Return to home screen",
   "room_auth_view_continue_button": "Continue",
-  "room_auth_view_eula_caption": "By clicking \"Continue\", you agree to our <2>End User Licensing Agreement (EULA)</2>",
+  "room_auth_view_ssla_caption": "By clicking \"Join call now\", you agree to our <2>Software and Services License Agreement (SSLA)</2>",
   "screenshare_button_label": "Share screen",
   "settings": {
     "audio_tab": {
@@ -200,8 +200,8 @@
   "submitting": "Submitting…",
   "switch_camera": "Switch camera",
   "unauthenticated_view_body": "Not registered yet? <2>Create an account</2>",
-  "unauthenticated_view_eula_caption": "By clicking \"Go\", you agree to our <2>End User Licensing Agreement (EULA)</2>",
   "unauthenticated_view_login_button": "Login to your account",
+  "unauthenticated_view_ssla_caption": "By clicking \"Go\", you agree to our <2>Software and Services License Agreement (SSLA)</2>",
   "unmute_microphone_button_label": "Unmute microphone",
   "version": "{{productName}} version: {{version}}",
   "video_tile": {

--- a/src/auth/RegisterPage.tsx
+++ b/src/auth/RegisterPage.tsx
@@ -216,8 +216,7 @@ export const RegisterPage: FC = () => {
                   apply.
                   <br />
                   By clicking "Register", you agree to our{" "}
-                  {/* if the deprecated eula field is setup we still show it. */}
-                  <ExternalLink href={Config.get().eula ?? Config.get().ssla}>
+                  <ExternalLink href={Config.get().ssla}>
                     Software and Services License Agreement (SSLA)
                   </ExternalLink>
                 </Trans>

--- a/src/auth/RegisterPage.tsx
+++ b/src/auth/RegisterPage.tsx
@@ -204,7 +204,7 @@ export const RegisterPage: FC = () => {
                 />
               </FieldRow>
               <Text size="sm">
-                <Trans i18nKey="recaptcha_caption">
+                <Trans i18nKey="recaptcha_ssla_caption">
                   This site is protected by ReCAPTCHA and the Google{" "}
                   <ExternalLink href="https://www.google.com/policies/privacy/">
                     Privacy Policy
@@ -216,8 +216,9 @@ export const RegisterPage: FC = () => {
                   apply.
                   <br />
                   By clicking "Register", you agree to our{" "}
-                  <ExternalLink href={Config.get().eula}>
-                    End User Licensing Agreement (EULA)
+                  {/* if the deprecated eula field is setup we still show it. */}
+                  <ExternalLink href={Config.get().eula ?? Config.get().ssla}>
+                    Software and Services License Agreement (SSLA)
                   </ExternalLink>
                 </Trans>
               </Text>

--- a/src/config/ConfigOptions.ts
+++ b/src/config/ConfigOptions.ts
@@ -78,12 +78,6 @@ export interface ConfigOptions {
 
   /**
    * A link to the software and services license agreement (SSLA)
-   * @deprecated renamed to ssla
-   */
-  eula?: string;
-
-  /**
-   * A link to the software and services license agreement (SSLA)
    */
   ssla?: string;
 

--- a/src/config/ConfigOptions.ts
+++ b/src/config/ConfigOptions.ts
@@ -158,7 +158,7 @@ export const DEFAULT_CONFIG: ResolvedConfigOptions = {
   features: {
     feature_use_device_session_member_events: true,
   },
-  ssla: " https://static.element.io/legal/element-software-and-services-license-agreement-uk-1.pdf",
+  ssla: "https://static.element.io/legal/element-software-and-services-license-agreement-uk-1.pdf",
   media_devices: {
     enable_audio: true,
     enable_video: true,

--- a/src/config/ConfigOptions.ts
+++ b/src/config/ConfigOptions.ts
@@ -77,9 +77,15 @@ export interface ConfigOptions {
   };
 
   /**
-   * A link to the end-user license agreement (EULA)
+   * A link to the software and services license agreement (SSLA)
+   * @deprecated renamed to ssla
    */
   eula?: string;
+
+  /**
+   * A link to the software and services license agreement (SSLA)
+   */
+  ssla?: string;
 
   media_devices?: {
     /**
@@ -134,7 +140,7 @@ export interface ResolvedConfigOptions extends ConfigOptions {
       server_name: string;
     };
   };
-  eula: string;
+  ssla: string;
   media_devices: {
     enable_audio: boolean;
     enable_video: boolean;
@@ -152,7 +158,7 @@ export const DEFAULT_CONFIG: ResolvedConfigOptions = {
   features: {
     feature_use_device_session_member_events: true,
   },
-  eula: "https://static.element.io/legal/online-EULA.pdf",
+  ssla: " https://static.element.io/legal/element-software-and-services-license-agreement-uk-1.pdf",
   media_devices: {
     enable_audio: true,
     enable_video: true,

--- a/src/home/UnauthenticatedView.tsx
+++ b/src/home/UnauthenticatedView.tsx
@@ -185,10 +185,11 @@ export const UnauthenticatedView: FC = () => {
               </Text>
             )}
             <Text size="sm" className={styles.notice}>
-              <Trans i18nKey="unauthenticated_view_eula_caption">
+              <Trans i18nKey="unauthenticated_view_ssla_caption">
                 By clicking "Go", you agree to our{" "}
-                <ExternalLink href={Config.get().eula}>
-                  End User Licensing Agreement (EULA)
+                {/* if the deprecated eula field is setup we still show it. */}
+                <ExternalLink href={Config.get().eula ?? Config.get().ssla}>
+                  Software and Services License Agreement (SSLA)
                 </ExternalLink>
               </Trans>
             </Text>

--- a/src/home/UnauthenticatedView.tsx
+++ b/src/home/UnauthenticatedView.tsx
@@ -187,8 +187,7 @@ export const UnauthenticatedView: FC = () => {
             <Text size="sm" className={styles.notice}>
               <Trans i18nKey="unauthenticated_view_ssla_caption">
                 By clicking "Go", you agree to our{" "}
-                {/* if the deprecated eula field is setup we still show it. */}
-                <ExternalLink href={Config.get().eula ?? Config.get().ssla}>
+                <ExternalLink href={Config.get().ssla}>
                   Software and Services License Agreement (SSLA)
                 </ExternalLink>
               </Trans>

--- a/src/room/RoomAuthView.tsx
+++ b/src/room/RoomAuthView.tsx
@@ -80,10 +80,11 @@ export const RoomAuthView: FC = () => {
               />
             </FieldRow>
             <Text size="sm">
-              <Trans i18nKey="room_auth_view_eula_caption">
+              <Trans i18nKey="room_auth_view_ssla_caption">
                 By clicking "Join call now", you agree to our{" "}
-                <ExternalLink href={Config.get().eula}>
-                  End User Licensing Agreement (EULA)
+                {/* if the deprecated eula field is setup we still show it. */}
+                <ExternalLink href={Config.get().eula ?? Config.get().ssla}>
+                  Software and Services License Agreement (SSLA)
                 </ExternalLink>
               </Trans>
             </Text>

--- a/src/room/RoomAuthView.tsx
+++ b/src/room/RoomAuthView.tsx
@@ -82,8 +82,7 @@ export const RoomAuthView: FC = () => {
             <Text size="sm">
               <Trans i18nKey="room_auth_view_ssla_caption">
                 By clicking "Join call now", you agree to our{" "}
-                {/* if the deprecated eula field is setup we still show it. */}
-                <ExternalLink href={Config.get().eula ?? Config.get().ssla}>
+                <ExternalLink href={Config.get().ssla}>
                   Software and Services License Agreement (SSLA)
                 </ExternalLink>
               </Trans>


### PR DESCRIPTION
The linked "End User License Agreement" is actually a "Software and Services License Agreement" so we should call it that.

fixes: https://github.com/element-hq/voip-internal/issues/320
 
- rename i18n fields to reference Software and Services License Agreement
- rename the config property `eula` to `ssla`
