### PR TITLE
Add simple release note automation

### DIFF
--- a/.github/realease.yml
+++ b/.github/realease.yml
@@ -2,15 +2,28 @@ changelog:
   categories:
     - title: 🛠 Breaking Changes
       labels:
-        - T-Breaking-Change
+        - PR-Breaking-Change
     - title: ✨ Features
       labels:
-        - T-Enhancement
+        - PR-Feature
+    - title: 🙌 Improvements
+      labels:
+        - PR-Improvement
+    - title: 📄 Documentation
+      labels:
+        - PR-Documentation
+    - title: 🐛 Bugfixes
+      labels:
+        - PR-Bug-Fix
+    - title: 💾 Developer Experience
+      labels:
+        - PR-Developer-Experience
     - title: Others
       labels:
         - "*"
       exclude:
         labels:
+          - PR-Task
           - dependencies
     - title: 👒 Dependencies
       labels:

--- a/.github/realease.yml
+++ b/.github/realease.yml
@@ -1,0 +1,17 @@
+changelog:
+  categories:
+    - title: 🛠 Breaking Changes
+      labels:
+        - T-Breaking-Change
+    - title: ✨ Features
+      labels:
+        - T-Enhancement
+    - title: Others
+      labels:
+        - "*"
+      exclude:
+        labels:
+          - dependencies
+    - title: 👒 Dependencies
+      labels:
+        - dependencies


### PR DESCRIPTION
Tries to keep it simple so we can iterate what we actually need.
The main driver is that we want a dedicated `Breaking-Change` section.