### PR TITLE
Widget: Add missing to device permission for encryption keys

### DIFF
--- a/src/widget.ts
+++ b/src/widget.ts
@@ -139,6 +139,7 @@ export const widget = ((): WidgetHelpers | null => {
         EventType.CallSDPStreamMetadataChanged,
         EventType.CallSDPStreamMetadataChangedPrefix,
         EventType.CallReplaces,
+        EventType.CallEncryptionKeysPrefix,
       ];
 
       const client = createRoomWidgetClient(


### PR DESCRIPTION
Part of https://github.com/element-hq/element-call/issues/3155
Missing permission for event type `io.element.call.encryption_keys`  as to_device