### PR TITLE
Improve the reliability of state changes in widget mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "livekit-client": "^2.11.3",
     "lodash-es": "^4.17.21",
     "loglevel": "^1.9.1",
-    "matrix-js-sdk": "github:matrix-org/matrix-js-sdk#f3f4a1f7e2f5f2c26cf4fce89a729a9197f619b5",
+    "matrix-js-sdk": "github:matrix-org/matrix-js-sdk#7fa9195e398764749b0195f14d3cf0190ad10253",
     "matrix-widget-api": "1.11.0",
     "normalize.css": "^8.0.1",
     "observable-hooks": "^4.2.3",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "livekit-client": "^2.11.3",
     "lodash-es": "^4.17.21",
     "loglevel": "^1.9.1",
-    "matrix-js-sdk": "github:matrix-org/matrix-js-sdk#7fa9195e398764749b0195f14d3cf0190ad10253",
+    "matrix-js-sdk": "github:matrix-org/matrix-js-sdk#head=toger5/add-room-key-fallback-on-encryption-manager-not-supported",
     "matrix-widget-api": "^1.13.0",
     "normalize.css": "^8.0.1",
     "observable-hooks": "^4.2.3",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "lodash-es": "^4.17.21",
     "loglevel": "^1.9.1",
     "matrix-js-sdk": "github:matrix-org/matrix-js-sdk#7fa9195e398764749b0195f14d3cf0190ad10253",
-    "matrix-widget-api": "1.11.0",
+    "matrix-widget-api": "^1.13.0",
     "normalize.css": "^8.0.1",
     "observable-hooks": "^4.2.3",
     "pako": "^2.0.4",
@@ -133,8 +133,7 @@
   },
   "resolutions": {
     "@livekit/components-core/rxjs": "^7.8.1",
-    "@livekit/track-processors/@mediapipe/tasks-vision": "^0.10.18",
-    "matrix-widget-api": "1.11.0"
+    "@livekit/track-processors/@mediapipe/tasks-vision": "^0.10.18"
   },
   "packageManager": "yarn@4.7.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7008,7 +7008,7 @@ __metadata:
     lodash-es: "npm:^4.17.21"
     loglevel: "npm:^1.9.1"
     matrix-js-sdk: "github:matrix-org/matrix-js-sdk#7fa9195e398764749b0195f14d3cf0190ad10253"
-    matrix-widget-api: "npm:1.11.0"
+    matrix-widget-api: "npm:^1.13.0"
     normalize.css: "npm:^8.0.1"
     observable-hooks: "npm:^4.2.3"
     pako: "npm:^2.0.4"
@@ -9633,13 +9633,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"matrix-widget-api@npm:1.11.0":
-  version: 1.11.0
-  resolution: "matrix-widget-api@npm:1.11.0"
+"matrix-widget-api@npm:^1.10.0, matrix-widget-api@npm:^1.13.0":
+  version: 1.13.1
+  resolution: "matrix-widget-api@npm:1.13.1"
   dependencies:
     "@types/events": "npm:^3.0.0"
     events: "npm:^3.2.0"
-  checksum: 10c0/ac35ed8fb2b5df6d186beb64b5faf907ec113d708ad8353bdd8f9196fb3da255561b8807e2e845f39d4cf7ae6af36f90b54c230a0a100556ac7ebd8f18bee848
+  checksum: 10c0/25ded744922755b3eb65f4e171cf6cff1a2e0fe43fc3fecbb13e565e41d8af066daa817dd2c3c7d921b996af399eec3b23df70ab7b682cf422d9cee7ca202512
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7007,7 +7007,7 @@ __metadata:
     livekit-client: "npm:^2.11.3"
     lodash-es: "npm:^4.17.21"
     loglevel: "npm:^1.9.1"
-    matrix-js-sdk: "github:matrix-org/matrix-js-sdk#f3f4a1f7e2f5f2c26cf4fce89a729a9197f619b5"
+    matrix-js-sdk: "github:matrix-org/matrix-js-sdk#7fa9195e398764749b0195f14d3cf0190ad10253"
     matrix-widget-api: "npm:1.11.0"
     normalize.css: "npm:^8.0.1"
     observable-hooks: "npm:^4.2.3"
@@ -9610,9 +9610,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"matrix-js-sdk@github:matrix-org/matrix-js-sdk#f3f4a1f7e2f5f2c26cf4fce89a729a9197f619b5":
-  version: 37.5.0
-  resolution: "matrix-js-sdk@https://github.com/matrix-org/matrix-js-sdk.git#commit=f3f4a1f7e2f5f2c26cf4fce89a729a9197f619b5"
+"matrix-js-sdk@github:matrix-org/matrix-js-sdk#7fa9195e398764749b0195f14d3cf0190ad10253":
+  version: 37.6.0
+  resolution: "matrix-js-sdk@https://github.com/matrix-org/matrix-js-sdk.git#commit=7fa9195e398764749b0195f14d3cf0190ad10253"
   dependencies:
     "@babel/runtime": "npm:^7.12.5"
     "@matrix-org/matrix-sdk-crypto-wasm": "npm:^14.0.1"
@@ -9629,7 +9629,7 @@ __metadata:
     sdp-transform: "npm:^2.14.1"
     unhomoglyph: "npm:^1.0.6"
     uuid: "npm:11"
-  checksum: 10c0/14058044851110df967252ab9df0dcc480b2f60cedfb049edb51f8b8925d131f78b4ee9b974e5cdd39093fa32ce7e3318523059c82ecce290fa2fe03ed98506b
+  checksum: 10c0/f2c973cf7e4ac01b387a78af11c44735cc2895b28b571f9bbe8c18ed29c3d7383272116dc181057b69e55771dbafb3a4a1527593d54f3c37db705fb57b81616d
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7007,7 +7007,7 @@ __metadata:
     livekit-client: "npm:^2.11.3"
     lodash-es: "npm:^4.17.21"
     loglevel: "npm:^1.9.1"
-    matrix-js-sdk: "github:matrix-org/matrix-js-sdk#7fa9195e398764749b0195f14d3cf0190ad10253"
+    matrix-js-sdk: "github:matrix-org/matrix-js-sdk#head=toger5/add-room-key-fallback-on-encryption-manager-not-supported"
     matrix-widget-api: "npm:^1.13.0"
     normalize.css: "npm:^8.0.1"
     observable-hooks: "npm:^4.2.3"
@@ -9610,7 +9610,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"matrix-js-sdk@github:matrix-org/matrix-js-sdk#7fa9195e398764749b0195f14d3cf0190ad10253":
+"matrix-js-sdk@github:matrix-org/matrix-js-sdk#head=toger5/add-room-key-fallback-on-encryption-manager-not-supported":
   version: 37.6.0
   resolution: "matrix-js-sdk@https://github.com/matrix-org/matrix-js-sdk.git#commit=7fa9195e398764749b0195f14d3cf0190ad10253"
   dependencies:


### PR DESCRIPTION
This makes the mechanism by which an Element Call widget can receive changes to room state more reliable by updating matrix-js-sdk and matrix-widget-api, which now support the `update_state` action from [the latest version of MSC2762](https://github.com/matrix-org/matrix-spec-proposals/pull/4237).

Depends on https://github.com/matrix-org/matrix-js-sdk/pull/4790
For https://github.com/element-hq/voip-internal/issues/289