### PR TITLE
Update default power levels for room and encrypt rooms on creation

### DIFF
--- a/src/utils/matrix.ts
+++ b/src/utils/matrix.ts
@@ -251,7 +251,8 @@ export async function createRoom(
         "m.room.encryption": 100,
         "m.room.name": 50,
         "m.room.message": 0,
-        "m.room.encrypted": 50,
+        // revert this once we do not rely on room messages for perSenderKeys anymore
+        "m.room.encrypted": 0,
         "m.sticker": 50,
         "org.matrix.msc3401.call.member": 0,
       },
@@ -259,6 +260,15 @@ export async function createRoom(
         [client.getUserId()!]: 100,
       },
     },
+    initial_state: [
+      {
+        type: "m.room.encryption",
+        state_key: "",
+        content: {
+          algorithm: "m.megolm.v1.aes-sha2",
+        },
+      },
+    ],
   });
 
   // Wait for the room to arrive


### PR DESCRIPTION
This change is pulled out from: https://github.com/element-hq/element-call/pull/3167
So we can decide if we really want it. Its mostly independent except that if we want room encryption event fallbacks this is needed.
For spa guest links we use rooms defined by EW so they should be encrypted already. So this is only for todevice (or room key) transport in the spa with rooms created in the spa.