### PR TITLE
Fix Docker image tag in release notes

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -66,8 +66,6 @@ jobs:
     name: Add docker release note
     runs-on: ubuntu-latest
     steps:
-      - name: Get artifact version
-        run: echo "ARTIFACT_VERSION=${VERSION:1}" >> "$GITHUB_ENV"
       - name: Add release note
         uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2
         with:
@@ -79,5 +77,5 @@ jobs:
             The image provides a full build of Element Call that can be used both in standalone and as a widget (on a remote URL).
 
             ```
-            docker pull ghcr.io/element-hq/element-call:${{ env.ARTIFACT_VERSION }}
+            docker pull ghcr.io/element-hq/element-call:${{ env.VERSION }}
             ```


### PR DESCRIPTION
The version tag of published Docker images includes a leading "v", so include it in release notes.

---

Example:
```
$ docker pull ghcr.io/element-hq/element-call:0.9.0
Error response from daemon: failed to resolve reference "ghcr.io/element-hq/element-call:0.9.0": ghcr.io/element-hq/element-call:0.9.0: not found
$ docker pull ghcr.io/element-hq/element-call:v0.9.0
v0.9.0: Pulling from element-hq/element-call
...
Digest: sha256:f13a30cb527a788b9058fd568073b380fe42ff417b58955c9cd8c4a4a8a65849
Status: Downloaded newer image for ghcr.io/element-hq/element-call:v0.9.0
ghcr.io/element-hq/element-call:v0.9.0
```