### PR TITLE
Set the correct license on docker images

### DIFF
--- a/.github/workflows/build-and-publish-docker.yaml
+++ b/.github/workflows/build-and-publish-docker.yaml
@@ -46,6 +46,8 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: ${{ inputs.docker_tags}}
+          labels: |
+            org.opencontainers.image.licenses=AGPL-3.0-only OR LicenseRef-Element-Commercial
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0


### PR DESCRIPTION
Previously the docker/metadata action was autodetecting the license and only getting AGPL not dual license.