### PR TITLE
Add a .links.temp-disabled.yaml state explicitly for when the pre-commit hook disabled the yaml.

### DIFF
--- a/.githooks/post-commit
+++ b/.githooks/post-commit
@@ -1,10 +1,10 @@
 #!/usr/bin/sh
 
-FILE=.links.disabled.yaml
+FILE=.links.temp-disabled.yaml
 if test -f "$FILE"; then
-  # echo "$FILE exists. -> moving to .links.disabled.yaml"
-  mv .links.disabled.yaml .links.yaml
-  # echo "running yarn"
+  # Only do the post-commit hook if the file was temp-disabled by the pre-commit hook.
+  # Otherwise linking was actively (`yarn links:disable`) disabled and this hook should noop.
+  mv .links.temp-disabled.yaml .links.yaml
   yarnLog=$(yarn)
   echo "[yarn-linker] The post-commit hook has re-enabled .links.yaml."
   exit 1

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -2,8 +2,7 @@
 
 FILE=".links.yaml"
 if test -f "$FILE"; then
-  # echo "$FILE exists. -> moving to .links.disabled.yaml"
-  mv .links.yaml .links.disabled.yaml
+  mv .links.yaml .links.temp-disabled.yaml
   # echo "running yarn"
   x=$(yarn)
   y=$(git add yarn.lock)

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ yarn-error.log
 !/.yarn/versions
 /.links.yaml
 /.links.disabled.yaml
+/.links.temp-disabled.yaml
 
 # Playwright
 /test-results/


### PR DESCRIPTION
Otherwise we end up with a linked repo after every commit.