### PR TITLE
(Backport to v0.10.0) Revert livekit-client to 2.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "i18next-parser": "^9.1.0",
     "jsdom": "^26.0.0",
     "knip": "^5.27.2",
-    "livekit-client": "2.11.2",
+    "livekit-client": "2.10.0",
     "lodash-es": "^4.17.21",
     "loglevel": "^1.9.1",
     "matrix-js-sdk": "github:matrix-org/matrix-js-sdk#44cf0aa93ae240d01e22d79b7912626c0e5d5ef6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6910,7 +6910,7 @@ __metadata:
     i18next-parser: "npm:^9.1.0"
     jsdom: "npm:^26.0.0"
     knip: "npm:^5.27.2"
-    livekit-client: "npm:2.11.2"
+    livekit-client: "npm:2.10.0"
     lodash-es: "npm:^4.17.21"
     loglevel: "npm:^1.9.1"
     matrix-js-sdk: "github:matrix-org/matrix-js-sdk#44cf0aa93ae240d01e22d79b7912626c0e5d5ef6"
@@ -9280,9 +9280,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"livekit-client@npm:2.11.2":
-  version: 2.11.2
-  resolution: "livekit-client@npm:2.11.2"
+"livekit-client@npm:2.10.0":
+  version: 2.10.0
+  resolution: "livekit-client@npm:2.10.0"
   dependencies:
     "@livekit/mutex": "npm:1.1.1"
     "@livekit/protocol": "npm:1.36.1"
@@ -9293,7 +9293,7 @@ __metadata:
     tslib: "npm:2.8.1"
     typed-emitter: "npm:^2.1.0"
     webrtc-adapter: "npm:^9.0.1"
-  checksum: 10c0/03a184f3a4f81beefb47a78adb37d3ba3b95a5d1f01e2ebbb83fb3769a120f6b8726ee8ccd96eb634164eeec508850cf05d40e2330fe7c1eda0e3d7f481561f7
+  checksum: 10c0/bc5d1d1e08576da3356f567836090a58dfad9b2d9ca2280584acf31676949a88d9526940ab10a9b6cf79545a49f82678cb0665f65851628e6148a9d559cacc90
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Backport of https://github.com/element-hq/element-call/pull/3222 to the v0.10.0 release branch.