### PR TITLE
Set `ratchetWindowSize` to > 0 enable rachet compatibility.

### DIFF
--- a/src/e2ee/matrixKeyProvider.ts
+++ b/src/e2ee/matrixKeyProvider.ts
@@ -16,7 +16,7 @@ export class MatrixKeyProvider extends BaseKeyProvider {
   private rtcSession?: MatrixRTCSession;
 
   public constructor() {
-    super({ ratchetWindowSize: 0, keyringSize: 256 });
+    super({ ratchetWindowSize: 10, keyringSize: 256 });
   }
 
   public setRTCSession(rtcSession: MatrixRTCSession): void {


### PR DESCRIPTION
This is a subset of: https://github.com/element-hq/element-call/pull/3214

It will allow us to be compatible with any version of EC that does ratcheting.