### PR TITLE
Backport v0.10.0: Set ratchetWindowSize > 0, to enable ratchet compatibility.

### DIFF
--- a/src/e2ee/matrixKeyProvider.ts
+++ b/src/e2ee/matrixKeyProvider.ts
@@ -16,7 +16,7 @@ export class MatrixKeyProvider extends BaseKeyProvider {
   private rtcSession?: MatrixRTCSession;
 
   public constructor() {
-    super({ ratchetWindowSize: 0, keyringSize: 256 });
+    super({ ratchetWindowSize: 10, keyringSize: 256 });
   }
 
   public setRTCSession(rtcSession: MatrixRTCSession): void {


### PR DESCRIPTION
Backport of: https://github.com/element-hq/element-call/pull/3224