### PR TITLE
(Backport) Return to latest livekit-client version (2.11.3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "i18next-parser": "^9.1.0",
     "jsdom": "^26.0.0",
     "knip": "^5.27.2",
-    "livekit-client": "2.10.0",
+    "livekit-client": "^2.11.3",
     "lodash-es": "^4.17.21",
     "loglevel": "^1.9.1",
     "matrix-js-sdk": "github:matrix-org/matrix-js-sdk#19b1b901f575755d29d1fe03ca48cbf7c1cae05c",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6910,7 +6910,7 @@ __metadata:
     i18next-parser: "npm:^9.1.0"
     jsdom: "npm:^26.0.0"
     knip: "npm:^5.27.2"
-    livekit-client: "npm:2.10.0"
+    livekit-client: "npm:^2.11.3"
     lodash-es: "npm:^4.17.21"
     loglevel: "npm:^1.9.1"
     matrix-js-sdk: "github:matrix-org/matrix-js-sdk#19b1b901f575755d29d1fe03ca48cbf7c1cae05c"
@@ -9280,9 +9280,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"livekit-client@npm:2.10.0":
-  version: 2.10.0
-  resolution: "livekit-client@npm:2.10.0"
+"livekit-client@npm:^2.11.3":
+  version: 2.11.3
+  resolution: "livekit-client@npm:2.11.3"
   dependencies:
     "@livekit/mutex": "npm:1.1.1"
     "@livekit/protocol": "npm:1.36.1"
@@ -9293,7 +9293,7 @@ __metadata:
     tslib: "npm:2.8.1"
     typed-emitter: "npm:^2.1.0"
     webrtc-adapter: "npm:^9.0.1"
-  checksum: 10c0/bc5d1d1e08576da3356f567836090a58dfad9b2d9ca2280584acf31676949a88d9526940ab10a9b6cf79545a49f82678cb0665f65851628e6148a9d559cacc90
+  checksum: 10c0/d56444f31c107b46ccd5532038ac77bd21038042910619008267c17894f1d3f054262ae2354d89df6fe0ba325aba01909b0612ad4c290906487c40d91641f6e4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Backport of https://github.com/element-hq/element-call/pull/3229 to the release branch.