### PR TITLE
Keep the HTML lang attribute in sync with the i18next language

### DIFF
--- a/src/initializer.tsx
+++ b/src/initializer.tsx
@@ -136,6 +136,11 @@ export class Initializer {
       lookup: () => getUrlParams().lang ?? undefined,
     });
 
+    // Synchronise the HTML lang attribute with the i18next language
+    i18n.on("languageChanged", (lng) => {
+      document.documentElement.lang = lng;
+    });
+
     await i18n
       .use(Backend)
       .use(languageDetector)


### PR DESCRIPTION
Small thing that has been bothering me for a bit: Firefox always offers me to translate the page, because it thinks it's in English, even though it's already in French.
