### PR TITLE
Docker-compose: do not access ports <443

### DIFF
--- a/backend/dev_nginx.conf
+++ b/backend/dev_nginx.conf
@@ -145,7 +145,7 @@ server {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
 
-      proxy_pass http://element-web:81;
+      proxy_pass http://element-web:8081;
       proxy_ssl_verify              off;
 
     }

--- a/dev-backend-docker-compose.yml
+++ b/dev-backend-docker-compose.yml
@@ -73,11 +73,11 @@ services:
     image: ghcr.io/element-hq/element-web:develop
     pull_policy: always
     volumes:
-      - ./backend/ew.test.config.json:/app/config.json
+      - ./backend/ew.test.config.json:/app/config.json:Z
     environment:
-      ELEMENT_WEB_PORT: 81
+      ELEMENT_WEB_PORT: 8081
     ports:
-      - "8081:81"
+      - "8081:8081"
     networks:
       - ecbackend
 
@@ -91,7 +91,6 @@ services:
       - ./backend/dev_tls_m.localhost.crt:/root/ssl/cert.pem:Z
     ports:
       # HOST_PORT:CONTAINER_PORT
-      - "80:80"
       - "443:443"
       - "8008:80"
       - "4443:443"


### PR DESCRIPTION
This does not allow podman (also docker) to start the containers without altering linux default security measurements.

The playwright tests also run with those the alternative ports: 4443, 8080, 8081