### PR TITLE
Update RTCSession configuration to non deprecated names.

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "livekit-client": "^2.11.3",
     "lodash-es": "^4.17.21",
     "loglevel": "^1.9.1",
-    "matrix-js-sdk": "github:matrix-org/matrix-js-sdk#19b1b901f575755d29d1fe03ca48cbf7c1cae05c",
+    "matrix-js-sdk": "github:matrix-org/matrix-js-sdk#457a300c9594dc24ba2f05cc16180112b9e8d0ac",
     "matrix-widget-api": "1.11.0",
     "normalize.css": "^8.0.1",
     "observable-hooks": "^4.2.3",

--- a/src/e2ee/matrixKeyProvider.ts
+++ b/src/e2ee/matrixKeyProvider.ts
@@ -44,7 +44,7 @@ export class MatrixKeyProvider extends BaseKeyProvider {
     encryptionKeyIndex: number,
     participantId: string,
   ): void => {
-    createKeyMaterialFromBuffer(encryptionKey).then(
+    createKeyMaterialFromBuffer(encryptionKey.buffer as ArrayBuffer).then(
       (keyMaterial) => {
         this.onSetEncryptionKey(keyMaterial, participantId, encryptionKeyIndex);
 

--- a/src/e2ee/matrixKeyProvider.ts
+++ b/src/e2ee/matrixKeyProvider.ts
@@ -5,7 +5,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
 Please see LICENSE in the repository root for full details.
 */
 
-import { BaseKeyProvider, createKeyMaterialFromBuffer } from "livekit-client";
+import { BaseKeyProvider } from "livekit-client";
 import { logger } from "matrix-js-sdk/lib/logger";
 import {
   type MatrixRTCSession,
@@ -44,20 +44,29 @@ export class MatrixKeyProvider extends BaseKeyProvider {
     encryptionKeyIndex: number,
     participantId: string,
   ): void => {
-    createKeyMaterialFromBuffer(encryptionKey.buffer as ArrayBuffer).then(
-      (keyMaterial) => {
-        this.onSetEncryptionKey(keyMaterial, participantId, encryptionKeyIndex);
+    crypto.subtle
+      .importKey("raw", encryptionKey, "HKDF", false, [
+        "deriveBits",
+        "deriveKey",
+      ])
+      .then(
+        (keyMaterial) => {
+          this.onSetEncryptionKey(
+            keyMaterial,
+            participantId,
+            encryptionKeyIndex,
+          );
 
-        logger.debug(
-          `Sent new key to livekit room=${this.rtcSession?.room.roomId} participantId=${participantId} encryptionKeyIndex=${encryptionKeyIndex}`,
-        );
-      },
-      (e) => {
-        logger.error(
-          `Failed to create key material from buffer for livekit room=${this.rtcSession?.room.roomId} participantId=${participantId} encryptionKeyIndex=${encryptionKeyIndex}`,
-          e,
-        );
-      },
-    );
+          logger.debug(
+            `Sent new key to livekit room=${this.rtcSession?.room.roomId} participantId=${participantId} encryptionKeyIndex=${encryptionKeyIndex}`,
+          );
+        },
+        (e) => {
+          logger.error(
+            `Failed to create key material from buffer for livekit room=${this.rtcSession?.room.roomId} participantId=${participantId} encryptionKeyIndex=${encryptionKeyIndex}`,
+            e,
+          );
+        },
+      );
   };
 }

--- a/src/rtcSessionHelpers.ts
+++ b/src/rtcSessionHelpers.ts
@@ -121,10 +121,9 @@ export async function enterRTCSession(
       ...(useDeviceSessionMemberEvents !== undefined && {
         useLegacyMemberEvents: !useDeviceSessionMemberEvents,
       }),
-      membershipServerSideExpiryTimeout:
+      delayedLeaveEventDelayMs:
         matrixRtcSessionConfig?.membership_server_side_expiry_timeout,
-      membershipKeepAlivePeriod:
-        matrixRtcSessionConfig?.membership_keep_alive_period,
+      networkErrorRetryMs: matrixRtcSessionConfig?.membership_keep_alive_period,
       makeKeyDelay: matrixRtcSessionConfig?.key_rotation_on_leave_delay,
       useExperimentalToDeviceTransport,
     },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "es2022",
     "module": "es2022",
     "jsx": "react-jsx",
-    "lib": ["es2022", "dom", "dom.iterable"],
+    "lib": ["es2024", "dom", "dom.iterable"],
 
     // From Matrix-JS-SDK
     "strict": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7000,7 +7000,7 @@ __metadata:
     livekit-client: "npm:^2.11.3"
     lodash-es: "npm:^4.17.21"
     loglevel: "npm:^1.9.1"
-    matrix-js-sdk: "github:matrix-org/matrix-js-sdk#19b1b901f575755d29d1fe03ca48cbf7c1cae05c"
+    matrix-js-sdk: "github:matrix-org/matrix-js-sdk#457a300c9594dc24ba2f05cc16180112b9e8d0ac"
     matrix-widget-api: "npm:1.11.0"
     normalize.css: "npm:^8.0.1"
     observable-hooks: "npm:^4.2.3"
@@ -9591,9 +9591,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"matrix-js-sdk@github:matrix-org/matrix-js-sdk#19b1b901f575755d29d1fe03ca48cbf7c1cae05c":
-  version: 37.4.0
-  resolution: "matrix-js-sdk@https://github.com/matrix-org/matrix-js-sdk.git#commit=19b1b901f575755d29d1fe03ca48cbf7c1cae05c"
+"matrix-js-sdk@github:matrix-org/matrix-js-sdk#457a300c9594dc24ba2f05cc16180112b9e8d0ac":
+  version: 37.5.0
+  resolution: "matrix-js-sdk@https://github.com/matrix-org/matrix-js-sdk.git#commit=457a300c9594dc24ba2f05cc16180112b9e8d0ac"
   dependencies:
     "@babel/runtime": "npm:^7.12.5"
     "@matrix-org/matrix-sdk-crypto-wasm": "npm:^14.0.1"
@@ -9610,7 +9610,7 @@ __metadata:
     sdp-transform: "npm:^2.14.1"
     unhomoglyph: "npm:^1.0.6"
     uuid: "npm:11"
-  checksum: 10c0/68a30a113059ba052b2e66502abcd9805f9a18a1bfd1d209203d728b36508af257a57e6248fb237c7018c81bfbe1ec78fa17aea8968c8af0729ea935398dcf8b
+  checksum: 10c0/121ecbe4ab6c3ce3fe399ab468958211b0c1c565d6da718903ccc0abc4af7341c764ebee07a553a4222b338bd8665de9fa50bb34a247555b908c4c2b46a97deb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
As introduced in: https://github.com/matrix-org/matrix-js-sdk/pull/4714

~~Is blocked until we bump the js-sdk to a version supporting the new names.~~

This pr now also updates the js-sdk version