### PR TITLE
Fix Playwright tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,6 +46,7 @@ jobs:
         run: yarn playwright install --with-deps
       - name: Run backend components
         run: |
+          docker compose -f playwright-backend-docker-compose.yml -f playwright-backend-docker-compose.override.yml pull
           docker compose -f playwright-backend-docker-compose.yml -f playwright-backend-docker-compose.override.yml up -d
           docker ps
       - name: Copy config file

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,7 +46,7 @@ jobs:
         run: yarn playwright install --with-deps
       - name: Run backend components
         run: |
-          docker compose -f playwright-backend-docker-compose.yml up -d
+          docker compose -f playwright-backend-docker-compose.yml -f playwright-backend-docker-compose.override.yml up -d
           docker ps
       - name: Copy config file
         run: cp config/config.devenv.json public/config.json

--- a/backend/dev_nginx.conf
+++ b/backend/dev_nginx.conf
@@ -62,8 +62,8 @@ server {
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
 
-      # JWT Service running at port 8080
-      proxy_pass http://auth-server:8080/;
+      # JWT Service running at port 6080
+      proxy_pass http://auth-server:6080/;
     }
 
     location ^~ /livekit/sfu/ {

--- a/dev-backend-docker-compose.yml
+++ b/dev-backend-docker-compose.yml
@@ -6,7 +6,7 @@ services:
     image: ghcr.io/element-hq/lk-jwt-service:latest-ci
     hostname: auth-server
     environment:
-      - LIVEKIT_JWT_PORT=8080
+      - LIVEKIT_JWT_PORT=6080
       - LIVEKIT_URL=wss://matrix-rtc.m.localhost/livekit/sfu
       - LIVEKIT_KEY=devkey
       - LIVEKIT_SECRET=secret
@@ -18,7 +18,7 @@ services:
         condition: on-failure
     ports:
       # HOST_PORT:CONTAINER_PORT
-      - 8080:8080
+      - 6080:6080
     networks:
       - ecbackend
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test": "vitest",
     "test:coverage": "vitest --coverage",
     "backend": "docker-compose -f dev-backend-docker-compose.yml up",
+    "backend-playwright": "docker-compose -f playwright-backend-docker-compose.yml -f playwright-backend-docker-compose.override.yml up",
     "test:playwright": "playwright test",
     "test:playwright:open": "yarn test:playwright --ui",
     "links:enable": "mv .links.disabled.yaml .links.yaml & touch .links.yaml",

--- a/playwright/fixtures/widget-user.ts
+++ b/playwright/fixtures/widget-user.ts
@@ -95,11 +95,14 @@ async function registerUser(
   await page.getByRole("textbox", { name: "Confirm password" }).fill(PASSWORD);
   await page.getByRole("button", { name: "Register" }).click();
   const continueButton = page.getByRole("button", { name: "Continue" });
-  if (await continueButton.isVisible().catch(() => false)) {
+  try {
+    await expect(continueButton).toBeVisible({ timeout: 5000 });
     await page
       .getByRole("textbox", { name: "Password", exact: true })
       .fill(PASSWORD);
     await continueButton.click();
+  } catch {
+    // continueButton not visible, continue as normal
   }
   await expect(
     page.getByRole("heading", { name: `Welcome ${username}` }),

--- a/playwright/fixtures/widget-user.ts
+++ b/playwright/fixtures/widget-user.ts
@@ -78,7 +78,7 @@ async function setDevToolElementCallDevUrl(page: Page): Promise<void> {
  * Registers a new user and returns page, clientHandle and mxId.
  */
 async function registerUser(
-  browser: typeof test["browser"],
+  browser: (typeof test)["browser"],
   username: string,
 ): Promise<{ page: Page; clientHandle: JSHandle<MatrixClient>; mxId: string }> {
   const userContext = await browser.newContext({
@@ -88,22 +88,31 @@ async function registerUser(
   await page.goto("http://localhost:8081/#/welcome");
   await page.getByRole("link", { name: "Create Account" }).click();
   await page.getByRole("textbox", { name: "Username" }).fill(username);
-  await page.getByRole("textbox", { name: "Password", exact: true }).fill(PASSWORD);
+  await page
+    .getByRole("textbox", { name: "Password", exact: true })
+    .fill(PASSWORD);
   await page.getByRole("textbox", { name: "Confirm password" }).click();
   await page.getByRole("textbox", { name: "Confirm password" }).fill(PASSWORD);
   await page.getByRole("button", { name: "Register" }).click();
   const continueButton = page.getByRole("button", { name: "Continue" });
   if (await continueButton.isVisible().catch(() => false)) {
-    await page.getByRole("textbox", { name: "Password", exact: true }).fill(PASSWORD);
+    await page
+      .getByRole("textbox", { name: "Password", exact: true })
+      .fill(PASSWORD);
     await continueButton.click();
   }
   await expect(
-    page.getByRole("heading", { name: `Welcome ${username}` })
+    page.getByRole("heading", { name: `Welcome ${username}` }),
   ).toBeVisible();
   await setDevToolElementCallDevUrl(page);
 
-  const clientHandle = await page.evaluateHandle(() => window.mxMatrixClientPeg.get());
-  const mxId = (await clientHandle.evaluate((cli) => cli.getUserId(), clientHandle))!;
+  const clientHandle = await page.evaluateHandle(() =>
+    window.mxMatrixClientPeg.get(),
+  );
+  const mxId = (await clientHandle.evaluate(
+    (cli) => cli.getUserId(),
+    clientHandle,
+  ))!;
 
   return { page, clientHandle, mxId };
 }
@@ -118,10 +127,16 @@ export const widgetTest = test.extend<MyFixtures>({
     const userB = `whistler_${Date.now()}`;
 
     // Register users
-    const { page: ewPage1, clientHandle: brooksClientHandle, mxId: brooksMxId } =
-    await registerUser(browser, userA);
-    const { page: ewPage2, clientHandle: whistlerClientHandle, mxId: whistlerMxId } =
-    await registerUser(browser, userB);
+    const {
+      page: ewPage1,
+      clientHandle: brooksClientHandle,
+      mxId: brooksMxId,
+    } = await registerUser(browser, userA);
+    const {
+      page: ewPage2,
+      clientHandle: whistlerClientHandle,
+      mxId: whistlerMxId,
+    } = await registerUser(browser, userB);
 
     // Invite the second user
     await ewPage1.getByRole("button", { name: "Add room" }).click();

--- a/playwright/fixtures/widget-user.ts
+++ b/playwright/fixtures/widget-user.ts
@@ -5,7 +5,13 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
 Please see LICENSE in the repository root for full details.
 */
 
-import { type Browser, type Page, test, expect, type JSHandle } from "@playwright/test";
+import {
+  type Browser,
+  type Page,
+  test,
+  expect,
+  type JSHandle,
+} from "@playwright/test";
 
 import type { MatrixClient } from "matrix-js-sdk";
 

--- a/playwright/fixtures/widget-user.ts
+++ b/playwright/fixtures/widget-user.ts
@@ -30,8 +30,8 @@ const PASSWORD = "foobarbaz1!";
 const CONFIG_JSON = {
   default_server_config: {
     "m.homeserver": {
-      base_url: "http://synapse.localhost:8008",
-      server_name: "synapse.localhost",
+      base_url: "https://synapse.m.localhost",
+      server_name: "synapse.m.localhost",
     },
   },
 

--- a/playwright/fixtures/widget-user.ts
+++ b/playwright/fixtures/widget-user.ts
@@ -74,6 +74,40 @@ async function setDevToolElementCallDevUrl(page: Page): Promise<void> {
   });
 }
 
+/**
+ * Registers a new user and returns page, clientHandle and mxId.
+ */
+async function registerUser(
+  browser: typeof test["browser"],
+  username: string,
+): Promise<{ page: Page; clientHandle: JSHandle<MatrixClient>; mxId: string }> {
+  const userContext = await browser.newContext({
+    reducedMotion: "reduce",
+  });
+  const page = await userContext.newPage();
+  await page.goto("http://localhost:8081/#/welcome");
+  await page.getByRole("link", { name: "Create Account" }).click();
+  await page.getByRole("textbox", { name: "Username" }).fill(username);
+  await page.getByRole("textbox", { name: "Password", exact: true }).fill(PASSWORD);
+  await page.getByRole("textbox", { name: "Confirm password" }).click();
+  await page.getByRole("textbox", { name: "Confirm password" }).fill(PASSWORD);
+  await page.getByRole("button", { name: "Register" }).click();
+  const continueButton = page.getByRole("button", { name: "Continue" });
+  if (await continueButton.isVisible().catch(() => false)) {
+    await page.getByRole("textbox", { name: "Password", exact: true }).fill(PASSWORD);
+    await continueButton.click();
+  }
+  await expect(
+    page.getByRole("heading", { name: `Welcome ${username}` })
+  ).toBeVisible();
+  await setDevToolElementCallDevUrl(page);
+
+  const clientHandle = await page.evaluateHandle(() => window.mxMatrixClientPeg.get());
+  const mxId = (await clientHandle.evaluate((cli) => cli.getUserId(), clientHandle))!;
+
+  return { page, clientHandle, mxId };
+}
+
 export const widgetTest = test.extend<MyFixtures>({
   asWidget: async ({ browser, context }, pUse) => {
     await context.route(`http://localhost:8081/config.json*`, async (route) => {
@@ -83,75 +117,11 @@ export const widgetTest = test.extend<MyFixtures>({
     const userA = `brooks_${Date.now()}`;
     const userB = `whistler_${Date.now()}`;
 
-    const user1Context = await browser.newContext({
-      reducedMotion: "reduce",
-    });
-    const ewPage1 = await user1Context.newPage();
-    // Register the first user
-    await ewPage1.goto("http://localhost:8081/#/welcome");
-    await ewPage1.getByRole("link", { name: "Create Account" }).click();
-    await ewPage1.getByRole("textbox", { name: "Username" }).fill(userA);
-    await ewPage1
-      .getByRole("textbox", { name: "Password", exact: true })
-      .fill(PASSWORD);
-    await ewPage1.getByRole("textbox", { name: "Confirm password" }).click();
-    await ewPage1
-      .getByRole("textbox", { name: "Confirm password" })
-      .fill(PASSWORD);
-    await ewPage1.getByRole("button", { name: "Register" }).click();
-    await expect(
-      ewPage1.getByRole("button", { name: "Continue" }),
-    ).toBeVisible();
-    await ewPage1
-      .getByRole("textbox", { name: "Password", exact: true })
-      .fill(PASSWORD);
-    await ewPage1.getByRole("button", { name: "Continue" }).click();
-    await expect(
-      ewPage1.getByRole("heading", { name: `Welcome ${userA}` }),
-    ).toBeVisible();
-    await setDevToolElementCallDevUrl(ewPage1);
-
-    const brooksClientHandle = await ewPage1.evaluateHandle(() =>
-      window.mxMatrixClientPeg.get(),
-    );
-    const brooksMxId = (await brooksClientHandle.evaluate((cli) => {
-      return cli.getUserId();
-    }, brooksClientHandle))!;
-
-    const user2Context = await browser.newContext({
-      reducedMotion: "reduce",
-    });
-    const ewPage2 = await user2Context.newPage();
-    // Register the second user
-    await ewPage2.goto("http://localhost:8081/#/welcome");
-    await ewPage2.getByRole("link", { name: "Create Account" }).click();
-    await ewPage2.getByRole("textbox", { name: "Username" }).fill(userB);
-    await ewPage2
-      .getByRole("textbox", { name: "Password", exact: true })
-      .fill(PASSWORD);
-    await ewPage2.getByRole("textbox", { name: "Confirm password" }).click();
-    await ewPage2
-      .getByRole("textbox", { name: "Confirm password" })
-      .fill(PASSWORD);
-    await ewPage2.getByRole("button", { name: "Register" }).click();
-    await expect(
-      ewPage2.getByRole("button", { name: "Continue" }),
-    ).toBeVisible();
-    await ewPage2
-      .getByRole("textbox", { name: "Password", exact: true })
-      .fill(PASSWORD);
-    await ewPage2.getByRole("button", { name: "Continue" }).click();
-    await expect(
-      ewPage2.getByRole("heading", { name: `Welcome ${userB}` }),
-    ).toBeVisible();
-    await setDevToolElementCallDevUrl(ewPage2);
-
-    const whistlerClientHandle = await ewPage2.evaluateHandle(() =>
-      window.mxMatrixClientPeg.get(),
-    );
-    const whistlerMxId = (await whistlerClientHandle.evaluate((cli) => {
-      return cli.getUserId();
-    }, whistlerClientHandle))!;
+    // Register users
+    const { page: ewPage1, clientHandle: brooksClientHandle, mxId: brooksMxId } =
+    await registerUser(browser, userA);
+    const { page: ewPage2, clientHandle: whistlerClientHandle, mxId: whistlerMxId } =
+    await registerUser(browser, userB);
 
     // Invite the second user
     await ewPage1.getByRole("button", { name: "Add room" }).click();

--- a/playwright/fixtures/widget-user.ts
+++ b/playwright/fixtures/widget-user.ts
@@ -100,6 +100,13 @@ export const widgetTest = test.extend<MyFixtures>({
       .fill(PASSWORD);
     await ewPage1.getByRole("button", { name: "Register" }).click();
     await expect(
+      ewPage1.getByRole("button", { name: "Continue" }),
+    ).toBeVisible();
+    await ewPage1
+      .getByRole("textbox", { name: "Password", exact: true })
+      .fill(PASSWORD);
+    await ewPage1.getByRole("button", { name: "Continue" }).click();
+    await expect(
       ewPage1.getByRole("heading", { name: `Welcome ${userA}` }),
     ).toBeVisible();
     await setDevToolElementCallDevUrl(ewPage1);
@@ -127,6 +134,13 @@ export const widgetTest = test.extend<MyFixtures>({
       .getByRole("textbox", { name: "Confirm password" })
       .fill(PASSWORD);
     await ewPage2.getByRole("button", { name: "Register" }).click();
+    await expect(
+      ewPage2.getByRole("button", { name: "Continue" }),
+    ).toBeVisible();
+    await ewPage2
+      .getByRole("textbox", { name: "Password", exact: true })
+      .fill(PASSWORD);
+    await ewPage2.getByRole("button", { name: "Continue" }).click();
     await expect(
       ewPage2.getByRole("heading", { name: `Welcome ${userB}` }),
     ).toBeVisible();

--- a/playwright/fixtures/widget-user.ts
+++ b/playwright/fixtures/widget-user.ts
@@ -5,7 +5,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
 Please see LICENSE in the repository root for full details.
 */
 
-import { type Page, test, expect, type JSHandle } from "@playwright/test";
+import { type Browser, type Page, test, expect, type JSHandle } from "@playwright/test";
 
 import type { MatrixClient } from "matrix-js-sdk";
 
@@ -78,7 +78,7 @@ async function setDevToolElementCallDevUrl(page: Page): Promise<void> {
  * Registers a new user and returns page, clientHandle and mxId.
  */
 async function registerUser(
-  browser: (typeof test)["browser"],
+  browser: Browser,
   username: string,
 ): Promise<{ page: Page; clientHandle: JSHandle<MatrixClient>; mxId: string }> {
   const userContext = await browser.newContext({
@@ -113,7 +113,7 @@ async function registerUser(
     window.mxMatrixClientPeg.get(),
   );
   const mxId = (await clientHandle.evaluate(
-    (cli) => cli.getUserId(),
+    (cli: MatrixClient) => cli.getUserId(),
     clientHandle,
   ))!;
 

--- a/playwright/widget/simple-create.spec.ts
+++ b/playwright/widget/simple-create.spec.ts
@@ -9,12 +9,13 @@ import { expect, test } from "@playwright/test";
 
 import { widgetTest } from "../fixtures/widget-user.ts";
 
-widgetTest("Start a new call as widget", async ({ asWidget, browserName }) => {
-  test.skip(
-    browserName === "firefox",
-    "This test is not working on firefox, after hangup brooks is locked in a strange state with a blank widget",
-  );
+// Skip test, including Fixtures
+widgetTest.skip(
+  ({ browserName }) => browserName === "firefox",
+  "This test is not working on firefox, after hangup brooks is locked in a strange state with a blank widget",
+);
 
+widgetTest("Start a new call as widget", async ({ asWidget, browserName }) => {
   test.slow(); // Triples the timeout
 
   const { brooks, whistler } = asWidget;

--- a/playwright/widget/simple-create.spec.ts
+++ b/playwright/widget/simple-create.spec.ts
@@ -15,6 +15,8 @@ widgetTest("Start a new call as widget", async ({ asWidget, browserName }) => {
     "This test is not working on firefox, after hangup brooks is locked in a strange state with a blank widget",
   );
 
+  test.slow(); // Triples the timeout
+
   const { brooks, whistler } = asWidget;
 
   await expect(


### PR DESCRIPTION
This PR aims at fixing Playwright tests by:
- Resolve port conflicts in docker-compose dev-backend-docker-compose.yml in conjunction with using the element web docker container
  - Change JWT port to 6080 to not conflict with the playwright tests.
- Adapt playwright element web fixture to work with the optional UX flow "Confirm your identity by entering your account password below."
- Fix test.skip() to properly ignore Firefox