### PR TITLE
Fix some correctness issues in useLocalStorage

### DIFF
--- a/src/useLocalStorage.test.tsx
+++ b/src/useLocalStorage.test.tsx
@@ -7,7 +7,8 @@ Please see LICENSE in the repository root for full details.
 
 import { test } from "vitest";
 import { render, screen } from "@testing-library/react";
-import { type FC, useEffect } from "react";
+import { type FC, useEffect, useState } from "react";
+import userEvent from "@testing-library/user-event";
 
 import { setLocalStorageItem, useLocalStorage } from "./useLocalStorage";
 
@@ -20,4 +21,28 @@ test("useLocalStorage reacts to changes made by an effect mounted on the same re
   };
   render(<Test />);
   screen.getByText("Hello!");
+});
+
+test("useLocalStorage reacts to key changes", async () => {
+  localStorage.clear();
+  localStorage.setItem("value-1", "1");
+  localStorage.setItem("value-2", "2");
+
+  const Test: FC = () => {
+    const [key, setKey] = useState("value-1");
+    const [value] = useLocalStorage(key);
+    if (key !== `value-${value}`) throw new Error("Value is out of sync");
+    return (
+      <>
+        <button onClick={() => setKey("value-2")}>Switch keys</button>
+        <div>Value is: {value}</div>
+      </>
+    );
+  };
+  const user = userEvent.setup();
+  render(<Test />);
+
+  screen.getByText("Value is: 1");
+  await user.click(screen.getByRole("button", { name: "Switch keys" }));
+  screen.getByText("Value is: 2");
 });

--- a/src/useLocalStorage.test.tsx
+++ b/src/useLocalStorage.test.tsx
@@ -1,0 +1,23 @@
+/*
+Copyright 2025 New Vector Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE in the repository root for full details.
+*/
+
+import { test } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { type FC, useEffect } from "react";
+
+import { setLocalStorageItem, useLocalStorage } from "./useLocalStorage";
+
+test("useLocalStorage reacts to changes made by an effect mounted on the same render", () => {
+  localStorage.clear();
+  const Test: FC = () => {
+    useEffect(() => setLocalStorageItem("my-value", "Hello!"), []);
+    const [myValue] = useLocalStorage("my-value");
+    return myValue;
+  };
+  render(<Test />);
+  screen.getByText("Hello!");
+});

--- a/src/useLocalStorage.ts
+++ b/src/useLocalStorage.ts
@@ -6,9 +6,10 @@ Please see LICENSE in the repository root for full details.
 */
 
 import EventEmitter from "events";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect } from "react";
 
 import { useLatest } from "./useLatest";
+import { useReactiveState } from "./useReactiveState";
 
 type LocalStorageItem = ReturnType<typeof localStorage.getItem>;
 
@@ -19,8 +20,9 @@ export const localStorageBus = new EventEmitter();
 export const useLocalStorage = (
   key: string,
 ): [LocalStorageItem, (value: string) => void] => {
-  const [value, setValue] = useState<LocalStorageItem>(() =>
-    localStorage.getItem(key),
+  const [value, setValue] = useReactiveState<LocalStorageItem>(
+    () => localStorage.getItem(key),
+    [key],
   );
   const latestValue = useLatest(value);
 

--- a/src/useLocalStorage.ts
+++ b/src/useLocalStorage.ts
@@ -8,6 +8,8 @@ Please see LICENSE in the repository root for full details.
 import EventEmitter from "events";
 import { useCallback, useEffect, useState } from "react";
 
+import { useLatest } from "./useLatest";
+
 type LocalStorageItem = ReturnType<typeof localStorage.getItem>;
 
 // Bus to notify other useLocalStorage consumers when an item is changed
@@ -20,13 +22,22 @@ export const useLocalStorage = (
   const [value, setValue] = useState<LocalStorageItem>(() =>
     localStorage.getItem(key),
   );
+  const latestValue = useLatest(value);
 
   useEffect(() => {
+    // We're about to set up the bus listener that will enable us to react to
+    // any future updates to the localStorage item. However, it's possible that
+    // we already missed an update if there was an effect which modified the
+    // item in the time *between* the render phase of useLocalStorage and the
+    // execution of this effect. Let's update the state if that happened.
+    const stored = localStorage.getItem(key);
+    if (latestValue.current !== stored) setValue(stored);
+
     localStorageBus.on(key, setValue);
     return (): void => {
       localStorageBus.off(key, setValue);
     };
-  }, [key, setValue]);
+  }, [key, latestValue, setValue]);
 
   return [
     value,


### PR DESCRIPTION
See the commits for the full details. I discovered these issues while looking back over https://github.com/element-hq/element-call/pull/3293 with Timo:

- It seems 6258bcec549c1b743601dff5e2c4869f97de8e61 *does* represent a race condition that we're hitting in practice with the `useRoomEncryptionSystem` shared secret logic. https://github.com/element-hq/element-call/pull/3293, as I understand it, causes us to depend on the existence of the race. But really we ought to fix the race (which this commit does), and also fix `useRoomEncryptionSystem` to not depend on it (PR from Timo is https://github.com/element-hq/element-call/pull/3302; this PR will be blocked until then).
- We haven't yet triggered the failure mode addressed by ccf168cadd58c3047e1a6ce178d415337cbd140b in practice, I think; this is more of a theoretical correctness thing.