### PR TITLE
Leave issue refactor

### DIFF
--- a/src/e2ee/sharedKeyManagement.ts
+++ b/src/e2ee/sharedKeyManagement.ts
@@ -7,16 +7,27 @@ Please see LICENSE in the repository root for full details.
 
 import { useEffect, useMemo } from "react";
 
-import { setLocalStorageItem, useLocalStorage } from "../useLocalStorage";
+import {
+  setLocalStorageItemReactive,
+  useLocalStorage,
+} from "../useLocalStorage";
 import { getUrlParams } from "../UrlParams";
 import { E2eeType } from "./e2eeType";
 import { useClient } from "../ClientContext";
+import { logger } from "matrix-js-sdk/lib/logger";
 
 /**
  * This setter will update the state for all `useRoomSharedKey` hooks
+ * if the password is different from the one in local storage or if its not yet in the local storage.
  */
 export function saveKeyForRoom(roomId: string, password: string): void {
-  setLocalStorageItem(getRoomSharedKeyLocalStorageKey(roomId), password);
+  if (
+    localStorage.getItem(getRoomSharedKeyLocalStorageKey(roomId)) !== password
+  )
+    setLocalStorageItemReactive(
+      getRoomSharedKeyLocalStorageKey(roomId),
+      password,
+    );
 }
 
 const getRoomSharedKeyLocalStorageKey = (roomId: string): string =>
@@ -48,7 +59,12 @@ const useRoomSharedKey = (
 
 export function getKeyForRoom(roomId: string): string | null {
   const { roomId: urlRoomId, password } = getUrlParams();
-  if (roomId !== urlRoomId) return null;
+  if (roomId !== urlRoomId)
+    logger.warn(
+      "requested key for a roomId which is not the current call room id (from the URL)",
+      roomId,
+      urlRoomId,
+    );
   return (
     password ?? localStorage.getItem(getRoomSharedKeyLocalStorageKey(roomId))
   );

--- a/src/e2ee/sharedKeyManagement.ts
+++ b/src/e2ee/sharedKeyManagement.ts
@@ -8,10 +8,13 @@ Please see LICENSE in the repository root for full details.
 import { useEffect, useMemo } from "react";
 
 import { setLocalStorageItem, useLocalStorage } from "../useLocalStorage";
-import { type UrlParams, getUrlParams, useUrlParams } from "../UrlParams";
+import { getUrlParams } from "../UrlParams";
 import { E2eeType } from "./e2eeType";
 import { useClient } from "../ClientContext";
 
+/**
+ * This setter will update the state for all `useRoomSharedKey` hooks
+ */
 export function saveKeyForRoom(roomId: string, password: string): void {
   setLocalStorageItem(getRoomSharedKeyLocalStorageKey(roomId), password);
 }
@@ -19,44 +22,37 @@ export function saveKeyForRoom(roomId: string, password: string): void {
 const getRoomSharedKeyLocalStorageKey = (roomId: string): string =>
   `room-shared-key-${roomId}`;
 
-const useInternalRoomSharedKey = (roomId: string): string | null => {
-  const key = getRoomSharedKeyLocalStorageKey(roomId);
-  const [roomSharedKey] = useLocalStorage(key);
+/**
+ * An upto-date shared key for the room. Either from local storage or the value from `setInitialValue`.
+ * @param roomId
+ * @param setInitialValue The value we get from the URL. The hook will overwrite the local storage value with this.
+ * @returns [roomSharedKey, setRoomSharedKey] like a react useState hook.
+ */
+const useRoomSharedKey = (
+  roomId: string,
+  setInitialValue?: string,
+): [string | null, setKey: (key: string) => void] => {
+  const [roomSharedKey, setRoomSharedKey] = useLocalStorage(
+    getRoomSharedKeyLocalStorageKey(roomId),
+  );
+  useEffect(() => {
+    // If setInitialValue is available, update the local storage (usually the password from the url).
+    // This will update roomSharedKey but wont update the returned value since
+    // that already defaults to setInitialValue.
+    if (setInitialValue) setRoomSharedKey(setInitialValue);
+  }, [setInitialValue, setRoomSharedKey]);
 
-  return roomSharedKey;
+  // make sure we never return the initial null value from `useLocalStorage`
+  return [setInitialValue ?? roomSharedKey, setRoomSharedKey];
 };
 
 export function getKeyForRoom(roomId: string): string | null {
-  saveKeyFromUrlParams(getUrlParams());
-  const key = getRoomSharedKeyLocalStorageKey(roomId);
-  return localStorage.getItem(key);
+  const { roomId: urlRoomId, password } = getUrlParams();
+  if (roomId !== urlRoomId) return null;
+  return (
+    password ?? localStorage.getItem(getRoomSharedKeyLocalStorageKey(roomId))
+  );
 }
-
-function saveKeyFromUrlParams(urlParams: UrlParams): void {
-  if (!urlParams.password || !urlParams.roomId) return;
-
-  // Take the key from the URL and save it.
-  // It's important to always use the room ID specified in the URL
-  // when saving keys rather than whatever the current room ID might be,
-  // in case we've moved to a different room but the URL hasn't changed.
-  saveKeyForRoom(urlParams.roomId, urlParams.password);
-}
-
-/**
- * Extracts the room password from the URL if one is present, saving it in localstorage
- * and returning it in a tuple with the corresponding room ID from the URL.
- * @returns A tuple of the roomId and password from the URL if the URL has both,
- *          otherwise [undefined, undefined]
- */
-const useKeyFromUrl = (): [string, string] | [undefined, undefined] => {
-  const urlParams = useUrlParams();
-
-  useEffect(() => saveKeyFromUrlParams(urlParams), [urlParams]);
-
-  return urlParams.roomId && urlParams.password
-    ? [urlParams.roomId, urlParams.password]
-    : [undefined, undefined];
-};
 
 export type Unencrypted = { kind: E2eeType.NONE };
 export type SharedSecret = { kind: E2eeType.SHARED_KEY; secret: string };
@@ -66,12 +62,11 @@ export type EncryptionSystem = Unencrypted | SharedSecret | PerParticipantE2EE;
 export function useRoomEncryptionSystem(roomId: string): EncryptionSystem {
   const { client } = useClient();
 
-  // make sure we've extracted the key from the URL first
-  // (and we still need to take the value it returns because
-  // the effect won't run in time for it to save to localstorage in
-  // time for us to read it out again).
-  const [urlRoomId, passwordFromUrl] = useKeyFromUrl();
-  const storedPassword = useInternalRoomSharedKey(roomId);
+  const [storedPassword] = useRoomSharedKey(
+    getRoomSharedKeyLocalStorageKey(roomId),
+    getKeyForRoom(roomId) ?? undefined,
+  );
+
   const room = client?.getRoom(roomId);
   const e2eeSystem = <EncryptionSystem>useMemo(() => {
     if (!room) return { kind: E2eeType.NONE };
@@ -80,15 +75,10 @@ export function useRoomEncryptionSystem(roomId: string): EncryptionSystem {
         kind: E2eeType.SHARED_KEY,
         secret: storedPassword,
       };
-    if (urlRoomId === roomId)
-      return {
-        kind: E2eeType.SHARED_KEY,
-        secret: passwordFromUrl,
-      };
     if (room.hasEncryptionStateEvent()) {
       return { kind: E2eeType.PER_PARTICIPANT };
     }
     return { kind: E2eeType.NONE };
-  }, [passwordFromUrl, room, roomId, storedPassword, urlRoomId]);
+  }, [room, storedPassword]);
   return e2eeSystem;
 }

--- a/src/e2ee/sharedKeyManagement.ts
+++ b/src/e2ee/sharedKeyManagement.ts
@@ -6,6 +6,7 @@ Please see LICENSE in the repository root for full details.
 */
 
 import { useEffect, useMemo } from "react";
+import { logger } from "matrix-js-sdk/lib/logger";
 
 import {
   setLocalStorageItemReactive,
@@ -14,7 +15,6 @@ import {
 import { getUrlParams } from "../UrlParams";
 import { E2eeType } from "./e2eeType";
 import { useClient } from "../ClientContext";
-import { logger } from "matrix-js-sdk/lib/logger";
 
 /**
  * This setter will update the state for all `useRoomSharedKey` hooks

--- a/src/home/useGroupCallRooms.ts
+++ b/src/home/useGroupCallRooms.ts
@@ -21,7 +21,7 @@ import {
   type MatrixRTCSession,
 } from "matrix-js-sdk/lib/matrixrtc";
 
-import { getKeyForRoom, saveKeyForRoom } from "../e2ee/sharedKeyManagement";
+import { getKeyForRoom } from "../e2ee/sharedKeyManagement";
 
 export interface GroupCallRoom {
   roomAlias?: string;
@@ -87,7 +87,6 @@ const roomIsJoinable = (room: Room): boolean => {
     // in case this key also does not exists we cannot join the room.
     return false;
   }
-  if (password) saveKeyForRoom(room.roomId, password);
   // otherwise we can always join rooms because we will automatically decide if we want to use perParticipant or password
   switch (room.getJoinRule()) {
     case JoinRule.Public:

--- a/src/home/useGroupCallRooms.ts
+++ b/src/home/useGroupCallRooms.ts
@@ -21,7 +21,7 @@ import {
   type MatrixRTCSession,
 } from "matrix-js-sdk/lib/matrixrtc";
 
-import { getKeyForRoom } from "../e2ee/sharedKeyManagement";
+import { getKeyForRoom, saveKeyForRoom } from "../e2ee/sharedKeyManagement";
 
 export interface GroupCallRoom {
   roomAlias?: string;
@@ -81,11 +81,13 @@ function sortRooms(client: MatrixClient, rooms: Room[]): Room[] {
 }
 
 const roomIsJoinable = (room: Room): boolean => {
-  if (!room.hasEncryptionStateEvent() && !getKeyForRoom(room.roomId)) {
-    // if we have an non encrypted room (no encryption state event) we need a locally stored shared key.
+  const password = getKeyForRoom(room.roomId);
+  if (!room.hasEncryptionStateEvent() && !password) {
+    // if we have a non encrypted room (no encryption state event) we need a locally stored shared key.
     // in case this key also does not exists we cannot join the room.
     return false;
   }
+  if (password) saveKeyForRoom(room.roomId, password);
   // otherwise we can always join rooms because we will automatically decide if we want to use perParticipant or password
   switch (room.getJoinRule()) {
     case JoinRule.Public:

--- a/src/livekit/useLivekit.ts
+++ b/src/livekit/useLivekit.ts
@@ -14,7 +14,7 @@ import {
   type RoomOptions,
   Track,
 } from "livekit-client";
-import { useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import E2EEWorker from "livekit-client/e2ee-worker?worker";
 import { logger } from "matrix-js-sdk/lib/logger";
 import { type MatrixRTCSession } from "matrix-js-sdk/lib/matrixrtc";
@@ -40,7 +40,6 @@ import {
   useTrackProcessor,
   useTrackProcessorSync,
 } from "./TrackProcessorContext";
-import { useInitial } from "../useInitial";
 import { observeTrackReference$ } from "../state/MediaViewModel";
 import { useUrlParams } from "../UrlParams";
 
@@ -57,64 +56,9 @@ export function useLivekit(
 ): UseLivekitResult {
   const { controlledAudioDevices } = useUrlParams();
 
-  const e2eeOptions = useMemo((): E2EEManagerOptions | undefined => {
-    if (e2eeSystem.kind === E2eeType.NONE) return undefined;
-
-    if (e2eeSystem.kind === E2eeType.PER_PARTICIPANT) {
-      logger.info("Created MatrixKeyProvider (per participant)");
-      return {
-        keyProvider: new MatrixKeyProvider(),
-        worker: new E2EEWorker(),
-      };
-    } else if (e2eeSystem.kind === E2eeType.SHARED_KEY && e2eeSystem.secret) {
-      logger.info("Created ExternalE2EEKeyProvider (shared key)");
-
-      return {
-        keyProvider: new ExternalE2EEKeyProvider(),
-        worker: new E2EEWorker(),
-      };
-    }
-  }, [e2eeSystem]);
-
-  useEffect(() => {
-    if (e2eeSystem.kind === E2eeType.NONE || !e2eeOptions) return;
-
-    if (e2eeSystem.kind === E2eeType.PER_PARTICIPANT) {
-      (e2eeOptions.keyProvider as MatrixKeyProvider).setRTCSession(rtcSession);
-    } else if (e2eeSystem.kind === E2eeType.SHARED_KEY && e2eeSystem.secret) {
-      (e2eeOptions.keyProvider as ExternalE2EEKeyProvider)
-        .setKey(e2eeSystem.secret)
-        .catch((e) => {
-          logger.error("Failed to set shared key for E2EE", e);
-        });
-    }
-  }, [e2eeOptions, e2eeSystem, rtcSession]);
-
   const initialMuteStates = useRef<MuteStates>(muteStates);
   const devices = useMediaDevices();
   const initialDevices = useRef<MediaDevices>(devices);
-
-  const { processor } = useTrackProcessor();
-  const initialProcessor = useInitial(() => processor);
-  const roomOptions = useMemo(
-    (): RoomOptions => ({
-      ...defaultLiveKitOptions,
-      videoCaptureDefaults: {
-        ...defaultLiveKitOptions.videoCaptureDefaults,
-        deviceId: initialDevices.current.videoInput.selectedId,
-        processor: initialProcessor,
-      },
-      audioCaptureDefaults: {
-        ...defaultLiveKitOptions.audioCaptureDefaults,
-        deviceId: initialDevices.current.audioInput.selectedId,
-      },
-      audioOutput: {
-        deviceId: initialDevices.current.audioOutput.selectedId,
-      },
-      e2ee: e2eeOptions,
-    }),
-    [e2eeOptions, initialProcessor],
-  );
 
   // Store if audio/video are currently updating. If to prohibit unnecessary calls
   // to setMicrophoneEnabled/setCameraEnabled
@@ -127,17 +71,112 @@ export function useLivekit(
     video: initialMuteStates.current.video.enabled,
   });
 
-  // We have to create the room manually here due to a bug inside
-  // @livekit/components-react. JSON.stringify() is used in deps of a
-  // useEffect() with an argument that references itself, if E2EE is enabled
-  const room = useMemo(() => {
-    logger.info("[LivekitRooms] Create LiveKit room with options", roomOptions);
-    const r = new Room(roomOptions);
-    r.setE2EEEnabled(e2eeSystem.kind !== E2eeType.NONE).catch((e) => {
+  const { processor } = useTrackProcessor();
+
+  const createRoom = (opt: RoomOptions, e2ee: EncryptionSystem): Room => {
+    logger.info("[LivekitRoom] Create LiveKit room with options", opt);
+    // We have to create the room manually here due to a bug inside
+    // @livekit/components-react. JSON.stringify() is used in deps of a
+    // useEffect() with an argument that references itself, if E2EE is enabled
+    let newE2eeOptions: E2EEManagerOptions | undefined;
+    if (e2ee.kind === E2eeType.PER_PARTICIPANT) {
+      logger.info("Created MatrixKeyProvider (per participant)");
+      newE2eeOptions = {
+        keyProvider: new MatrixKeyProvider(),
+        worker: new E2EEWorker(),
+      };
+    } else if (e2ee.kind === E2eeType.SHARED_KEY && e2ee.secret) {
+      logger.info("Created ExternalE2EEKeyProvider (shared key)");
+      newE2eeOptions = {
+        keyProvider: new ExternalE2EEKeyProvider(),
+        worker: new E2EEWorker(),
+      };
+    }
+    const r = new Room({ ...opt, e2ee: newE2eeOptions });
+    r.setE2EEEnabled(e2ee.kind !== E2eeType.NONE).catch((e) => {
       logger.error("Failed to set E2EE enabled on room", e);
     });
+
     return r;
-  }, [roomOptions, e2eeSystem]);
+  };
+
+  // Track the current room options in case we need to recreate the room if the encryption system changes
+  // Only needed because we allow swapping the room in case the e2ee system changes.
+  // otherwise this could become part of: `createRoom`
+  const roomOptions = useMemo(
+    (): RoomOptions => ({
+      ...defaultLiveKitOptions,
+      videoCaptureDefaults: {
+        ...defaultLiveKitOptions.videoCaptureDefaults,
+        deviceId: devices.videoInput.selectedId,
+        processor: processor,
+      },
+      audioCaptureDefaults: {
+        ...defaultLiveKitOptions.audioCaptureDefaults,
+        deviceId: devices.audioInput.selectedId,
+      },
+      audioOutput: {
+        deviceId: devices.audioOutput.selectedId,
+      },
+    }),
+    [processor, devices],
+  );
+  const [room, setRoom] = useState(() => createRoom(roomOptions, e2eeSystem));
+
+  // Setup and update the already existing keyProvider
+  useEffect(() => {
+    const e2eeOptions = room.options.e2ee;
+    if (
+      e2eeSystem.kind === E2eeType.NONE ||
+      !(e2eeOptions && "keyProvider" in e2eeOptions)
+    )
+      return;
+
+    if (e2eeSystem.kind === E2eeType.PER_PARTICIPANT) {
+      (e2eeOptions.keyProvider as MatrixKeyProvider).setRTCSession(rtcSession);
+    } else if (e2eeSystem.kind === E2eeType.SHARED_KEY && e2eeSystem.secret) {
+      (e2eeOptions.keyProvider as ExternalE2EEKeyProvider)
+        .setKey(e2eeSystem.secret)
+        .catch((e) => {
+          logger.error("Failed to set shared key for E2EE", e);
+        });
+    }
+  }, [room.options.e2ee, e2eeSystem, rtcSession]);
+
+  // Do we really allow hot swapping the e2ee system?
+  // Will we ever reach this code?
+  useEffect(() => {
+    const e2eeOptions = room.options.e2ee;
+    // Only do sth if our e2eeSystem has changed.
+    if (
+      // from non to sth else.
+      (e2eeSystem.kind === E2eeType.NONE && e2eeOptions !== undefined) ||
+      // from MatrixKeyProvider to sth else
+      (e2eeSystem.kind === E2eeType.PER_PARTICIPANT &&
+        !(
+          e2eeOptions &&
+          "keyProvider" in e2eeOptions &&
+          e2eeOptions.keyProvider instanceof MatrixKeyProvider
+        )) ||
+      // from ExternalE2EEKeyProvider to sth else
+      (e2eeSystem.kind === E2eeType.SHARED_KEY &&
+        !(
+          e2eeOptions &&
+          "keyProvider" in e2eeOptions &&
+          e2eeOptions.keyProvider instanceof ExternalE2EEKeyProvider
+        ))
+    ) {
+      logger.warn(
+        "[LivekitRoom] we cannot change the key provider after the room has been created, disconnecting and creating a new room",
+      );
+      const resetRoom = async (): Promise<void> => {
+        await room.disconnect();
+        const newRoom = createRoom(roomOptions, e2eeSystem);
+        setRoom(newRoom);
+      };
+      void resetRoom();
+    }
+  }, [room, e2eeSystem, roomOptions, createRoom]);
 
   // Sync the requested track processors with LiveKit
   useTrackProcessorSync(

--- a/src/livekit/useLivekit.ts
+++ b/src/livekit/useLivekit.ts
@@ -14,7 +14,7 @@ import {
   type RoomOptions,
   Track,
 } from "livekit-client";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef } from "react";
 import E2EEWorker from "livekit-client/e2ee-worker?worker";
 import { logger } from "matrix-js-sdk/lib/logger";
 import { type MatrixRTCSession } from "matrix-js-sdk/lib/matrixrtc";
@@ -24,11 +24,7 @@ import { map } from "rxjs";
 import { defaultLiveKitOptions } from "./options";
 import { type SFUConfig } from "./openIDSFU";
 import { type MuteStates } from "../room/MuteStates";
-import {
-  type MediaDeviceHandle,
-  type MediaDevices,
-  useMediaDevices,
-} from "./MediaDevicesContext";
+import { type MediaDeviceHandle, useMediaDevices } from "./MediaDevicesContext";
 import {
   type ECConnectionState,
   useECConnectionState,
@@ -42,6 +38,7 @@ import {
 } from "./TrackProcessorContext";
 import { observeTrackReference$ } from "../state/MediaViewModel";
 import { useUrlParams } from "../UrlParams";
+import { useInitial } from "../useInitial";
 
 interface UseLivekitResult {
   livekitRoom?: Room;
@@ -56,9 +53,10 @@ export function useLivekit(
 ): UseLivekitResult {
   const { controlledAudioDevices } = useUrlParams();
 
-  const initialMuteStates = useRef<MuteStates>(muteStates);
+  const initialMuteStates = useInitial(() => muteStates);
+
   const devices = useMediaDevices();
-  const initialDevices = useRef<MediaDevices>(devices);
+  const initialDevices = useInitial(() => devices);
 
   // Store if audio/video are currently updating. If to prohibit unnecessary calls
   // to setMicrophoneEnabled/setCameraEnabled
@@ -67,63 +65,59 @@ export function useLivekit(
   // Store the current button mute state that gets passed to this hook via props.
   // We need to store it for awaited code that relies on the current value.
   const buttonEnabled = useRef({
-    audio: initialMuteStates.current.audio.enabled,
-    video: initialMuteStates.current.video.enabled,
+    audio: initialMuteStates.audio.enabled,
+    video: initialMuteStates.video.enabled,
   });
 
   const { processor } = useTrackProcessor();
 
-  const createRoom = (opt: RoomOptions, e2ee: EncryptionSystem): Room => {
-    logger.info("[LivekitRoom] Create LiveKit room with options", opt);
-    // We have to create the room manually here due to a bug inside
-    // @livekit/components-react. JSON.stringify() is used in deps of a
-    // useEffect() with an argument that references itself, if E2EE is enabled
-    let newE2eeOptions: E2EEManagerOptions | undefined;
-    if (e2ee.kind === E2eeType.PER_PARTICIPANT) {
+  // Only ever create the room once via useInitial.
+  const room = useInitial(() => {
+    logger.info("[LivekitRoom] Create LiveKit room");
+
+    let e2ee: E2EEManagerOptions | undefined;
+    if (e2eeSystem.kind === E2eeType.PER_PARTICIPANT) {
       logger.info("Created MatrixKeyProvider (per participant)");
-      newE2eeOptions = {
+      e2ee = {
         keyProvider: new MatrixKeyProvider(),
         worker: new E2EEWorker(),
       };
-    } else if (e2ee.kind === E2eeType.SHARED_KEY && e2ee.secret) {
+    } else if (e2eeSystem.kind === E2eeType.SHARED_KEY && e2eeSystem.secret) {
       logger.info("Created ExternalE2EEKeyProvider (shared key)");
-      newE2eeOptions = {
+      e2ee = {
         keyProvider: new ExternalE2EEKeyProvider(),
         worker: new E2EEWorker(),
       };
     }
-    const r = new Room({ ...opt, e2ee: newE2eeOptions });
-    r.setE2EEEnabled(e2ee.kind !== E2eeType.NONE).catch((e) => {
-      logger.error("Failed to set E2EE enabled on room", e);
-    });
 
-    return r;
-  };
-
-  // Track the current room options in case we need to recreate the room if the encryption system changes
-  // Only needed because we allow swapping the room in case the e2ee system changes.
-  // otherwise this could become part of: `createRoom`
-  const roomOptions = useMemo(
-    (): RoomOptions => ({
+    const roomOptions: RoomOptions = {
       ...defaultLiveKitOptions,
       videoCaptureDefaults: {
         ...defaultLiveKitOptions.videoCaptureDefaults,
-        deviceId: devices.videoInput.selectedId,
-        processor: processor,
+        deviceId: initialDevices.videoInput.selectedId,
+        processor,
       },
       audioCaptureDefaults: {
         ...defaultLiveKitOptions.audioCaptureDefaults,
-        deviceId: devices.audioInput.selectedId,
+        deviceId: initialDevices.audioInput.selectedId,
       },
       audioOutput: {
-        deviceId: devices.audioOutput.selectedId,
+        deviceId: initialDevices.audioOutput.selectedId,
       },
-    }),
-    [processor, devices],
-  );
-  const [room, setRoom] = useState(() => createRoom(roomOptions, e2eeSystem));
+      e2ee,
+    };
+    // We have to create the room manually here due to a bug inside
+    // @livekit/components-react. JSON.stringify() is used in deps of a
+    // useEffect() with an argument that references itself, if E2EE is enabled
+    const room = new Room(roomOptions);
+    room.setE2EEEnabled(e2eeSystem.kind !== E2eeType.NONE).catch((e) => {
+      logger.error("Failed to set E2EE enabled on room", e);
+    });
 
-  // Setup and update the already existing keyProvider
+    return room;
+  });
+
+  // Setup and update the keyProvider which was create by `createRoom`
   useEffect(() => {
     const e2eeOptions = room.options.e2ee;
     if (
@@ -142,41 +136,6 @@ export function useLivekit(
         });
     }
   }, [room.options.e2ee, e2eeSystem, rtcSession]);
-
-  // Do we really allow hot swapping the e2ee system?
-  // Will we ever reach this code?
-  useEffect(() => {
-    const e2eeOptions = room.options.e2ee;
-    // Only do sth if our e2eeSystem has changed.
-    if (
-      // from non to sth else.
-      (e2eeSystem.kind === E2eeType.NONE && e2eeOptions !== undefined) ||
-      // from MatrixKeyProvider to sth else
-      (e2eeSystem.kind === E2eeType.PER_PARTICIPANT &&
-        !(
-          e2eeOptions &&
-          "keyProvider" in e2eeOptions &&
-          e2eeOptions.keyProvider instanceof MatrixKeyProvider
-        )) ||
-      // from ExternalE2EEKeyProvider to sth else
-      (e2eeSystem.kind === E2eeType.SHARED_KEY &&
-        !(
-          e2eeOptions &&
-          "keyProvider" in e2eeOptions &&
-          e2eeOptions.keyProvider instanceof ExternalE2EEKeyProvider
-        ))
-    ) {
-      logger.warn(
-        "[LivekitRoom] we cannot change the key provider after the room has been created, disconnecting and creating a new room",
-      );
-      const resetRoom = async (): Promise<void> => {
-        await room.disconnect();
-        const newRoom = createRoom(roomOptions, e2eeSystem);
-        setRoom(newRoom);
-      };
-      void resetRoom();
-    }
-  }, [room, e2eeSystem, roomOptions, createRoom]);
 
   // Sync the requested track processors with LiveKit
   useTrackProcessorSync(
@@ -198,8 +157,8 @@ export function useLivekit(
   );
 
   const connectionState = useECConnectionState(
-    initialDevices.current.audioInput.selectedId,
-    initialMuteStates.current.audio.enabled,
+    initialDevices.audioInput.selectedId,
+    initialMuteStates.audio.enabled,
     room,
     sfuConfig,
   );

--- a/src/room/GroupCallView.tsx
+++ b/src/room/GroupCallView.tsx
@@ -43,7 +43,10 @@ import { MUTE_PARTICIPANT_COUNT, type MuteStates } from "./MuteStates";
 import { useMediaDevices } from "../livekit/MediaDevicesContext";
 import { useMatrixRTCSessionMemberships } from "../useMatrixRTCSessionMemberships";
 import { enterRTCSession, leaveRTCSession } from "../rtcSessionHelpers";
-import { useRoomEncryptionSystem } from "../e2ee/sharedKeyManagement";
+import {
+  saveKeyForRoom,
+  useRoomEncryptionSystem,
+} from "../e2ee/sharedKeyManagement";
 import { useRoomAvatar } from "./useRoomAvatar";
 import { useRoomName } from "./useRoomName";
 import { useJoinRule } from "./useJoinRule";
@@ -166,6 +169,12 @@ export const GroupCallView: FC<Props> = ({
   const [useExperimentalToDeviceTransport] = useSetting(
     useExperimentalToDeviceTransportSetting,
   );
+
+  // Save the password once we start the groupCallView
+  const { password: passwordFromUrl } = useUrlParams();
+  useEffect(() => {
+    if (passwordFromUrl) saveKeyForRoom(room.roomId, passwordFromUrl);
+  }, [passwordFromUrl, room.roomId]);
 
   usePageTitle(roomName);
 

--- a/src/room/InCallView.tsx
+++ b/src/room/InCallView.tsx
@@ -148,7 +148,7 @@ export const ActiveCall: FC<ActiveCallProps> = (props) => {
         });
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [livekitRoom]);
 
   useEffect(() => {
     if (livekitRoom !== undefined) {

--- a/src/room/InCallView.tsx
+++ b/src/room/InCallView.tsx
@@ -147,7 +147,6 @@ export const ActiveCall: FC<ActiveCallProps> = (props) => {
           logger.error("[Lifecycle] Failed to disconnect from livekit room", e);
         });
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [livekitRoom]);
 
   useEffect(() => {

--- a/src/useLocalStorage.ts
+++ b/src/useLocalStorage.ts
@@ -15,8 +15,8 @@ export const localStorageBus = new EventEmitter();
 
 /**
  * Like useState, but reads from and persists the value to localStorage
- * this hook will not update when we write to localStorage.setItem(key, value) directly.
- * For the hook to react either use the returned setter or `saveKeyForRoom`.
+ * This hook will not update when we write to localStorage.setItem(key, value) directly.
+ * For the hook to react either use the returned setter or `setLocalStorageItemReactive`.
  */
 export const useLocalStorage = (
   key: string,
@@ -45,7 +45,10 @@ export const useLocalStorage = (
   ];
 };
 
-export const setLocalStorageItem = (key: string, value: string): void => {
+export const setLocalStorageItemReactive = (
+  key: string,
+  value: string,
+): void => {
   localStorage.setItem(key, value);
   localStorageBus.emit(key, value);
 };

--- a/src/useLocalStorage.ts
+++ b/src/useLocalStorage.ts
@@ -13,7 +13,11 @@ type LocalStorageItem = ReturnType<typeof localStorage.getItem>;
 // Bus to notify other useLocalStorage consumers when an item is changed
 export const localStorageBus = new EventEmitter();
 
-// Like useState, but reads from and persists the value to localStorage
+/**
+ * Like useState, but reads from and persists the value to localStorage
+ * this hook will not update when we write to localStorage.setItem(key, value) directly.
+ * For the hook to react either use the returned setter or `saveKeyForRoom`.
+ */
 export const useLocalStorage = (
   key: string,
 ): [LocalStorageItem, (value: string) => void] => {
@@ -42,14 +46,6 @@ export const useLocalStorage = (
 };
 
 export const setLocalStorageItem = (key: string, value: string): void => {
-  // Avoid unnecessary updates. Not avoiding them so can cause unexpected state updates across hooks.
-  // For instance:
-  // - In call view uses useRoomEncryptionSystem
-  // - This will set the key again.
-  // - All other instances of useRoomEncryptionSystem will now do a useMemo update of the e2eeSystem
-  //   - because the dependency `storedPassword = useInternalRoomSharedKey(roomId);` would change.
-  if (localStorage.getItem(key) === value) return;
-
   localStorage.setItem(key, value);
   localStorageBus.emit(key, value);
 };


### PR DESCRIPTION
A follow up refactor after the leave issue fix.

It contains two parts:
 - simplifying the local storage key management
 - refactoring useLivekit

This change tries to make the code more explicit so that we only do the things we really need to do and rely less on react updating everything correctly.

It also surfaces, that we are currently implementing useLivekit in a way, so that we can change the encryption system on the fly and recreate the room. I am not sure this is a case we need to support?