### PR TITLE
Break loop in acquiring media on Safari

### DIFF
--- a/src/livekit/MediaDevicesContext.tsx
+++ b/src/livekit/MediaDevicesContext.tsx
@@ -17,9 +17,10 @@ import {
   type JSX,
 } from "react";
 import { createMediaDeviceObserver } from "@livekit/components-core";
-import { combineLatest, map, startWith } from "rxjs";
+import { combineLatest, distinctUntilChanged, map, startWith } from "rxjs";
 import { useObservable, useObservableEagerState } from "observable-hooks";
 import { logger } from "matrix-js-sdk/lib/logger";
+import { isEqual } from "lodash-es";
 
 import {
   useSetting,
@@ -140,7 +141,13 @@ function useMediaDeviceHandle(
         kind,
         () => logger.error("Error creating MediaDeviceObserver"),
         requestPermissions,
-      ).pipe(startWith([])),
+        // This Observable emits new values whenever the browser fires a
+        // MediaDevices 'devicechange' event. One would think, innocently, that
+        // a 'devicechange' event means the devices have changed. But as of the
+        // time of writing, we are seeing mobile Safari firing spurious
+        // 'devicechange' events (where no change has actually occurred) when
+        // we call MediaDevices.getUserMedia. So, filter by deep equality.
+      ).pipe(startWith([]), distinctUntilChanged<MediaDeviceInfo[]>(isEqual)),
     [kind, requestPermissions],
   );
   const available = useObservableEagerState(

--- a/src/room/LobbyView.tsx
+++ b/src/room/LobbyView.tsx
@@ -53,6 +53,7 @@ import {
   useTrackProcessorSync,
 } from "../livekit/TrackProcessorContext";
 import { usePageTitle } from "../usePageTitle";
+import { useLatest } from "../useLatest";
 
 interface Props {
   client: MatrixClient;
@@ -159,13 +160,14 @@ export const LobbyView: FC<Props> = ({
     ],
   );
 
+  const latestMuteStates = useLatest(muteStates);
   const onError = useCallback(
     (error: Error) => {
       logger.error("Error while creating preview Tracks:", error);
-      muteStates.audio.setEnabled?.(false);
-      muteStates.video.setEnabled?.(false);
+      latestMuteStates.current.audio.setEnabled?.(false);
+      latestMuteStates.current.video.setEnabled?.(false);
     },
-    [muteStates.audio, muteStates.video],
+    [latestMuteStates],
   );
 
   const tracks = usePreviewTracks(localTrackOptions, onError);

--- a/src/room/MuteStates.ts
+++ b/src/room/MuteStates.ts
@@ -60,7 +60,7 @@ function useMuteState(
     // Determine the default value once devices are actually connected
     (prev) =>
       prev ?? (device.available.size > 0 ? enabledByDefault() : undefined),
-    [device],
+    [device.available.size],
   );
   return useMemo(
     () =>
@@ -70,7 +70,7 @@ function useMuteState(
             enabled: enabled ?? false,
             setEnabled: setEnabled as Dispatch<SetStateAction<boolean>>,
           },
-    [device, enabled, setEnabled],
+    [device.available.size, enabled, setEnabled],
   );
 }
 


### PR DESCRIPTION
As of this week we've started seeing an issue in mobile Safari where Element Call will fail to acquire media, calling `getUserMedia` over and over in a loop. How this happened:

- It seems that, for whatever reason (a recent Safari update?) the browser will emit a MediaDevices 'devicechange' event whenever you call `getUserMedia`, even though there is no change in the devices returned by `enumerateDevices`.
- Then, because Element Call's reactivity happened to be a little too coarse-grained in a couple of spots (specifically, the LobbyView and MuteStates files), every 'devicechange' event would have the unintentional side effect of triggering a new call to `getUserMedia`. And so, the loop begins.

While it is pretty annoying that Safari has started emitting spurious 'devicechange' events, we can easily work around this situation by making our reactivity more fine-grained, breaking the loop. And this may result in performance improvements for all browsers, so, why not.

Here's the specifics of the loop:

- LobbyView calls `usePreviewTracks`
- `usePreviewTracks` has an effect which calls `getUserMedia`
- The browser emits a MediaDevices 'devicechange' event
- Media devices observer emits a new devices map
- MediaDevicesContext invalidates its available devices memo and returns a new devices map
- Devices map is passed to MuteStates
- MuteStates (unnecessarily) invalidates its mute states memos and returns new ones
- Mute states are passed to the LobbyView
- LobbyView (unnecessarily) invalidates its `onError` callback and passes a new one to `usePreviewTracks`
- `usePreviewTracks` uses the `onError` callback as one of the effect dependencies, so the effect runs again, and we call `getUserMedia` again