### PR TITLE
Revert "Upgrade Android publishing to use Maven Central Portal"

### DIFF
--- a/embedded/android/gradle/libs.versions.toml
+++ b/embedded/android/gradle/libs.versions.toml
@@ -9,4 +9,4 @@ android_gradle_plugin = { module = "com.android.tools.build:gradle", version.ref
 
 [plugins]
 android_library = { id = "com.android.library", version.ref = "android_gradle_plugin" }
-maven_publish = { id = "com.vanniktech.maven.publish", version = "0.32.0" }
+maven_publish = { id = "com.vanniktech.maven.publish", version = "0.31.0" }

--- a/embedded/android/lib/build.gradle.kts
+++ b/embedded/android/lib/build.gradle.kts
@@ -27,7 +27,7 @@ android {
 }
 
 mavenPublishing {
-    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, automaticRelease = true)
+    publishToMavenCentral(SonatypeHost.S01, automaticRelease = true)
 
     signAllPublications()
 


### PR DESCRIPTION
Reverts element-hq/element-call#3313

This PR was merged too soon, we'll add it back once we're ready to do the migration.