### PR TITLE
Upgrade Android publishing to use Maven Central Portal (again)

### DIFF
--- a/embedded/android/gradle/libs.versions.toml
+++ b/embedded/android/gradle/libs.versions.toml
@@ -9,4 +9,4 @@ android_gradle_plugin = { module = "com.android.tools.build:gradle", version.ref
 
 [plugins]
 android_library = { id = "com.android.library", version.ref = "android_gradle_plugin" }
-maven_publish = { id = "com.vanniktech.maven.publish", version = "0.31.0" }
+maven_publish = { id = "com.vanniktech.maven.publish", version = "0.32.0" }

--- a/embedded/android/lib/build.gradle.kts
+++ b/embedded/android/lib/build.gradle.kts
@@ -27,7 +27,7 @@ android {
 }
 
 mavenPublishing {
-    publishToMavenCentral(SonatypeHost.S01, automaticRelease = true)
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, automaticRelease = true)
 
     signAllPublications()
 


### PR DESCRIPTION
Adds back the needed code to migrate to the Maven Central Portal. This will be scheduled later so we can migrate all `io.element` libraries at once.