### PR TITLE
Fix white borders in PiP mode android (Fix scroll issues in small documents)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -69,6 +69,11 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   -webkit-tap-highlight-color: transparent;
+}
+
+/* This prohibits the view to scroll for pages smaller than 122px in width
+we use this for mobile pip webviews */
+.no-scroll-body {
   position: fixed;
   width: 100%;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -69,6 +69,8 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   -webkit-tap-highlight-color: transparent;
+  position: fixed;
+  width: 100%;
 }
 
 /* We use this to not render the page at all until we know the theme.*/

--- a/src/room/GroupCallView.tsx
+++ b/src/room/GroupCallView.tsx
@@ -132,6 +132,16 @@ export const GroupCallView: FC<Props> = ({
     };
   }, []);
 
+  // This CSS is the only way we could find to not make element call scroll for
+  // viewport sizes smaller than 122px width. (It is actually this exact number: 122px
+  // tested on different devices...)
+  useEffect(() => {
+    document.body.classList.add("no-scroll-body");
+    return (): void => {
+      document.body.classList.remove("no-scroll-body");
+    };
+  }, []);
+
   useEffect(() => {
     window.rtcSession = rtcSession;
     return (): void => {


### PR DESCRIPTION
This scroll issue resulted in white borders on android PiP mode.