### PR TITLE
Fix initial selection when using controlled media

### DIFF
--- a/src/controls.ts
+++ b/src/controls.ts
@@ -50,7 +50,7 @@ export const setPipEnabled$ = new Subject<boolean>();
 
 export const availableOutputDevices$ = new Subject<OutputDevice[]>();
 
-export const outputDevice$ = new Subject<string | undefined>();
+export const outputDevice$ = new Subject<string>();
 
 /**
  * This allows the os to mute the call if the user

--- a/src/state/MediaDevices.ts
+++ b/src/state/MediaDevices.ts
@@ -269,21 +269,21 @@ class ControlledAudioOutput
     this.deviceSelection$.next(id);
   }
 
-  public readonly selected$ = combineLatest([
-    this.available$,
-    merge(
-      controlledOutputSelection$.pipe(startWith(undefined)),
-      this.deviceSelection$,
-    ),
-  ]).pipe(
-    map(([available, selectId]) => {
+  public readonly selected$ = combineLatest(
+    [
+      this.available$,
+      merge(
+        controlledOutputSelection$.pipe(startWith(undefined)),
+        this.deviceSelection$,
+      ),
+    ],
+    (available, selectId) => {
       const id = selectId ?? available.keys().next().value;
       return id
         ? { id, virtualEarpiece: id === EARPIECE_CONFIG_ID }
         : undefined;
-    }),
-    this.scope.state(),
-  );
+    },
+  ).pipe(this.scope.state());
 
   public constructor(private readonly scope: ObservableScope) {
     this.selected$.subscribe((device) => {

--- a/src/state/MediaDevices.ts
+++ b/src/state/MediaDevices.ts
@@ -277,8 +277,8 @@ class ControlledAudioOutput
         this.deviceSelection$,
       ),
     ],
-    (available, selectId) => {
-      const id = selectId ?? available.keys().next().value;
+    (available, preferredId) => {
+      const id = preferredId ?? available.keys().next().value;
       return id === undefined
         ? undefined
         : { id, virtualEarpiece: id === EARPIECE_CONFIG_ID };

--- a/src/state/MediaDevices.ts
+++ b/src/state/MediaDevices.ts
@@ -279,9 +279,9 @@ class ControlledAudioOutput
     ],
     (available, selectId) => {
       const id = selectId ?? available.keys().next().value;
-      return id
-        ? { id, virtualEarpiece: id === EARPIECE_CONFIG_ID }
-        : undefined;
+      return id === undefined
+        ? undefined
+        : { id, virtualEarpiece: id === EARPIECE_CONFIG_ID };
     },
   ).pipe(this.scope.state());
 

--- a/src/state/MediaDevices.ts
+++ b/src/state/MediaDevices.ts
@@ -269,16 +269,19 @@ class ControlledAudioOutput
     this.deviceSelection$.next(id);
   }
 
-  public readonly selected$ = merge(
-    this.deviceSelection$,
-    controlledOutputSelection$,
-  ).pipe(
-    startWith<string | undefined>(undefined),
-    map((id) =>
-      id === undefined
-        ? undefined
-        : { id, virtualEarpiece: id === EARPIECE_CONFIG_ID },
+  public readonly selected$ = combineLatest([
+    this.available$,
+    merge(
+      controlledOutputSelection$.pipe(startWith(undefined)),
+      this.deviceSelection$,
     ),
+  ]).pipe(
+    map(([available, selectId]) => {
+      const id = selectId ?? available.keys().next().value;
+      return id
+        ? { id, virtualEarpiece: id === EARPIECE_CONFIG_ID }
+        : undefined;
+    }),
     this.scope.state(),
   );
 


### PR DESCRIPTION
At this location we were too careful to not set the controlled media to a default device. We removed all "set first device in available array" logic to mitigate possible toggle issues. This PR adds back this logic in the case where we have not yet selected any inital devices and just received the available devices from the native os.

Best case the native os should call `setOutputDevice` right after setting the available devices. But now, if it does not, we use the first availbel device to at least have selected sth.