### PR TITLE
Fix bluetooth iOS issue (device auto switches from Bluetooth to speaker)

### DIFF
--- a/src/livekit/useLivekit.ts
+++ b/src/livekit/useLivekit.ts
@@ -47,6 +47,7 @@ import { useUrlParams } from "../UrlParams";
 import { useInitial } from "../useInitial";
 import { getValue } from "../utils/observable";
 import { type SelectedDevice } from "../state/MediaDevices";
+import { platform } from "../Platform";
 
 interface UseLivekitResult {
   livekitRoom?: Room;
@@ -320,16 +321,18 @@ export function useLivekit(
 
   useEffect(() => {
     // Sync the requested devices with LiveKit's devices
-    if (
-      room !== undefined &&
-      connectionState === ConnectionState.Connected &&
-      !controlledAudioDevices
-    ) {
+    if (room !== undefined && connectionState === ConnectionState.Connected) {
       const syncDevice = (
         kind: MediaDeviceKind,
         selected$: Observable<SelectedDevice | undefined>,
       ): Subscription =>
         selected$.subscribe((device) => {
+          logger.info(
+            "[LivekitRoom] syncDevice room.getActiveDevice(kind) !== d.id :",
+            room.getActiveDevice(kind),
+            " !== ",
+            device?.id,
+          );
           if (
             device !== undefined &&
             room.getActiveDevice(kind) !== device.id
@@ -344,7 +347,9 @@ export function useLivekit(
 
       const subscriptions = [
         syncDevice("audioinput", devices.audioInput.selected$),
-        syncDevice("audiooutput", devices.audioOutput.selected$),
+        !controlledAudioDevices
+          ? syncDevice("audiooutput", devices.audioOutput.selected$)
+          : undefined,
         syncDevice("videoinput", devices.videoInput.selected$),
         // Restart the audio input track whenever we detect that the active media
         // device has changed to refer to a different hardware device. We do this
@@ -384,7 +389,7 @@ export function useLivekit(
       ];
 
       return (): void => {
-        for (const s of subscriptions) s.unsubscribe();
+        for (const s of subscriptions) s?.unsubscribe();
       };
     }
   }, [room, devices, connectionState, controlledAudioDevices]);

--- a/src/livekit/useLivekit.ts
+++ b/src/livekit/useLivekit.ts
@@ -47,7 +47,6 @@ import { useUrlParams } from "../UrlParams";
 import { useInitial } from "../useInitial";
 import { getValue } from "../utils/observable";
 import { type SelectedDevice } from "../state/MediaDevices";
-import { platform } from "../Platform";
 
 interface UseLivekitResult {
   livekitRoom?: Room;

--- a/src/room/MuteStates.ts
+++ b/src/room/MuteStates.ts
@@ -86,6 +86,14 @@ export function useMuteStates(isJoined: boolean): MuteStates {
   const audio = useMuteState(devices.audioInput, () => {
     return Config.get().media_devices.enable_audio && !skipLobby && !isJoined;
   });
+  useEffect(() => {
+    // If audio is enabled, we need to request the device names again,
+    // because iOS will not be able to switch to the correct device after un-muting.
+    // This is one of the main changes that makes iOS work with bluetooth audio devices.
+    if (audio.enabled) {
+      devices.requestDeviceNames();
+    }
+  }, [audio.enabled, devices]);
   const isEarpiece = useIsEarpiece();
   const video = useMuteState(
     devices.videoInput,

--- a/src/state/CallViewModel.ts
+++ b/src/state/CallViewModel.ts
@@ -1276,7 +1276,7 @@ export class CallViewModel extends ViewModel {
     (available, selected) => {
       const selectionType = selected && available.get(selected.id)?.type;
 
-      // If we are in any output mode other than spaeker switch to speaker.
+      // If we are in any output mode other than speaker switch to speaker.
       const newSelectionType =
         selectionType === "speaker" ? "earpiece" : "speaker";
       const newSelection = [...available].find(

--- a/src/state/MediaDevices.ts
+++ b/src/state/MediaDevices.ts
@@ -264,6 +264,15 @@ class AudioOutput
 class ControlledAudioOutput
   implements MediaDevice<AudioOutputDeviceLabel, SelectedAudioOutputDevice>
 {
+  // We need to subscribe to the raw devices so that the OS does update the input
+  // back to what it was before. otherwise we will switch back to the default
+  // whenever we allocate a new stream.
+  public readonly availableRaw$ = availableRawDevices$(
+    "audiooutput",
+    this.usingNames$,
+    this.scope,
+  );
+
   public readonly available$ = combineLatest(
     [controlledAvailableOutputDevices$.pipe(startWith([])), iosDeviceMenu$],
     (availableRaw, iosDeviceMenu) => {
@@ -311,14 +320,17 @@ class ControlledAudioOutput
     },
   ).pipe(this.scope.state());
 
-  public constructor(private readonly scope: ObservableScope) {
+  public constructor(
+    private readonly usingNames$: Observable<boolean>,
+    private readonly scope: ObservableScope,
+  ) {
     this.selected$.subscribe((device) => {
       // Let the hosting application know which output device has been selected.
       // This information is probably only of interest if the earpiece mode has
       // been selected - for example, Element X iOS listens to this to determine
       // whether it should enable the proximity sensor.
       if (device !== undefined) {
-        logger.info("[controlled-output] setAudioDeviceSelect called:", device);
+        logger.info("[controlled-output] onAudioDeviceSelect called:", device);
         window.controls.onAudioDeviceSelect?.(device.id);
         // Also invoke the deprecated callback for backward compatibility
         window.controls.onOutputDeviceSelect?.(device.id);
@@ -326,6 +338,9 @@ class ControlledAudioOutput
     });
     this.available$.subscribe((available) => {
       logger.info("[controlled-output] available devices:", available);
+    });
+    this.availableRaw$.subscribe((availableRaw) => {
+      logger.info("[controlled-output] available raw devices:", availableRaw);
     });
   }
 }
@@ -393,7 +408,7 @@ export class MediaDevices {
     AudioOutputDeviceLabel,
     SelectedAudioOutputDevice
   > = getUrlParams().controlledAudioDevices
-    ? new ControlledAudioOutput(this.scope)
+    ? new ControlledAudioOutput(this.usingNames$, this.scope)
     : new AudioOutput(this.usingNames$, this.scope);
 
   public readonly videoInput: MediaDevice<DeviceLabel, SelectedDevice> =


### PR DESCRIPTION
Fixes https://github.com/element-hq/element-call/issues/3389

This fixes the ios bluetooth device selection on the `livekit` branch.

The main trick in this PR is:
 - we still sync devices in controlled output audio mode
 - we subscribe to `createMediaObserver` with `kind=audiooutput` in controlled media
 - we call `devices.requestDeviceNames` when the audio mute state changes.

The issue is that the os will switch back to the speaker on unmute and subscribing to `createMediaObserver` with `kind=audiooutput`will trigger a sync device call taht syncs us back to the state before.

TODO: this does need a follow up task to find out if it is enough to only call `devices.requestDeviceNames` without the subscribe to `createMediaObserver` step.
Signed-off-by: Timo K <toger5@hotmail.de>