### PR TITLE
Trim extra characters from roomId parameter in URL

### DIFF
--- a/src/UrlParams.test.ts
+++ b/src/UrlParams.test.ts
@@ -82,11 +82,14 @@ describe("UrlParams", () => {
         getRoomIdentifierFromUrl("", `?roomId=${ROOM_ID}`, "").roomId,
       ).toBe(ROOM_ID);
     });
-    it("handles params with unprintable characters", () => {
+    it("(roomId with unprintable characters)", () => {
       const invisibleChar = "\u2066";
       expect(
-        getRoomIdentifierFromUrl("", `?roomId=${ROOM_ID}${invisibleChar}`, "")
-          .roomId,
+        getRoomIdentifierFromUrl(
+          "",
+          `?roomId=${invisibleChar}${ROOM_ID}${invisibleChar}`,
+          "",
+        ).roomId,
       ).toBe(ROOM_ID);
     });
   });

--- a/src/UrlParams.test.ts
+++ b/src/UrlParams.test.ts
@@ -82,14 +82,11 @@ describe("UrlParams", () => {
         getRoomIdentifierFromUrl("", `?roomId=${ROOM_ID}`, "").roomId,
       ).toBe(ROOM_ID);
     });
-    it("(roomId with unprintable chatacters)", () => {
+    it("handles params with unprintable characters", () => {
       const invisibleChar = "\u2066";
       expect(
-        getRoomIdentifierFromUrl(
-          "",
-          `?roomId=${invisibleChar}${ROOM_ID}${invisibleChar}`,
-          "",
-        ).roomId,
+        getRoomIdentifierFromUrl("", `?roomId=${ROOM_ID}${invisibleChar}`, "")
+          .roomId,
       ).toBe(ROOM_ID);
     });
   });

--- a/src/UrlParams.test.ts
+++ b/src/UrlParams.test.ts
@@ -82,6 +82,16 @@ describe("UrlParams", () => {
         getRoomIdentifierFromUrl("", `?roomId=${ROOM_ID}`, "").roomId,
       ).toBe(ROOM_ID);
     });
+    it("(roomId with unprintable chatacters)", () => {
+      const invisibleChar = "⁦";
+      expect(
+        getRoomIdentifierFromUrl(
+          "",
+          `?roomId=${invisibleChar}${ROOM_ID}${invisibleChar}`,
+          "",
+        ).roomId,
+      ).toBe(ROOM_ID);
+    });
   });
 
   it("ignores room alias", () => {

--- a/src/UrlParams.test.ts
+++ b/src/UrlParams.test.ts
@@ -83,7 +83,7 @@ describe("UrlParams", () => {
       ).toBe(ROOM_ID);
     });
     it("(roomId with unprintable chatacters)", () => {
-      const invisibleChar = "⁦";
+      const invisibleChar = "\u2066";
       expect(
         getRoomIdentifierFromUrl(
           "",

--- a/src/UrlParams.ts
+++ b/src/UrlParams.ts
@@ -387,10 +387,14 @@ export function getRoomIdentifierFromUrl(
 
   // Make sure roomId is valid
   let roomId: string | null = parser.getParam("roomId");
-  if (!roomId?.startsWith("!")) {
-    roomId = null;
-  } else if (!roomId.includes("")) {
-    roomId = null;
+  if (roomId !== null) {
+    // Replace any non-printable characters that another client may have inserted.
+    roomId = roomId.replaceAll(/^[^ -~]+|[^ -~]+$/g, "");
+    if (!roomId.startsWith("!")) {
+      roomId = null;
+    } else if (!roomId.includes("")) {
+      roomId = null;
+    }
   }
 
   return {

--- a/src/UrlParams.ts
+++ b/src/UrlParams.ts
@@ -220,8 +220,6 @@ class ParamParser {
   private queryParams: URLSearchParams;
 
   public constructor(search: string, hash: string) {
-    // Replace any non-printable characters that another client may have inserted.
-    search = search.replaceAll(/^[^ -~]+|[^ -~]+$/g, "");
     this.queryParams = new URLSearchParams(search);
 
     const fragmentQueryStart = hash.indexOf("?");
@@ -260,8 +258,6 @@ export const getUrlParams = (
   search = window.location.search,
   hash = window.location.hash,
 ): UrlParams => {
-  // Replace any non-printable characters that another client may have inserted.
-  search = search.replaceAll(/^[^ -~]+|[^ -~]+$/g, "");
   const parser = new ParamParser(search, hash);
 
   const fontScale = parseFloat(parser.getParam("fontScale") ?? "");
@@ -391,10 +387,14 @@ export function getRoomIdentifierFromUrl(
 
   // Make sure roomId is valid
   let roomId: string | null = parser.getParam("roomId");
-  if (!roomId?.startsWith("!")) {
-    roomId = null;
-  } else if (!roomId.includes("")) {
-    roomId = null;
+  if (roomId !== null) {
+    // Replace any non-printable characters that another client may have inserted.
+    roomId = roomId.replaceAll(/^[^ -~]+|[^ -~]+$/g, "");
+    if (!roomId.startsWith("!")) {
+      roomId = null;
+    } else if (!roomId.includes("")) {
+      roomId = null;
+    }
   }
 
   return {

--- a/src/UrlParams.ts
+++ b/src/UrlParams.ts
@@ -389,6 +389,8 @@ export function getRoomIdentifierFromUrl(
   let roomId: string | null = parser.getParam("roomId");
   if (roomId !== null) {
     // Replace any non-printable characters that another client may have inserted.
+    // For instance on iOS, some copied links end up with zero width characters on the end which get encoded into the URL.
+    // This isn't valid for a roomId, so we can freely strip the content.
     roomId = roomId.replaceAll(/^[^ -~]+|[^ -~]+$/g, "");
     if (!roomId.startsWith("!")) {
       roomId = null;

--- a/src/UrlParams.ts
+++ b/src/UrlParams.ts
@@ -220,6 +220,8 @@ class ParamParser {
   private queryParams: URLSearchParams;
 
   public constructor(search: string, hash: string) {
+    // Replace any non-printable characters that another client may have inserted.
+    search = search.replaceAll(/^[^ -~]+|[^ -~]+$/g, "");
     this.queryParams = new URLSearchParams(search);
 
     const fragmentQueryStart = hash.indexOf("?");
@@ -258,6 +260,8 @@ export const getUrlParams = (
   search = window.location.search,
   hash = window.location.hash,
 ): UrlParams => {
+  // Replace any non-printable characters that another client may have inserted.
+  search = search.replaceAll(/^[^ -~]+|[^ -~]+$/g, "");
   const parser = new ParamParser(search, hash);
 
   const fontScale = parseFloat(parser.getParam("fontScale") ?? "");
@@ -387,14 +391,10 @@ export function getRoomIdentifierFromUrl(
 
   // Make sure roomId is valid
   let roomId: string | null = parser.getParam("roomId");
-  if (roomId !== null) {
-    // Replace any non-printable characters that another client may have inserted.
-    roomId = roomId.replaceAll(/^[^ -~]+|[^ -~]+$/g, "");
-    if (!roomId.startsWith("!")) {
-      roomId = null;
-    } else if (!roomId.includes("")) {
-      roomId = null;
-    }
+  if (!roomId?.startsWith("!")) {
+    roomId = null;
+  } else if (!roomId.includes("")) {
+    roomId = null;
   }
 
   return {


### PR DESCRIPTION
Some users get bitten by their client pasting random extra crap onto the end of a URL, which mucks up parsing. I think this has a low risk since we're only trimming unprintable characters.