### PR TITLE
Backport: Set available devices to empty map on safari.

### DIFF
--- a/src/livekit/MatrixAudioRenderer.tsx
+++ b/src/livekit/MatrixAudioRenderer.tsx
@@ -182,7 +182,7 @@ interface StereoPanAudioTrackProps {
 /**
  * This wraps `livekit.AudioTrack` to allow adding audio nodes to a track.
  * It main purpose is to remount the AudioTrack component when switching from
- * audiooContext to normal audio playback.
+ * audioContext to normal audio playback.
  * As of now the AudioTrack component does not support adding audio nodes while being mounted.
  * @param param0
  * @returns
@@ -202,7 +202,7 @@ function AudioTrackWithAudioNodes({
   const [trackReady, setTrackReady] = useReactiveState(
     () => false,
     // We only want the track to reset once both (audioNodes and audioContext) are set.
-    // for unsetting the audioContext its enough if one of the the is undefined.
+    // for unsetting the audioContext its enough if one of the two is undefined.
     [audioContext && audioNodes],
   );
 

--- a/src/room/InCallView.tsx
+++ b/src/room/InCallView.tsx
@@ -150,7 +150,7 @@ export const ActiveCall: FC<ActiveCallProps> = (props) => {
         ?.disconnect()
         .then(() => {
           logger.info(
-            `[Lifecycle] Disconnected from livekite room, state:${livekitRoom?.state}`,
+            `[Lifecycle] Disconnected from livekit room, state:${livekitRoom?.state}`,
           );
         })
         .catch((e) => {

--- a/src/state/MediaDevices.ts
+++ b/src/state/MediaDevices.ts
@@ -211,7 +211,7 @@ class AudioOutput
   public readonly available$ = this.scope.behavior(
     availableRawDevices$("audiooutput", this.usingNames$, this.scope).pipe(
       map((availableRaw) => {
-        const available: Map<string, AudioOutputDeviceLabel> =
+        let available: Map<string, AudioOutputDeviceLabel> =
           buildDeviceMap(availableRaw);
         // Create a virtual default audio output for browsers that don't have one.
         // Its device ID must be the empty string because that's what setSinkId
@@ -221,6 +221,10 @@ class AudioOutput
             type: "default",
             name: availableRaw[0]?.label || null,
           });
+        if (navigator.userAgent.includes("Safari")) {
+          // set to empty map if we are on Safari, because it does not support setSinkId
+          available = new Map();
+        }
         // Note: creating virtual default input devices would be another problem
         // entirely, because requesting a media stream from deviceId "" won't
         // automatically track the default device.

--- a/src/state/MediaDevices.ts
+++ b/src/state/MediaDevices.ts
@@ -221,7 +221,9 @@ class AudioOutput
             type: "default",
             name: availableRaw[0]?.label || null,
           });
-        if (navigator.userAgent.includes("Safari")) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const isSafari = !!(window as any).GestureEvent; // non standard api only found on Safari. https://developer.mozilla.org/en-US/docs/Web/API/GestureEvent#browser_compatibility
+        if (isSafari) {
           // set to empty map if we are on Safari, because it does not support setSinkId
           available = new Map();
         }


### PR DESCRIPTION
Backport of: https://github.com/element-hq/element-call/pull/3426

Signed-off-by: Timo K <toger5@hotmail.de>