### PR TITLE
Display a custom error for restricted SFU config error

### DIFF
--- a/locales/en/app.json
+++ b/locales/en/app.json
@@ -94,6 +94,8 @@
     "matrix_rtc_focus_missing": "The server is not configured to work with {{brand}}. Please contact your server admin (Domain: {{domain}}, Error Code: {{ errorCode }}).",
     "open_elsewhere": "Opened in another tab",
     "open_elsewhere_description": "{{brand}} has been opened in another tab. If that doesn't sound right, try reloading the page.",
+    "room_creation_restricted": "Failed to create call",
+    "room_creation_restricted_description": "Call creation might be restricted to authorized users only. Try again later, or contact your server admin if the problem persists.",
     "unexpected_ec_error": "An unexpected error occurred (<0>Error Code:</0> <1>{{ errorCode }}</1>). Please contact your server admin."
   },
   "group_call_loader": {

--- a/playwright/errors.spec.ts
+++ b/playwright/errors.spec.ts
@@ -72,3 +72,39 @@ test("Should automatically retry non fatal JWT errors", async ({
   await hasRetriedPromise;
   await expect(page.getByTestId("video").first()).toBeVisible();
 });
+
+test("Should show error screen if call creation is restricted", async ({
+  page,
+}) => {
+  await page.goto("/");
+
+  await page.getByTestId("home_callName").click();
+  await page.getByTestId("home_callName").fill("HelloCall");
+  await page.getByTestId("home_displayName").click();
+  await page.getByTestId("home_displayName").fill("John Doe");
+  await page.getByTestId("home_go").click();
+
+  // Simulate when the room was not created prior to the call.
+  // Livekit will not auto_create anymore and will return a 404 error.
+  await page.route(
+    "**/livekit/sfu/rtc/validate?*",
+    async (route) =>
+      await route.fulfill({
+        // 418 is a non retryable error, so test will fail immediately
+        status: 404,
+        contentType: "text/plain",
+        body: "requested room does not exist",
+      }),
+  );
+
+  // Join the call
+  await page.getByTestId("lobby_joinCall").click();
+
+  // Should fail
+  await expect(page.getByText("Failed to create call")).toBeVisible();
+  await expect(
+    page.getByText(
+      /Call creation might be restricted to authorized users only/,
+    ),
+  ).toBeVisible();
+});

--- a/playwright/errors.spec.ts
+++ b/playwright/errors.spec.ts
@@ -78,16 +78,25 @@ test("Should show error screen if call creation is restricted", async ({
 }) => {
   await page.goto("/");
 
-  await page.getByTestId("home_callName").click();
-  await page.getByTestId("home_callName").fill("HelloCall");
-  await page.getByTestId("home_displayName").click();
-  await page.getByTestId("home_displayName").fill("John Doe");
-  await page.getByTestId("home_go").click();
+  // We need the socket connection to fail, but this cannot be done by using the websocket route.
+  // Instead, we will trick the app by returning a bad URL for the SFU that will not be reachable an error out.
+  await page.route(
+    "**/matrix-rtc.m.localhost/livekit/jwt/sfu/get",
+    async (route) =>
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          url: "wss://badurltotricktest/livekit/sfu",
+          jwt: "FAKE",
+        }),
+      }),
+  );
 
-  // Simulate when the room was not created prior to the call.
+  // Then if the socket connection fails, livekit will try to validate the token!
   // Livekit will not auto_create anymore and will return a 404 error.
   await page.route(
-    "**/livekit/sfu/rtc/validate?*",
+    "**/badurltotricktest/livekit/sfu/rtc/validate?**",
     async (route) =>
       await route.fulfill({
         status: 404,
@@ -96,9 +105,18 @@ test("Should show error screen if call creation is restricted", async ({
       }),
   );
 
+  await page.pause();
+
+  await page.getByTestId("home_callName").click();
+  await page.getByTestId("home_callName").fill("HelloCall");
+  await page.getByTestId("home_displayName").click();
+  await page.getByTestId("home_displayName").fill("John Doe");
+  await page.getByTestId("home_go").click();
+
   // Join the call
   await page.getByTestId("lobby_joinCall").click();
 
+  await page.pause();
   // Should fail
   await expect(page.getByText("Failed to create call")).toBeVisible();
   await expect(

--- a/playwright/errors.spec.ts
+++ b/playwright/errors.spec.ts
@@ -90,7 +90,6 @@ test("Should show error screen if call creation is restricted", async ({
     "**/livekit/sfu/rtc/validate?*",
     async (route) =>
       await route.fulfill({
-        // 418 is a non retryable error, so test will fail immediately
         status: 404,
         contentType: "text/plain",
         body: "requested room does not exist",

--- a/src/livekit/useECConnectionState.ts
+++ b/src/livekit/useECConnectionState.ts
@@ -22,6 +22,7 @@ import { PosthogAnalytics } from "../analytics/PosthogAnalytics";
 import {
   ElementCallError,
   InsufficientCapacityError,
+  SFURoomCreationRestrictedError,
   UnknownCallError,
 } from "../utils/errors.ts";
 import { AbortHandle } from "../utils/abortHandle.ts";
@@ -184,11 +185,19 @@ async function connectAndPublish(
     // participant limits.
     // LiveKit Cloud uses 429 for connection limits.
     // Either way, all these errors can be explained as "insufficient capacity".
-    if (
-      e instanceof ConnectionError &&
-      (e.status === 503 || e.status === 200 || e.status === 429)
-    )
-      throw new InsufficientCapacityError();
+    if (e instanceof ConnectionError) {
+      if (e.status === 503 || e.status === 200 || e.status === 429) {
+        throw new InsufficientCapacityError();
+      }
+      if (e.status === 404) {
+        // error msg is "Could not establish signal connection: requested room does not exist"
+        // The room does not exist. There are two different modes of operation for the SFU:
+        // - the room is created on the fly when connecting (livekit `auto_create` option)
+        // - Only authorized users can create rooms, so the room must exist before connecting (done by the auth jwt service)
+        // In the first case there will not be a 404, so we are in the second case.
+        throw new SFURoomCreationRestrictedError();
+      }
+    }
     throw e;
   }
 

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -17,6 +17,7 @@ export enum ErrorCode {
   INSUFFICIENT_CAPACITY_ERROR = "INSUFFICIENT_CAPACITY_ERROR",
   E2EE_NOT_SUPPORTED = "E2EE_NOT_SUPPORTED",
   OPEN_ID_ERROR = "OPEN_ID_ERROR",
+  SFU_ERROR = "SFU_ERROR",
   UNKNOWN_ERROR = "UNKNOWN_ERROR",
 }
 
@@ -126,6 +127,17 @@ export class InsufficientCapacityError extends ElementCallError {
       ErrorCode.INSUFFICIENT_CAPACITY_ERROR,
       ErrorCategory.UNKNOWN,
       t("error.insufficient_capacity_description"),
+    );
+  }
+}
+
+export class SFURoomCreationRestrictedError extends ElementCallError {
+  public constructor() {
+    super(
+      t("error.room_creation_restricted"),
+      ErrorCode.SFU_ERROR,
+      ErrorCategory.CONFIGURATION_ISSUE,
+      t("error.room_creation_restricted_description"),
     );
   }
 }


### PR DESCRIPTION
This can happens if there is a configurtion problem with the SFU with the [lk-jwt-service v3](https://github.com/element-hq/lk-jwt-service/releases/tag/v0.3.0).

Without this change, if you are not allowed to create a room on the active SFU
<img width="618" height="384" alt="image" src="https://github.com/user-attachments/assets/4b761e14-56e9-4882-96bb-38f06057d1db" />

After:
<img width="570" height="393" alt="image" src="https://github.com/user-attachments/assets/d50acf9d-9b23-4982-8ca9-e92491e1f9f7" />
