### PR TITLE
DevX: update dev backend to support jwt-token v3

### DIFF
--- a/backend/dev_livekit.yaml
+++ b/backend/dev_livekit.yaml
@@ -21,3 +21,5 @@ turn:
   external_tls: true
 keys:
   devkey: secret
+room:
+  auto_create: false

--- a/dev-backend-docker-compose.yml
+++ b/dev-backend-docker-compose.yml
@@ -14,12 +14,15 @@ services:
       # If the configured homeserver runs on localhost, it'll probably be using
       # a self-signed certificate
       - LIVEKIT_INSECURE_SKIP_VERIFY_TLS=YES_I_KNOW_WHAT_I_AM_DOING
+      - LIVEKIT_FULL_ACCESS_HOMESERVERS=*
     deploy:
       restart_policy:
         condition: on-failure
     ports:
       # HOST_PORT:CONTAINER_PORT
       - 6080:6080
+    extra_hosts:
+      - "matrix-rtc.m.localhost:host-gateway"
     networks:
       - ecbackend
 

--- a/dev-backend-docker-compose.yml
+++ b/dev-backend-docker-compose.yml
@@ -21,8 +21,6 @@ services:
     ports:
       # HOST_PORT:CONTAINER_PORT
       - 6080:6080
-    extra_hosts:
-      - "matrix-rtc.m.localhost:host-gateway"
     networks:
       - ecbackend
 
@@ -104,4 +102,6 @@ services:
     depends_on:
       - synapse
     networks:
-      - ecbackend
+      ecbackend:
+        aliases:
+          - matrix-rtc.m.localhost

--- a/dev-backend-docker-compose.yml
+++ b/dev-backend-docker-compose.yml
@@ -3,7 +3,7 @@ networks:
 
 services:
   auth-service:
-    image: ghcr.io/element-hq/lk-jwt-service:0.2.3
+    image: ghcr.io/element-hq/lk-jwt-service:latest-ci
     pull_policy: always
     hostname: auth-server
     environment:


### PR DESCRIPTION
Update the livekit configuration to not auto create room.
Pass the env variable to the auth-service using the wild card

Noticable change:
```
services:
  auth-service:
    ....
    extra_hosts:
      - "matrix-rtc.m.localhost:host-gateway"
```
This allows the auth-service to reach directly the livekit service to create the room