### PR TITLE
Add "wait for pickup" overlay with sound. Leave on decline/timeout

### DIFF
--- a/src/room/InCallView.tsx
+++ b/src/room/InCallView.tsx
@@ -117,7 +117,10 @@ import waitingStyles from "./WaitingForJoin.module.css";
 import { prefetchSounds } from "../soundUtils";
 import { useAudioContext } from "../useAudioContext";
 // TODO: Dont use this!!!  use the correct sound
-import { GenericReaction } from "../reactions";
+import genericSoundOgg from "../sound/reactions/generic.ogg?url";
+import genericSoundMp3 from "../sound/reactions/generic.mp3?url";
+import leftCallSoundMp3 from "../sound/left_call.mp3";
+import leftCallSoundOgg from "../sound/left_call.ogg";
 
 const canScreenshare = "getDisplayMedia" in (navigator.mediaDevices ?? {});
 
@@ -273,18 +276,18 @@ export const InCallView: FC<InCallViewProps> = ({
   const muteAllAudio = useBehavior(muteAllAudio$);
   // Call pickup state and display names are needed for waiting overlay/sounds
   const callPickupState = useBehavior(vm.callPickupState$);
-  const displaynames = useBehavior(vm.memberDisplaynames$);
-  // Preload a subtle waiting/ringing tone
-  const [waitingSoundCache, setWaitingSoundCache] = useState<ReturnType<
-    typeof prefetchSounds
-  > | null>(null);
-  useEffect(() => {
-    if (!waitingSoundCache && callPickupState === "ringing") {
-      setWaitingSoundCache(prefetchSounds({ waiting: GenericReaction.sound! }));
-    }
-  }, [waitingSoundCache, callPickupState]);
-  const waitingAudio = useAudioContext({
-    sounds: waitingSoundCache,
+
+  // Preload a waiting and decline sounds
+  const pickupPhaseSoundCache = useInitial(async () => {
+    return prefetchSounds({
+      waiting: { mp3: genericSoundMp3, ogg: genericSoundOgg },
+      decline: { mp3: leftCallSoundMp3, ogg: leftCallSoundOgg },
+      // do we want a timeout sound?
+    });
+  });
+
+  const pickupPhaseAudio = useAudioContext({
+    sounds: pickupPhaseSoundCache,
     latencyHint: "interactive",
     muted: muteAllAudio,
   });
@@ -351,49 +354,64 @@ export const InCallView: FC<InCallViewProps> = ({
   const audioOutputSwitcher = useBehavior(vm.audioOutputSwitcher$);
   useSubscription(vm.autoLeave$, onLeave);
 
-  // When waiting for pickup, loop a quiet waiting sound
+  // When we enter timeout or decline we will leave the call.
   useEffect((): void | (() => void) => {
-    // if (callPickupState !== "ringing") return;
+    if (callPickupState === "timeout") {
+      onLeave();
+    }
+    if (callPickupState === "decline") {
+      void pickupPhaseAudio
+        ?.playSound("decline")
+        .then(() => {
+          onLeave();
+        })
+        .catch((e) => {
+          logger.error("Failed to play decline sound", e);
+        });
+    }
+  });
+
+  // When waiting for pickup, loop a waiting sound
+  useEffect((): void | (() => void) => {
+    if (callPickupState !== "ringing") return;
     // play immediately and then every ~2.5s while in ringing
-    void waitingAudio?.playSound("waiting");
+    void pickupPhaseAudio?.playSound("waiting");
     const id = window.setInterval(
-      () => void waitingAudio?.playSound("waiting"),
+      () => void pickupPhaseAudio?.playSound("waiting"),
       2500,
     );
     return (): void => window.clearInterval(id);
-  }, [callPickupState, waitingAudio]);
+  }, [callPickupState, pickupPhaseAudio]);
 
   // Waiting UI overlay
   const waitingOverlay: JSX.Element | null = useMemo(() => {
-    // if (callPickupState !== "ringing") return null;
+    // No overlay if not in ringing state
+    if (callPickupState !== "ringing") return null;
 
-    // Fallback to room state (joined or invited members)
+    // Use room state for other participants data (the one that we likely want to reach)
     const roomOthers = [
       ...matrixRoom.getMembersWithMembership("join"),
       ...matrixRoom.getMembersWithMembership("invite"),
     ].filter((m) => m.userId !== client.getUserId());
-    const roomOtherIds = Array.from(new Set(roomOthers.map((m) => m.userId)));
+    // Yield if there are not other members in the room.
+    if (roomOthers.length === 0) return null;
 
-    const isOneOnOne = roomOtherIds.length === 1;
-    const otherId = isOneOnOne ? roomOtherIds[0] : undefined;
-    const otherMember = isOneOnOne
-      ? (roomOthers.find((m) => m.userId === otherId) ??
-        matrixRoom.getMember(otherId!))
-      : null;
-    const name: string = isOneOnOne
-      ? (displaynames.get(otherId!) ?? otherMember?.name ?? otherId!)
-      : "Other participants";
-    const avatarMxc = otherMember?.getMxcAvatarUrl?.() ?? undefined;
+    const otherMember = roomOthers.length > 0 ? roomOthers[0] : undefined;
+    const isOneOnOne = roomOthers.length === 1 && otherMember;
     const text = isOneOnOne
-      ? `Waiting for ${name} to join…`
+      ? `Waiting for ${otherMember.name ?? otherMember.userId} to join…`
       : "Waiting for other participants…";
+    const avatarMxc = isOneOnOne
+      ? (otherMember.getMxcAvatarUrl?.() ?? undefined)
+      : (matrixRoom.getMxcAvatarUrl() ?? undefined);
+
     return (
       <div className={waitingStyles.overlay}>
         <div className={waitingStyles.content}>
           <div className={waitingStyles.pulse}>
             <Avatar
-              id={otherId ?? "others"}
-              name={name}
+              id={isOneOnOne ? otherMember.userId : matrixRoom.roomId}
+              name={isOneOnOne ? otherMember.name : matrixRoom.name}
               src={avatarMxc}
               size={AvatarSize.XL}
             />
@@ -404,7 +422,7 @@ export const InCallView: FC<InCallViewProps> = ({
         </div>
       </div>
     );
-  }, [client, displaynames, matrixRoom]);
+  }, [callPickupState, client, matrixRoom]);
 
   // Ideally we could detect taps by listening for click events and checking
   // that the pointerType of the event is "touch", but this isn't yet supported

--- a/src/room/InCallView.tsx
+++ b/src/room/InCallView.tsx
@@ -283,11 +283,12 @@ export const InCallView: FC<InCallViewProps> = ({
     return prefetchSounds({
       waiting: { mp3: genericSoundMp3, ogg: genericSoundOgg },
       decline: { mp3: leftCallSoundMp3, ogg: leftCallSoundOgg },
-      // do we want a timeout sound?
+      // Do we want a timeout sound?
     });
   });
   // configure this to sth that fits to the pickup waiting sound.
-  const PICKUP_SOUND_INTERVAL = 1000;
+  // 1600 is in sync with the animation.
+  const PICKUP_SOUND_INTERVAL = 1600;
 
   const pickupPhaseAudio = useAudioContext({
     sounds: pickupPhaseSoundCache,
@@ -373,7 +374,7 @@ export const InCallView: FC<InCallViewProps> = ({
           onLeave();
         });
     }
-  });
+  }, [callPickupState, onLeave, pickupPhaseAudio]);
 
   // When waiting for pickup, loop a waiting sound
   useEffect((): void | (() => void) => {
@@ -418,7 +419,9 @@ export const InCallView: FC<InCallViewProps> = ({
               size={AvatarSize.XL}
             />
           </div>
-          <Text size="md">{text}</Text>
+          <Text size="md" className={waitingStyles.text}>
+            {text}
+          </Text>
         </div>
       </div>
     );

--- a/src/room/InCallView.tsx
+++ b/src/room/InCallView.tsx
@@ -378,6 +378,7 @@ export const InCallView: FC<InCallViewProps> = ({
 
   // When waiting for pickup, loop a waiting sound
   useEffect((): void | (() => void) => {
+    if (callPickupState !== "ringing") return;
     const interval = window.setInterval(() => {
       void pickupPhaseAudio?.playSound("waiting");
     }, PICKUP_SOUND_INTERVAL);

--- a/src/room/InCallView.tsx
+++ b/src/room/InCallView.tsx
@@ -362,11 +362,11 @@ export const InCallView: FC<InCallViewProps> = ({
     if (callPickupState === "decline") {
       void pickupPhaseAudio
         ?.playSound("decline")
-        .then(() => {
-          onLeave();
-        })
         .catch((e) => {
           logger.error("Failed to play decline sound", e);
+        })
+        .finally(() => {
+          onLeave();
         });
     }
   });

--- a/src/room/InCallView.tsx
+++ b/src/room/InCallView.tsx
@@ -372,16 +372,23 @@ export const InCallView: FC<InCallViewProps> = ({
   });
 
   // When waiting for pickup, loop a waiting sound
+  const [playing, setPlaying] = useState(false);
   useEffect((): void | (() => void) => {
     if (callPickupState !== "ringing") return;
-    // play immediately and then every ~2.5s while in ringing
-    void pickupPhaseAudio?.playSound("waiting");
-    const id = window.setInterval(
-      () => void pickupPhaseAudio?.playSound("waiting"),
-      2500,
-    );
-    return (): void => window.clearInterval(id);
-  }, [callPickupState, pickupPhaseAudio]);
+    setPlaying(true);
+    // play and then wait for 1.5s
+    const playSoundAndWait = async (): Promise<void> => {
+      await pickupPhaseAudio?.playSound("waiting");
+      await new Promise((res) => setTimeout(res, 1500));
+    };
+    const startPlaying = async (): Promise<void> => {
+      while (playing) {
+        await playSoundAndWait();
+      }
+    };
+    void startPlaying();
+    return (): void => setPlaying(false);
+  }, [callPickupState, pickupPhaseAudio, playing]);
 
   // Waiting UI overlay
   const waitingOverlay: JSX.Element | null = useMemo(() => {

--- a/src/room/InCallView.tsx
+++ b/src/room/InCallView.tsx
@@ -423,9 +423,7 @@ export const InCallView: FC<InCallViewProps> = ({
               size={AvatarSize.XL}
             />
           </div>
-          <Text size="md" className={waitingStyles.label}>
-            {text}
-          </Text>
+          <Text size="md">{text}</Text>
         </div>
       </div>
     );

--- a/src/room/InCallView.tsx
+++ b/src/room/InCallView.tsx
@@ -50,6 +50,7 @@ import { type HeaderStyle, useUrlParams } from "../UrlParams";
 import { useCallViewKeyboardShortcuts } from "../useCallViewKeyboardShortcuts";
 import { ElementWidgetActions, widget } from "../widget";
 import styles from "./InCallView.module.css";
+import overlayStyles from "../Overlay.module.css";
 import { GridTile } from "../tile/GridTile";
 import { type OTelGroupCallMembership } from "../otel/OTelGroupCallMembership";
 import { SettingsModal, defaultSettingsTab } from "../settings/SettingsModal";
@@ -285,6 +286,8 @@ export const InCallView: FC<InCallViewProps> = ({
       // do we want a timeout sound?
     });
   });
+  // configure this to sth that fits to the pickup waiting sound.
+  const PICKUP_SOUND_INTERVAL = 1000;
 
   const pickupPhaseAudio = useAudioContext({
     sounds: pickupPhaseSoundCache,
@@ -360,6 +363,7 @@ export const InCallView: FC<InCallViewProps> = ({
       onLeave();
     }
     if (callPickupState === "decline") {
+      // Wait for the sound to finish before leaving
       void pickupPhaseAudio
         ?.playSound("decline")
         .catch((e) => {
@@ -372,23 +376,12 @@ export const InCallView: FC<InCallViewProps> = ({
   });
 
   // When waiting for pickup, loop a waiting sound
-  const [playing, setPlaying] = useState(false);
   useEffect((): void | (() => void) => {
-    if (callPickupState !== "ringing") return;
-    setPlaying(true);
-    // play and then wait for 1.5s
-    const playSoundAndWait = async (): Promise<void> => {
-      await pickupPhaseAudio?.playSound("waiting");
-      await new Promise((res) => setTimeout(res, 1500));
-    };
-    const startPlaying = async (): Promise<void> => {
-      while (playing) {
-        await playSoundAndWait();
-      }
-    };
-    void startPlaying();
-    return (): void => setPlaying(false);
-  }, [callPickupState, pickupPhaseAudio, playing]);
+    const interval = window.setInterval(() => {
+      void pickupPhaseAudio?.playSound("waiting");
+    }, PICKUP_SOUND_INTERVAL);
+    return (): void => window.clearInterval(interval);
+  }, [callPickupState, pickupPhaseAudio]);
 
   // Waiting UI overlay
   const waitingOverlay: JSX.Element | null = useMemo(() => {
@@ -413,8 +406,10 @@ export const InCallView: FC<InCallViewProps> = ({
       : (matrixRoom.getMxcAvatarUrl() ?? undefined);
 
     return (
-      <div className={waitingStyles.overlay}>
-        <div className={waitingStyles.content}>
+      <div className={classNames(overlayStyles.bg, waitingStyles.overlay)}>
+        <div
+          className={classNames(overlayStyles.content, waitingStyles.content)}
+        >
           <div className={waitingStyles.pulse}>
             <Avatar
               id={isOneOnOne ? otherMember.userId : matrixRoom.roomId}

--- a/src/room/InCallView.tsx
+++ b/src/room/InCallView.tsx
@@ -112,6 +112,12 @@ import { EarpieceOverlay } from "./EarpieceOverlay.tsx";
 import { useAppBarHidden, useAppBarSecondaryButton } from "../AppBar.tsx";
 import { useBehavior } from "../useBehavior.ts";
 import { Toast } from "../Toast.tsx";
+import { Avatar, Size as AvatarSize } from "../Avatar";
+import waitingStyles from "./WaitingForJoin.module.css";
+import { prefetchSounds } from "../soundUtils";
+import { useAudioContext } from "../useAudioContext";
+// TODO: Dont use this!!!  use the correct sound
+import { GenericReaction } from "../reactions";
 
 const canScreenshare = "getDisplayMedia" in (navigator.mediaDevices ?? {});
 
@@ -265,6 +271,23 @@ export const InCallView: FC<InCallViewProps> = ({
   });
 
   const muteAllAudio = useBehavior(muteAllAudio$);
+  // Call pickup state and display names are needed for waiting overlay/sounds
+  const callPickupState = useBehavior(vm.callPickupState$);
+  const displaynames = useBehavior(vm.memberDisplaynames$);
+  // Preload a subtle waiting/ringing tone
+  const [waitingSoundCache, setWaitingSoundCache] = useState<ReturnType<
+    typeof prefetchSounds
+  > | null>(null);
+  useEffect(() => {
+    if (!waitingSoundCache && callPickupState === "ringing") {
+      setWaitingSoundCache(prefetchSounds({ waiting: GenericReaction.sound! }));
+    }
+  }, [waitingSoundCache, callPickupState]);
+  const waitingAudio = useAudioContext({
+    sounds: waitingSoundCache,
+    latencyHint: "interactive",
+    muted: muteAllAudio,
+  });
 
   // This seems like it might be enough logic to use move it into the call view model?
   const [didFallbackToRoomKey, setDidFallbackToRoomKey] = useState(false);
@@ -327,6 +350,61 @@ export const InCallView: FC<InCallViewProps> = ({
   const earpieceMode = useBehavior(vm.earpieceMode$);
   const audioOutputSwitcher = useBehavior(vm.audioOutputSwitcher$);
   useSubscription(vm.autoLeave$, onLeave);
+
+  // When waiting for pickup, loop a quiet waiting sound
+  useEffect((): void | (() => void) => {
+    // if (callPickupState !== "ringing") return;
+    // play immediately and then every ~2.5s while in ringing
+    void waitingAudio?.playSound("waiting");
+    const id = window.setInterval(
+      () => void waitingAudio?.playSound("waiting"),
+      2500,
+    );
+    return (): void => window.clearInterval(id);
+  }, [callPickupState, waitingAudio]);
+
+  // Waiting UI overlay
+  const waitingOverlay: JSX.Element | null = useMemo(() => {
+    // if (callPickupState !== "ringing") return null;
+
+    // Fallback to room state (joined or invited members)
+    const roomOthers = [
+      ...matrixRoom.getMembersWithMembership("join"),
+      ...matrixRoom.getMembersWithMembership("invite"),
+    ].filter((m) => m.userId !== client.getUserId());
+    const roomOtherIds = Array.from(new Set(roomOthers.map((m) => m.userId)));
+
+    const isOneOnOne = roomOtherIds.length === 1;
+    const otherId = isOneOnOne ? roomOtherIds[0] : undefined;
+    const otherMember = isOneOnOne
+      ? (roomOthers.find((m) => m.userId === otherId) ??
+        matrixRoom.getMember(otherId!))
+      : null;
+    const name: string = isOneOnOne
+      ? (displaynames.get(otherId!) ?? otherMember?.name ?? otherId!)
+      : "Other participants";
+    const avatarMxc = otherMember?.getMxcAvatarUrl?.() ?? undefined;
+    const text = isOneOnOne
+      ? `Waiting for ${name} to join…`
+      : "Waiting for other participants…";
+    return (
+      <div className={waitingStyles.overlay}>
+        <div className={waitingStyles.content}>
+          <div className={waitingStyles.pulse}>
+            <Avatar
+              id={otherId ?? "others"}
+              name={name}
+              src={avatarMxc}
+              size={AvatarSize.XL}
+            />
+          </div>
+          <Text size="md" className={waitingStyles.label}>
+            {text}
+          </Text>
+        </div>
+      </div>
+    );
+  }, [client, displaynames, matrixRoom]);
 
   // Ideally we could detect taps by listening for click events and checking
   // that the pointerType of the event is "touch", but this isn't yet supported
@@ -806,6 +884,7 @@ export const InCallView: FC<InCallViewProps> = ({
         onBackToVideoPressed={audioOutputSwitcher?.switch}
       />
       <ReactionsOverlay vm={vm} />
+      {waitingOverlay}
       {footer}
       {layout.type !== "pip" && (
         <>

--- a/src/room/WaitingForJoin.module.css
+++ b/src/room/WaitingForJoin.module.css
@@ -44,8 +44,3 @@
     opacity: 0;
   }
 }
-
-.label {
-  color: white;
-  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
-}

--- a/src/room/WaitingForJoin.module.css
+++ b/src/room/WaitingForJoin.module.css
@@ -1,0 +1,51 @@
+.overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+  background: var(--cpd-color-bg-canvas-default);
+  opacity: 0.94;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+}
+
+.pulse {
+  position: relative;
+  height: 90px;
+}
+
+.pulse::before {
+  content: "";
+  position: absolute;
+  inset: -12px;
+  border-radius: 9999px;
+  border: 2px solid rgba(255, 255, 255, 0.6);
+  animation: pulse 1.6s ease-out infinite;
+}
+
+@keyframes pulse {
+  0% {
+    transform: scale(0.95);
+    opacity: 0.7;
+  }
+  70% {
+    transform: scale(1.15);
+    opacity: 0.15;
+  }
+  100% {
+    transform: scale(1.2);
+    opacity: 0;
+  }
+}
+
+.label {
+  color: white;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
+}

--- a/src/room/WaitingForJoin.module.css
+++ b/src/room/WaitingForJoin.module.css
@@ -5,8 +5,6 @@
   align-items: center;
   justify-content: center;
   pointer-events: none;
-  background: var(--cpd-color-bg-canvas-default);
-  opacity: 0.94;
 }
 
 .content {

--- a/src/room/WaitingForJoin.module.css
+++ b/src/room/WaitingForJoin.module.css
@@ -24,8 +24,12 @@
   position: absolute;
   inset: -12px;
   border-radius: 9999px;
-  border: 2px solid rgba(255, 255, 255, 0.6);
+  border: 12px solid rgba(255, 255, 255, 0.6);
   animation: pulse 1.6s ease-out infinite;
+}
+
+.text {
+  color: var(--cpd-color-text-on-solid-primary);
 }
 
 @keyframes pulse {

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -116,6 +116,7 @@ export const widget = ((): WidgetHelpers | null => {
         EventType.Reaction,
         EventType.RoomRedaction,
         ElementCallReactionEventType,
+        EventType.RTCDecline,
       ];
 
       const sendState = [


### PR DESCRIPTION
Sounds are reusing existing audio as a stop-gap.

- [x] show dialing animation
- [x] play dialing sound
- [ ] show timeout screen _just close EC without interactive message in this iteration_
- [ ] play timeout sound _only play sound when the other user declines_
- [ ] show decline screen (and auto quit EC) _only doing the auto quit of EC_


Signed-off-by: Timo K <toger5@hotmail.de>