### PR TITLE
Prevent showing calling view when disconnected from Livekit.

### DIFF
--- a/src/room/InCallView.test.tsx
+++ b/src/room/InCallView.test.tsx
@@ -17,7 +17,7 @@ import { act, render, type RenderResult } from "@testing-library/react";
 import { type MatrixClient, JoinRule, type RoomState } from "matrix-js-sdk";
 import { type MatrixRTCSession } from "matrix-js-sdk/lib/matrixrtc";
 import { type RelationsContainer } from "matrix-js-sdk/lib/models/relations-container";
-import { ConnectionState, type LocalParticipant } from "livekit-client";
+import { type LocalParticipant } from "livekit-client";
 import { of } from "rxjs";
 import { BrowserRouter } from "react-router-dom";
 import { TooltipProvider } from "@vector-im/compound-web";
@@ -180,7 +180,6 @@ function createInCallView(): RenderResult & {
                 onLeave={function (): void {
                   throw new Error("Function not implemented.");
                 }}
-                connState={ConnectionState.Connected}
                 onShareClick={null}
               />
             </RoomContext>

--- a/src/room/InCallView.tsx
+++ b/src/room/InCallView.tsx
@@ -25,7 +25,11 @@ import useMeasure from "react-use-measure";
 import { type MatrixRTCSession } from "matrix-js-sdk/lib/matrixrtc";
 import classNames from "classnames";
 import { BehaviorSubject, map } from "rxjs";
-import { useObservable, useSubscription } from "observable-hooks";
+import {
+  useObservable,
+  useObservableEagerState,
+  useSubscription,
+} from "observable-hooks";
 import { logger } from "matrix-js-sdk/lib/logger";
 import { RoomAndToDeviceEvents } from "matrix-js-sdk/lib/matrixrtc/RoomAndToDeviceKeyTransport";
 import {
@@ -249,7 +253,7 @@ export const InCallView: FC<InCallViewProps> = ({
     useReactionsSender();
 
   useWakeLock();
-  const isDisconnected = useBehavior(vm.livekitDisconnected$);
+  const isDisconnected = useObservableEagerState(vm.livekitConnectionState$);
 
   // annoyingly we don't get the disconnection reason this way,
   // only by listening for the emitted event

--- a/src/room/InCallView.tsx
+++ b/src/room/InCallView.tsx
@@ -7,7 +7,7 @@ Please see LICENSE in the repository root for full details.
 
 import { RoomContext, useLocalParticipant } from "@livekit/components-react";
 import { IconButton, Text, Tooltip } from "@vector-im/compound-web";
-import { type Room as LivekitRoom } from "livekit-client";
+import { ConnectionState, type Room as LivekitRoom } from "livekit-client";
 import { type MatrixClient, type Room as MatrixRoom } from "matrix-js-sdk";
 import {
   type FC,
@@ -253,11 +253,12 @@ export const InCallView: FC<InCallViewProps> = ({
     useReactionsSender();
 
   useWakeLock();
-  const isDisconnected = useObservableEagerState(vm.livekitConnectionState$);
+  const connectionState = useObservableEagerState(vm.livekitConnectionState$);
 
   // annoyingly we don't get the disconnection reason this way,
   // only by listening for the emitted event
-  if (isDisconnected) throw new ConnectionLostError();
+  if (connectionState === ConnectionState.Disconnected)
+    throw new ConnectionLostError();
 
   const containerRef1 = useRef<HTMLDivElement | null>(null);
   const [containerRef2, bounds] = useMeasure();

--- a/src/room/InCallView.tsx
+++ b/src/room/InCallView.tsx
@@ -7,7 +7,7 @@ Please see LICENSE in the repository root for full details.
 
 import { RoomContext, useLocalParticipant } from "@livekit/components-react";
 import { IconButton, Text, Tooltip } from "@vector-im/compound-web";
-import { ConnectionState, type Room as LivekitRoom } from "livekit-client";
+import { type Room as LivekitRoom } from "livekit-client";
 import { type MatrixClient, type Room as MatrixRoom } from "matrix-js-sdk";
 import {
   type FC,
@@ -63,7 +63,6 @@ import { type MuteStates } from "./MuteStates";
 import { type MatrixInfo } from "./VideoPreview";
 import { InviteButton } from "../button/InviteButton";
 import { LayoutToggle } from "./LayoutToggle";
-import { type ECConnectionState } from "../livekit/useECConnectionState";
 import { useOpenIDSFU } from "../livekit/openIDSFU";
 import {
   CallViewModel,
@@ -212,12 +211,7 @@ export const ActiveCall: FC<ActiveCallProps> = (props) => {
   return (
     <RoomContext value={livekitRoom}>
       <ReactionsSenderProvider vm={vm} rtcSession={props.rtcSession}>
-        <InCallView
-          {...props}
-          vm={vm}
-          livekitRoom={livekitRoom}
-          connState={connState}
-        />
+        <InCallView {...props} vm={vm} livekitRoom={livekitRoom} />
       </ReactionsSenderProvider>
     </RoomContext>
   );
@@ -235,7 +229,6 @@ export interface InCallViewProps {
   onLeave: (cause: "user", soundFile?: CallEventSounds) => void;
   header: HeaderStyle;
   otelGroupCallMembership?: OTelGroupCallMembership;
-  connState: ECConnectionState;
   onShareClick: (() => void) | null;
 }
 
@@ -249,7 +242,6 @@ export const InCallView: FC<InCallViewProps> = ({
   muteStates,
   onLeave,
   header: headerStyle,
-  connState,
   onShareClick,
 }) => {
   const { t } = useTranslation();
@@ -257,11 +249,11 @@ export const InCallView: FC<InCallViewProps> = ({
     useReactionsSender();
 
   useWakeLock();
+  const isDisconnected = useBehavior(vm.livekitDisconnected$);
 
   // annoyingly we don't get the disconnection reason this way,
   // only by listening for the emitted event
-  if (connState === ConnectionState.Disconnected)
-    throw new ConnectionLostError();
+  if (isDisconnected) throw new ConnectionLostError();
 
   const containerRef1 = useRef<HTMLDivElement | null>(null);
   const [containerRef2, bounds] = useMeasure();

--- a/src/state/CallViewModel.test.ts
+++ b/src/state/CallViewModel.test.ts
@@ -1291,6 +1291,51 @@ describe("waitForCallPickup$", () => {
     });
   });
 
+  test("ringing -> unknown if we get disconnected", () => {
+    withTestScheduler(({ behavior, schedule, expectObservable }) => {
+      const connectionState$ = new BehaviorSubject(ConnectionState.Connected);
+      // Someone joins at 20ms (both LiveKit participant and MatrixRTC member)
+      withCallViewModel(
+        {
+          remoteParticipants$: behavior("a 19ms b", {
+            a: [],
+            b: [aliceParticipant],
+          }),
+          rtcMembers$: behavior("a 19ms b", {
+            a: [localRtcMember],
+            b: [localRtcMember, aliceRtcMember],
+          }),
+          connectionState$,
+        },
+        (vm, rtcSession) => {
+          // Notify at 5ms so we enter ringing, then get disconnected 5ms later
+          schedule("          5ms r 5ms d", {
+            r: () => {
+              rtcSession.emit(
+                MatrixRTCSessionEvent.DidSendCallNotification,
+                mockRingEvent("$notif2", 100),
+                mockLegacyRingEvent,
+              );
+            },
+            d: () => {
+              connectionState$.next(ConnectionState.Disconnected);
+            },
+          });
+
+          expectObservable(vm.callPickupState$).toBe("a 4ms b 5ms c", {
+            a: "unknown",
+            b: "ringing",
+            c: "unknown",
+          });
+        },
+        {
+          waitForCallPickup: true,
+          encryptionSystem: { kind: E2eeType.PER_PARTICIPANT },
+        },
+      );
+    });
+  });
+
   test("success when someone joins before we notify", () => {
     withTestScheduler(({ behavior, schedule, expectObservable }) => {
       // Join at 10ms, notify later at 20ms (state should stay success)

--- a/src/state/CallViewModel.ts
+++ b/src/state/CallViewModel.ts
@@ -465,6 +465,14 @@ export class CallViewModel extends ViewModel {
     ),
   );
 
+  public readonly livekitDisconnected$ = this.scope.behavior(
+    and$(
+      this.livekitConnectionState$.pipe(
+        map((state) => state === ConnectionState.Disconnected),
+      ),
+    ),
+  );
+
   private readonly connected$ = this.scope.behavior(
     and$(
       this.matrixConnected$,
@@ -957,15 +965,19 @@ export class CallViewModel extends ViewModel {
     "unknown" | "ringing" | "timeout" | "decline" | "success" | null
   > = this.options.waitForCallPickup
     ? this.scope.behavior<
-        "unknown" | "ringing" | "timeout" | "decline" | "success"
+        "unknown" | "ringing" | "timeout" | "decline" | "success" | null
       >(
-        this.someoneElseJoined$.pipe(
-          switchMap((someoneElseJoined) =>
-            someoneElseJoined
-              ? of("success" as const)
-              : // Show the ringing state of the most recent ringing attempt.
-                this.ring$.pipe(switchAll()),
-          ),
+        combineLatest(this.livekitDisconnected$, this.someoneElseJoined$).pipe(
+          switchMap(([isDisconnected, someoneElseJoined]) => {
+            if (isDisconnected) {
+              // Do not ring until we're connected.
+              return of(null);
+            } else if (someoneElseJoined) {
+              of("success" as const);
+            }
+            // Show the ringing state of the most recent ringing attempt.
+            return this.ring$.pipe(switchAll());
+          }),
           // The state starts as 'unknown' because we don't know if the RTC
           // session will actually send a notify event yet. It will only be
           // known once we send our own membership and see that we were the

--- a/src/state/CallViewModel.ts
+++ b/src/state/CallViewModel.ts
@@ -968,7 +968,10 @@ export class CallViewModel extends ViewModel {
     ? this.scope.behavior<
         "unknown" | "ringing" | "timeout" | "decline" | "success"
       >(
-        combineLatest(this.livekitDisconnected$, this.someoneElseJoined$).pipe(
+        combineLatest([
+          this.livekitDisconnected$,
+          this.someoneElseJoined$,
+        ]).pipe(
           switchMap(([isDisconnected, someoneElseJoined]) => {
             if (isDisconnected) {
               // Do not ring until we're connected.

--- a/src/state/CallViewModel.ts
+++ b/src/state/CallViewModel.ts
@@ -972,12 +972,12 @@ export class CallViewModel extends ViewModel {
           this.livekitDisconnected$,
           this.someoneElseJoined$,
         ]).pipe(
-          switchMap(([isDisconnected, someoneElseJoined]) => {
-            if (isDisconnected) {
+          switchMap(([disconnected, someoneElseJoined]) => {
+            if (disconnected) {
               // Do not ring until we're connected.
               return of("unknown" as const);
             } else if (someoneElseJoined) {
-              of("success" as const);
+              return of("success" as const);
             }
             // Show the ringing state of the most recent ringing attempt.
             return this.ring$.pipe(switchAll());

--- a/src/state/CallViewModel.ts
+++ b/src/state/CallViewModel.ts
@@ -955,6 +955,7 @@ export class CallViewModel extends ViewModel {
    * The current call pickup state of the call.
    *  - "unknown": The client has not yet sent the notification event. We don't know if it will because it first needs to send its own membership.
    *     Then we can conclude if we were the first one to join or not.
+   *     This may also be set if we are disconnected.
    *  - "ringing": The call is ringing on other devices in this room (This client should give audiovisual feedback that this is happening).
    *  - "timeout": No-one picked up in the defined time this call should be ringing on others devices.
    *     The call failed. If desired this can be used as a trigger to exit the call.
@@ -965,13 +966,13 @@ export class CallViewModel extends ViewModel {
     "unknown" | "ringing" | "timeout" | "decline" | "success" | null
   > = this.options.waitForCallPickup
     ? this.scope.behavior<
-        "unknown" | "ringing" | "timeout" | "decline" | "success" | null
+        "unknown" | "ringing" | "timeout" | "decline" | "success"
       >(
         combineLatest(this.livekitDisconnected$, this.someoneElseJoined$).pipe(
           switchMap(([isDisconnected, someoneElseJoined]) => {
             if (isDisconnected) {
               // Do not ring until we're connected.
-              return of(null);
+              return of("unknown" as const);
             } else if (someoneElseJoined) {
               of("success" as const);
             }

--- a/src/state/CallViewModel.ts
+++ b/src/state/CallViewModel.ts
@@ -465,14 +465,6 @@ export class CallViewModel extends ViewModel {
     ),
   );
 
-  public readonly livekitDisconnected$ = this.scope.behavior(
-    and$(
-      this.livekitConnectionState$.pipe(
-        map((state) => state === ConnectionState.Disconnected),
-      ),
-    ),
-  );
-
   private readonly connected$ = this.scope.behavior(
     and$(
       this.matrixConnected$,
@@ -969,11 +961,11 @@ export class CallViewModel extends ViewModel {
         "unknown" | "ringing" | "timeout" | "decline" | "success"
       >(
         combineLatest([
-          this.livekitDisconnected$,
+          this.livekitConnectionState$,
           this.someoneElseJoined$,
         ]).pipe(
-          switchMap(([disconnected, someoneElseJoined]) => {
-            if (disconnected) {
+          switchMap(([livekitConnectionState, someoneElseJoined]) => {
+            if (livekitConnectionState === ConnectionState.Disconnected) {
               // Do not ring until we're connected.
               return of("unknown" as const);
             } else if (someoneElseJoined) {
@@ -1698,7 +1690,7 @@ export class CallViewModel extends ViewModel {
     private readonly livekitRoom: LivekitRoom,
     private readonly mediaDevices: MediaDevices,
     private readonly options: CallViewModelOptions,
-    private readonly livekitConnectionState$: Observable<ECConnectionState>,
+    public readonly livekitConnectionState$: Observable<ECConnectionState>,
     private readonly handsRaisedSubject$: Observable<
       Record<string, RaisedHandInfo>
     >,


### PR DESCRIPTION
Hopefully fixes the problem where we still show 1:1 calling UI while disconnected from livekit. This also refactors InCallView to use CallViewModel for disconnection state.