### PR TITLE
Correct Caddy reverse proxy config example

### DIFF
--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -136,8 +136,8 @@ handle @jwt_service {
   reverse_proxy http://[::1]:8080 {
     header_up Host {host}
     header_up X-Forwarded-Server {host}
-    header_up X-Real-IP {remote_addr}
-    header_up X-Forwarded-For {remote_addr}
+    header_up X-Real-IP {remote_host}
+    header_up X-Forwarded-For {remote_host}
   }
 }
 
@@ -146,8 +146,8 @@ handle {
   reverse_proxy http://localhost:7880 {
     header_up Host {host}
     header_up X-Forwarded-Server {host}
-    header_up X-Real-IP {remote_addr}
-    header_up X-Forwarded-For {remote_addr}
+    header_up X-Real-IP {remote_host}
+    header_up X-Forwarded-For {remote_host}
   }
 }
 ```


### PR DESCRIPTION
remote_addr in the configuration example for using Caddy as reverse proxy is not a valid placeholder - see https://caddyserver.com/docs/caddyfile/concepts#placeholders .
Due to the mistake Caddy will pass the string "{remote_addr}" instead of the remote IP address. I guess this was missed while rewriting the nginx example.
The correct placeholder is remote_host