### PR TITLE
keep livekit 1.9.4 as the latest is breaking the dev backend

### DIFF
--- a/dev-backend-docker-compose.yml
+++ b/dev-backend-docker-compose.yml
@@ -47,7 +47,7 @@ services:
       - ecbackend
 
   livekit:
-    image: livekit/livekit-server:latest
+    image: livekit/livekit-server:v1.9.4
     pull_policy: always
     hostname: livekit-sfu
     command: --dev --config /etc/livekit.yaml
@@ -67,7 +67,7 @@ services:
       - ecbackend
 
   livekit-1:
-    image: livekit/livekit-server:latest
+    image: livekit/livekit-server:v1.9.4
     pull_policy: always
     hostname: livekit-sfu-1
     command: --dev --config /etc/livekit.yaml


### PR DESCRIPTION
Until this is fixed https://github.com/element-hq/lk-jwt-service/issues/136
Fixed to lk server v1.9.4 to not break CI