### PR TITLE
Use British English consistently as the source translation language

### DIFF
--- a/locales/en/app.json
+++ b/locales/en/app.json
@@ -119,7 +119,7 @@
     "open_elsewhere": "Opened in another tab",
     "open_elsewhere_description": "{{brand}} has been opened in another tab. If that doesn't sound right, try reloading the page.",
     "room_creation_restricted": "Failed to create call",
-    "room_creation_restricted_description": "Call creation might be restricted to authorized users only. Try again later, or contact your server admin if the problem persists.",
+    "room_creation_restricted_description": "Call creation might be restricted to authorised users only. Try again later, or contact your server admin if the problem persists.",
     "unexpected_ec_error": "An unexpected error occurred (<0>Error Code:</0> <1>{{ errorCode }}</1>). Please contact your server admin."
   },
   "group_call_loader": {


### PR DESCRIPTION
This PR modifies a translation base string to use British English consistently, in line with the usual practice for other Element repositories. The American English translation will be restored through Localazy.