### PR TITLE
Make EC compatible with custom `member.id` value (Pseudonomous users on the SFU)

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "livekit-client": "^2.13.0",
     "lodash-es": "^4.17.21",
     "loglevel": "^1.9.1",
-    "matrix-js-sdk": "^39.2.0",
+    "matrix-js-sdk": "git://github.com/matrix-org/matrix-js-sdk.git#5af046f54fc891c62f99b1400aad9964157a87b6",
     "matrix-widget-api": "^1.14.0",
     "normalize.css": "^8.0.1",
     "observable-hooks": "^4.2.3",

--- a/src/state/CallViewModel/remoteMembers/MatrixLivekitMembers.ts
+++ b/src/state/CallViewModel/remoteMembers/MatrixLivekitMembers.ts
@@ -87,8 +87,13 @@ export function createMatrixLivekitMembers$({
         // Each change in the keys (new key, missing key) will result in a call to the factory function.
         function* ([membershipsWithTransports, managerData]) {
           for (const { membership, transport } of membershipsWithTransports) {
-            // TODO! cannot use membership.membershipID yet, Currently its hardcoded by the jwt service to
-            const participantId = /*membership.membershipID*/ `${membership.userId}:${membership.deviceId}`;
+            // membership.membershipID will default to `${membership.userId}:${membership.deviceId}` if undefined.
+            // membership.membershipID will be set to sessionEvent.content.membershipID (stateEvents)
+            // or matrixRTCEvent.content.member.id (stickyEvents)
+            // On top of that session memebrship events from v0.17.0 upwards are going to be sent with `${membership.userId}:${membership.deviceId}`
+            // And sticky event rtc memberships are might be sent with a UUID. This is why this has to be fetched from the memerbship because the
+            // previous hardcoded rule `${membership.userId}:${membership.deviceId}` does not apply to matrix2.0 events.
+            const participantId = membership.membershipID;
 
             const participants = transport
               ? managerData.getParticipantForTransport(transport)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2795,10 +2795,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@matrix-org/matrix-sdk-crypto-wasm@npm:^15.3.0":
-  version: 15.3.0
-  resolution: "@matrix-org/matrix-sdk-crypto-wasm@npm:15.3.0"
-  checksum: 10c0/45628f36b7b0e54a8777ae67a7233dbdf3e3cf14e0d95d21f62f89a7ea7e3f907232f1eb7b1262193b1e227759fad47af829dcccc103ded89011f13c66f01d76
+"@matrix-org/matrix-sdk-crypto-wasm@npm:^16.0.0":
+  version: 16.0.0
+  resolution: "@matrix-org/matrix-sdk-crypto-wasm@npm:16.0.0"
+  checksum: 10c0/13b4ede3e618da819957abff778afefcf3baf9a2faac04a36bb5a07a44fae2ea05fbfa072eb3408d48b2b7b9aaf27242ce52c594c8ce9bf1fb8b3aade2832be1
   languageName: node
   linkType: hard
 
@@ -7547,7 +7547,7 @@ __metadata:
     livekit-client: "npm:^2.13.0"
     lodash-es: "npm:^4.17.21"
     loglevel: "npm:^1.9.1"
-    matrix-js-sdk: "npm:^39.2.0"
+    matrix-js-sdk: "git://github.com/matrix-org/matrix-js-sdk.git#5af046f54fc891c62f99b1400aad9964157a87b6"
     matrix-widget-api: "npm:^1.14.0"
     normalize.css: "npm:^8.0.1"
     observable-hooks: "npm:^4.2.3"
@@ -10352,12 +10352,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"matrix-js-sdk@npm:^39.2.0":
-  version: 39.2.0
-  resolution: "matrix-js-sdk@npm:39.2.0"
+"matrix-js-sdk@git://github.com/matrix-org/matrix-js-sdk.git#5af046f54fc891c62f99b1400aad9964157a87b6":
+  version: 39.3.0
+  resolution: "matrix-js-sdk@https://github.com/matrix-org/matrix-js-sdk.git#commit=5af046f54fc891c62f99b1400aad9964157a87b6"
   dependencies:
     "@babel/runtime": "npm:^7.12.5"
-    "@matrix-org/matrix-sdk-crypto-wasm": "npm:^15.3.0"
+    "@matrix-org/matrix-sdk-crypto-wasm": "npm:^16.0.0"
     another-json: "npm:^0.2.0"
     bs58: "npm:^6.0.0"
     content-type: "npm:^1.0.4"
@@ -10370,7 +10370,7 @@ __metadata:
     sdp-transform: "npm:^3.0.0"
     unhomoglyph: "npm:^1.0.6"
     uuid: "npm:13"
-  checksum: 10c0/f8b5261de2744305330ba3952821ca9303698170bfd3a0ff8a767b9286d4e8d4ed5aaf6fbaf8a1e8ff9dbd859102a2a47d882787e2da3b3078965bec00157959
+  checksum: 10c0/a6efa5d1d573f30d0197dace6299e935464ed184b72db4ed1113076c32c69654c9b9cdc7cafa57027cd558984b345f01e04040eb3b16e4f2e9f704157a79f2bb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This is the companioning PR for: https://github.com/matrix-org/matrix-js-sdk/pull/5105

It allows to use a custom UUID value in the `member.id` field.
 - compatible with matrix2.0 (it expects the livekit identity to be what we have in member.id)
 - allows us to hide the identity from he SFU.

It also makes sure EC (from v0.17.0 and onwards) will always send the `membershipID` or `member.id` with the expected value.

 