### PR TITLE
Start publishing latest docker tags again.

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -61,6 +61,7 @@ jobs:
       docker_tags: |
         type=sha,format=short,event=branch
         type=raw,value=${{ github.event.release.tag_name }}
+        type=raw,value=latest
       # Like before, using ${{ env.VERSION }} above doesn't work
   add_docker_release_note:
     needs: publish_docker


### PR DESCRIPTION
Fixes https://github.com/element-hq/element-call/issues/3647

Based on https://github.com/docker/metadata-action?tab=readme-ov-file#latest-tag