### PR TITLE
Remove duplicate IntentAndPlatformDerivedConfiguration interface

### DIFF
--- a/src/UrlParams.ts
+++ b/src/UrlParams.ts
@@ -246,10 +246,7 @@ export interface UrlConfiguration {
 
   callIntent?: RTCCallIntent;
 }
-interface IntentAndPlatformDerivedConfiguration {
-  defaultAudioEnabled?: boolean;
-  defaultVideoEnabled?: boolean;
-}
+
 interface IntentAndPlatformDerivedConfiguration {
   defaultAudioEnabled?: boolean;
   defaultVideoEnabled?: boolean;


### PR DESCRIPTION
I don't know how Typescript allows this.