### PR TITLE
Change the livekit alias to just be the room id (for backwards compatibility)

### DIFF
--- a/dev-backend-docker-compose.yml
+++ b/dev-backend-docker-compose.yml
@@ -3,7 +3,7 @@ networks:
 
 services:
   auth-service:
-    image: ghcr.io/element-hq/lk-jwt-service:pr_139
+    image: ghcr.io/element-hq/lk-jwt-service:sha-f8ddd00
     pull_policy: always
     hostname: auth-server
     environment:
@@ -25,7 +25,7 @@ services:
       - ecbackend
 
   auth-service-1:
-    image: ghcr.io/element-hq/lk-jwt-service:pr_139
+    image: ghcr.io/element-hq/lk-jwt-service:sha-f8ddd00
     pull_policy: always
     hostname: auth-server-1
     environment:

--- a/src/state/CallViewModel/localMember/LocalTransport.ts
+++ b/src/state/CallViewModel/localMember/LocalTransport.ts
@@ -250,7 +250,18 @@ async function makeTransport(
       transport: {
         type: "livekit",
         livekit_service_url: url,
-        livekit_alias: sfuConfig.livekitAlias,
+        // WARNING PLS READ ME!!!
+        // This looks unintuitive especially considering that `sfuConfig.livekitAlias` exists.
+        // Why do we not use: `livekit_alias: sfuConfig.livekitAlias`
+        //
+        //  - This is going to be used for sending our state event transport (focus_preferred)
+        //  - In sticky events it is expected to NOT send this field at all. The transport is only the `type`, `livekit_service_url`
+        //  - If we set it to the hased alias we get from the jwt, we will end up using the hashed alias as the body.roomId field
+        //    in v0.16.0. (It will use oldest member transport. It is using the transport.livekit_alias as the body.roomId)
+        //
+        // TLDR this is a temporal fild that allow for comaptibilty but the spec expects it to not exists. (but its existance also does not break anything)
+        // It is just named poorly: It was intetended to be the actual alias. But now we do pseudonymys ids so we use a hashed alias.
+        livekit_alias: roomId,
       },
       sfuConfig,
     };

--- a/src/state/CallViewModel/localMember/LocalTransport.ts
+++ b/src/state/CallViewModel/localMember/LocalTransport.ts
@@ -68,6 +68,27 @@ export enum JwtEndpointVersion {
   Matrix_2_0 = "matrix_2_0",
 }
 
+// TODO livekit_alias-cleanup
+// 1. We need to move away from transports map to connections!!!
+//
+// 2. We need to stop sending livekit_alias all together
+//
+//
+// 1.
+// Transports are just the jwt service adress but do not contain the information which room on this transport to use.
+// That requires slot and roomId.
+//
+// We need one connection per room on the transport.
+//
+// We need an object that contains:
+// transport
+// roomId
+// slotId
+//
+// To map to the connections. Prosposal: `ConnectionIdentifier`
+//
+// 2.
+// We need to make sure we do not sent livekit_alias in sticky events and that we drop all code for sending state events!
 export interface LocalTransportWithSFUConfig {
   transport: LivekitTransport;
   sfuConfig: SFUConfig;

--- a/src/state/CallViewModel/localMember/LocalTransport.ts
+++ b/src/state/CallViewModel/localMember/LocalTransport.ts
@@ -280,7 +280,7 @@ async function makeTransport(
         //  - If we set it to the hased alias we get from the jwt, we will end up using the hashed alias as the body.roomId field
         //    in v0.16.0. (It will use oldest member transport. It is using the transport.livekit_alias as the body.roomId)
         //
-        // TLDR this is a temporal fild that allow for comaptibilty but the spec expects it to not exists. (but its existance also does not break anything)
+        // TLDR this is a temporal field that allow for comaptibilty but the spec expects it to not exists. (but its existance also does not break anything)
         // It is just named poorly: It was intetended to be the actual alias. But now we do pseudonymys ids so we use a hashed alias.
         livekit_alias: roomId,
       },

--- a/src/state/CallViewModel/remoteMembers/MatrixLivekitMembers.ts
+++ b/src/state/CallViewModel/remoteMembers/MatrixLivekitMembers.ts
@@ -143,9 +143,13 @@ export function areLivekitTransportsEqual<T extends LivekitTransport>(
   t1: T | null,
   t2: T | null,
 ): boolean {
-  if (t1 && t2) return t1.livekit_service_url === t2.livekit_service_url;
-  // In case we have different lk rooms in the same SFU (depends on the livekit authorization service)
-  // It is only needed in case the livekit authorization service is not behaving as expected (or custom implementation)
+  if (t1 && t2)
+    return (
+      t1.livekit_service_url === t2.livekit_service_url &&
+      // In case we have different lk rooms in the same SFU (depends on the livekit authorization service)
+      // It is only needed in case the livekit authorization service is not behaving as expected (or custom implementation)
+      t1.livekit_alias === t2.livekit_alias
+    );
   if (!t1 && !t2) return true;
   return false;
 }

--- a/src/state/CallViewModel/remoteMembers/MatrixLivekitMembers.ts
+++ b/src/state/CallViewModel/remoteMembers/MatrixLivekitMembers.ts
@@ -148,6 +148,7 @@ export function areLivekitTransportsEqual<T extends LivekitTransport>(
       t1.livekit_service_url === t2.livekit_service_url &&
       // In case we have different lk rooms in the same SFU (depends on the livekit authorization service)
       // It is only needed in case the livekit authorization service is not behaving as expected (or custom implementation)
+      // Also LivekitTransport is planned to become a `ConnectionIdentifier` which moves this equal somewhere else.
       t1.livekit_alias === t2.livekit_alias
     );
   if (!t1 && !t2) return true;


### PR DESCRIPTION
compatibility.

The main context can be found in the code comment:
```
        // This looks unintuitive especially considering that `sfuConfig.livekitAlias` exists.
        // Why do we not use: `livekit_alias: sfuConfig.livekitAlias`
        //
        //  - This is going to be used for sending our state event transport (focus_preferred)
        //  - In sticky events it is expected to NOT send this field at all. The transport is only the `type`, `livekit_service_url`
        //  - If we set it to the hased alias we get from the jwt, we will end up using the hashed alias as the body.roomId field
        //    in v0.16.0. (It will use oldest member transport. It is using the transport.livekit_alias as the body.roomId)
        //
        // TLDR this is a temporal fild that allow for comaptibilty but the spec expects it to not exists. (but its existance also does not break anything)
        // It is just named poorly: It was intetended to be the actual alias. But now we do pseudonymys ids so we use a hashed alias.

```