### PR TITLE
Add livekitAlias debugging info

### DIFF
--- a/src/room/InCallView.tsx
+++ b/src/room/InCallView.tsx
@@ -842,6 +842,7 @@ export const InCallView: FC<InCallViewProps> = ({
               .getConnections()
               .map((connectionItem) => ({
                 room: connectionItem.livekitRoom,
+                livekitAlias: connectionItem.livekitAlias,
                 // TODO compute is local or tag it in the livekit room items already
                 isLocal: undefined,
                 url: connectionItem.transport.livekit_service_url,

--- a/src/settings/DeveloperSettingsTab.test.tsx
+++ b/src/settings/DeveloperSettingsTab.test.tsx
@@ -25,7 +25,7 @@ function createMockLivekitRoom(
   wsUrl: string,
   serverInfo: object,
   metadata: string,
-): { isLocal: boolean; url: string; room: LivekitRoom } {
+): { isLocal: boolean; url: string; room: LivekitRoom; livekitAlias: string } {
   const mockRoom = {
     serverInfo,
     metadata,
@@ -38,6 +38,7 @@ function createMockLivekitRoom(
     isLocal: true,
     url: wsUrl,
     room: mockRoom,
+    livekitAlias: "TestAlias",
   };
 }
 
@@ -61,6 +62,7 @@ describe("DeveloperSettingsTab", () => {
       room: LivekitRoom;
       url: string;
       isLocal?: boolean;
+      livekitAlias: string;
     }[] = [
       createMockLivekitRoom(
         "wss://local-sfu.example.org",
@@ -69,6 +71,7 @@ describe("DeveloperSettingsTab", () => {
       ),
       {
         isLocal: false,
+        livekitAlias: "TestAlias2",
         url: "wss://remote-sfu.example.org",
         room: {
           localParticipant: { identity: "localParticipantIdentity" },

--- a/src/settings/DeveloperSettingsTab.tsx
+++ b/src/settings/DeveloperSettingsTab.tsx
@@ -48,7 +48,12 @@ import { useUrlParams } from "../UrlParams";
 
 interface Props {
   client: MatrixClient;
-  livekitRooms?: { room: LivekitRoom; url: string; isLocal?: boolean }[];
+  livekitRooms?: {
+    room: LivekitRoom;
+    url: string;
+    isLocal?: boolean;
+    livekitAlias?: string;
+  }[];
   env: ImportMetaEnv;
 }
 
@@ -310,6 +315,7 @@ export const DeveloperSettingsTab: FC<Props> = ({
               url: livekitRoom.url || "unknown",
             })}
           </h4>
+          <p>LivekitAlias: {livekitRoom.livekitAlias}</p>
           {livekitRoom.isLocal && <p>ws-url: {localSfuUrl?.href}</p>}
           <p>
             {t("developer_mode.livekit_server_info")}(

--- a/src/settings/__snapshots__/DeveloperSettingsTab.test.tsx.snap
+++ b/src/settings/__snapshots__/DeveloperSettingsTab.test.tsx.snap
@@ -356,6 +356,10 @@ exports[`DeveloperSettingsTab > renders and matches snapshot 1`] = `
       LiveKit SFU: wss://local-sfu.example.org
     </h4>
     <p>
+      LivekitAlias: 
+      TestAlias
+    </p>
+    <p>
       ws-url: 
       wss://local-sfu.example.org/
     </p>
@@ -393,6 +397,10 @@ exports[`DeveloperSettingsTab > renders and matches snapshot 1`] = `
     <h4>
       LiveKit SFU: wss://remote-sfu.example.org
     </h4>
+    <p>
+      LivekitAlias: 
+      TestAlias2
+    </p>
     <p>
       LiveKit Server Info
       (

--- a/src/state/CallViewModel/remoteMembers/Connection.ts
+++ b/src/state/CallViewModel/remoteMembers/Connection.ts
@@ -118,6 +118,14 @@ export class Connection {
   public readonly remoteParticipants$: Behavior<RemoteParticipant[]>;
 
   /**
+   * The alias of the LiveKit room.
+   */
+  public get livekitAlias(): string | undefined {
+    return this._livekitAlias;
+  }
+  private _livekitAlias?: string;
+
+  /**
    * Whether the connection has been stopped.
    * @see Connection.stop
    * */
@@ -144,9 +152,10 @@ export class Connection {
       this._state$.next(ConnectionState.FetchingConfig);
       // We should already have this information after creating the localTransport.
       // only call getSFUConfigWithOpenID for connections where we do not have a token yet. (existingJwtTokenData === undefined)
-      const { url, jwt } =
+      const { url, jwt, livekitAlias } =
         this.existingSFUConfig ??
         (await this.getSFUConfigForRemoteConnection());
+      this._livekitAlias = livekitAlias;
       // If we were stopped while fetching the config, don't proceed to connect
       if (this.stopped) return;
 


### PR DESCRIPTION
This adds the actual livekit alias (not the one sent via the state event that just is the roomId) to the devtools.