### PR TITLE
Fix delayId delegation. Use correct event reemitting types.

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "livekit-client": "^2.13.0",
     "lodash-es": "^4.17.21",
     "loglevel": "^1.9.1",
-    "matrix-js-sdk": "matrix-org/matrix-js-sdk#develop",
+    "matrix-js-sdk": "matrix-org/matrix-js-sdk#4a75d2c92f1ac7476a6d398057b91c65054f1b80",
     "matrix-widget-api": "^1.14.0",
     "node-stdlib-browser": "^1.3.1",
     "normalize.css": "^8.0.1",

--- a/src/state/CallViewModel/CallViewModel.ts
+++ b/src/state/CallViewModel/CallViewModel.ts
@@ -142,6 +142,7 @@ import {
 import { Publisher } from "./localMember/Publisher.ts";
 import { type Connection } from "./remoteMembers/Connection.ts";
 import { createLayoutModeSwitch } from "./LayoutSwitch.ts";
+import { IMembershipManager } from "matrix-js-sdk/lib/matrixrtc/IMembershipManager";
 
 const logger = rootLogger.getChild("[CallViewModel]");
 //TODO
@@ -445,8 +446,17 @@ export function createCallViewModel$(
         fromEvent(
           matrixRTCSession,
           MembershipManagerEvent.DelayIdChanged,
-        ) as Observable<string | undefined>
-      ).pipe(map((v) => v ?? null)),
+          // The type of reemitted event includes the original emitted as the second arg.
+        ) as Observable<[string | undefined, IMembershipManager]>
+      ).pipe(
+        map(([delayId]) => {
+          logger.debug(
+            "DelayId change emitted from matrixRTCSession: ",
+            delayId,
+          );
+          return delayId ?? null;
+        }),
+      ),
       matrixRTCSession.delayId ?? null,
     ),
     roomId: matrixRoom.roomId,

--- a/src/state/CallViewModel/CallViewModel.ts
+++ b/src/state/CallViewModel/CallViewModel.ts
@@ -48,6 +48,7 @@ import {
 import { type IWidgetApiRequest } from "matrix-widget-api";
 import { type CallMembershipIdentityParts } from "matrix-js-sdk/lib/matrixrtc/EncryptionManager";
 import { v4 as uuidv4 } from "uuid";
+import { type IMembershipManager } from "matrix-js-sdk/lib/matrixrtc/IMembershipManager";
 
 import {
   LocalUserMediaViewModel,
@@ -142,7 +143,6 @@ import {
 import { Publisher } from "./localMember/Publisher.ts";
 import { type Connection } from "./remoteMembers/Connection.ts";
 import { createLayoutModeSwitch } from "./LayoutSwitch.ts";
-import { IMembershipManager } from "matrix-js-sdk/lib/matrixrtc/IMembershipManager";
 
 const logger = rootLogger.getChild("[CallViewModel]");
 //TODO

--- a/src/state/CallViewModel/CallViewModel.ts
+++ b/src/state/CallViewModel/CallViewModel.ts
@@ -448,15 +448,7 @@ export function createCallViewModel$(
           MembershipManagerEvent.DelayIdChanged,
           // The type of reemitted event includes the original emitted as the second arg.
         ) as Observable<[string | undefined, IMembershipManager]>
-      ).pipe(
-        map(([delayId]) => {
-          logger.debug(
-            "DelayId change emitted from matrixRTCSession: ",
-            delayId,
-          );
-          return delayId ?? null;
-        }),
-      ),
+      ).pipe(map(([delayId]) => delayId ?? null)),
       matrixRTCSession.delayId ?? null,
     ),
     roomId: matrixRoom.roomId,

--- a/src/state/CallViewModel/localMember/LocalTransport.ts
+++ b/src/state/CallViewModel/localMember/LocalTransport.ts
@@ -177,8 +177,11 @@ export const createLocalTransport$ = ({
       switchMap(([customUrl, delayId, forceEndpoint]) => {
         logger.info(
           "Creating preferred transport based on: ",
+          "customUrl: ",
           customUrl,
+          "delayId: ",
           delayId,
+          "forceEndpoint: ",
           forceEndpoint,
         );
         return from(

--- a/yarn.lock
+++ b/yarn.lock
@@ -11453,8 +11453,8 @@ __metadata:
   linkType: hard
 
 "matrix-js-sdk@matrix-org/matrix-js-sdk#develop":
-  version: 39.4.0
-  resolution: "matrix-js-sdk@https://github.com/matrix-org/matrix-js-sdk.git#commit=4d0d32307eb4f1ce1fb65080fcca704f5bdedc31"
+  version: 40.0.0
+  resolution: "matrix-js-sdk@https://github.com/matrix-org/matrix-js-sdk.git#commit=899cdb0e1da4933d3eaf4c7337c1846e1ec8174c"
   dependencies:
     "@babel/runtime": "npm:^7.12.5"
     "@matrix-org/matrix-sdk-crypto-wasm": "npm:^17.0.0"
@@ -11470,7 +11470,7 @@ __metadata:
     sdp-transform: "npm:^3.0.0"
     unhomoglyph: "npm:^1.0.6"
     uuid: "npm:13"
-  checksum: 10c0/59c9d81ccf823584dc783502cb5c928562e3490c63f5ce98ee3232a603545d6278e90dc951c1fd0bae2792ba732ec5171e03596fd396bb2150d596cebb7fbac9
+  checksum: 10c0/2476eb0bfed0b74fe5dcae25022a28d53d69297570d93f6121893246a9fd22452c48477fa605e99f25405f0249b14ffcaed0fd7cbf3318ad4cee20458689f40e
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8364,7 +8364,7 @@ __metadata:
     livekit-client: "npm:^2.13.0"
     lodash-es: "npm:^4.17.21"
     loglevel: "npm:^1.9.1"
-    matrix-js-sdk: "matrix-org/matrix-js-sdk#develop"
+    matrix-js-sdk: "matrix-org/matrix-js-sdk#4a75d2c92f1ac7476a6d398057b91c65054f1b80"
     matrix-widget-api: "npm:^1.14.0"
     node-stdlib-browser: "npm:^1.3.1"
     normalize.css: "npm:^8.0.1"
@@ -11452,9 +11452,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"matrix-js-sdk@matrix-org/matrix-js-sdk#develop":
+"matrix-js-sdk@matrix-org/matrix-js-sdk#4a75d2c92f1ac7476a6d398057b91c65054f1b80":
   version: 40.0.0
-  resolution: "matrix-js-sdk@https://github.com/matrix-org/matrix-js-sdk.git#commit=899cdb0e1da4933d3eaf4c7337c1846e1ec8174c"
+  resolution: "matrix-js-sdk@https://github.com/matrix-org/matrix-js-sdk.git#commit=4a75d2c92f1ac7476a6d398057b91c65054f1b80"
   dependencies:
     "@babel/runtime": "npm:^7.12.5"
     "@matrix-org/matrix-sdk-crypto-wasm": "npm:^17.0.0"
@@ -11470,7 +11470,7 @@ __metadata:
     sdp-transform: "npm:^3.0.0"
     unhomoglyph: "npm:^1.0.6"
     uuid: "npm:13"
-  checksum: 10c0/2476eb0bfed0b74fe5dcae25022a28d53d69297570d93f6121893246a9fd22452c48477fa605e99f25405f0249b14ffcaed0fd7cbf3318ad4cee20458689f40e
+  checksum: 10c0/4b0d970fcdd6a43a369c08ce224a7d52d30706020b30af6896e07f2335df4616c068147ae76fca46506a1c6dedadfd633d96a4c9f43ce751e2b411d2c80211d3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
When using reemitters, the callback args will change to an array including the originals emitter.

Blocked by: https://github.com/matrix-org/matrix-js-sdk/pull/5144