### PR TITLE
Do not end call with error in case of MediaDeviceError

### DIFF
--- a/src/state/CallViewModel/localMember/LocalMember.ts
+++ b/src/state/CallViewModel/localMember/LocalMember.ts
@@ -266,11 +266,11 @@ export const createLocalMembership$ = ({
 
   mediaErrors$.pipe(scope.bind()).subscribe((error) => {
     if (error) {
+      // This is a MediaDevice error, can be PermissionDenied, NotFound, DeviceInUse, Other.
+      // Will also occurs if you cancel screen sharing browser prompt.
+      // This is not necessarily fatal, since the user might be able to join without media.
+      // XXX We might want to give some user feedback here to let them know their media is not working.
       logger.error(`Failed to create local tracks:`, error);
-      setMatrixError(
-        // TODO is it fatal? Do we need to create a new Specialized Error?
-        new UnknownCallError(new Error(`Media device error: ${error}`)),
-      );
     }
   });
   // MATRIX RELATED


### PR DESCRIPTION
Fix regressions after CallViewModel refactoring
#Fixes https://github.com/element-hq/voip-internal/issues/440 - Call ends with error if try to enable camera when permission was denied
#Fixes https://github.com/element-hq/voip-internal/issues/439 - Call ends with error if user cancel sceensharing at the window selection screen.

I tried to do some playwright test for that, but could not find a way to **Deny** a permission.
It is possible to not **grant** a permission, but when doing that the playwright browser is in an intermediate state where the permission is nor granted nor denied. Thus it is not possible to reproduce :/
Maybe this could have helped? https://github.com/microsoft/playwright/issues/6488 but it was closed