### PR TITLE
fix: Netlify preview broken

### DIFF
--- a/.github/workflows/deploy-to-netlify.yaml
+++ b/.github/workflows/deploy-to-netlify.yaml
@@ -64,6 +64,8 @@ jobs:
       - name: Add config file
         run: |
           if [ "${{ inputs.package }}" = "full" ]; then
+            curl -s "https://raw.githubusercontent.com/${{ inputs.pr_head_full_name }}/${{ inputs.pr_head_ref }}/config/config_netlify_preview.json" > webapp/config.json
+          else
             curl -s "https://raw.githubusercontent.com/${{ inputs.pr_head_full_name }}/${{ inputs.pr_head_ref }}/config/config_netlify_preview_sdk.json" > webapp/config.json
           fi
       - name: ☁️ Deploy to Netlify

--- a/config/config_netlify_preview_sdk.json
+++ b/config/config_netlify_preview_sdk.json
@@ -1,0 +1,16 @@
+{
+  "default_server_config": {
+    "m.homeserver": {
+      "base_url": "https://call-unstable.ems.host",
+      "server_name": "call-unstable.ems.host"
+    }
+  },
+  "ssla": "https://static.element.io/legal/element-software-and-services-license-agreement-uk-1.pdf",
+  "matrix_rtc_session": {
+    "wait_for_key_rotation_ms": 3000,
+    "membership_event_expiry_ms": 180000000,
+    "delayed_leave_event_delay_ms": 18000,
+    "delayed_leave_event_restart_ms": 4000,
+    "network_error_retry_ms": 100
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/element-hq/voip-internal/issues/475

Regression due to https://github.com/element-hq/element-call/pull/3720

`deploy-to-netlify.yaml` was referencing a non-existing config file. 
Causing the required config file to be served with a 200 OK response but a body `404 not found`, thus preventing the app to load

Not sure what was the expected behavior wanted by @toger5 , for now I am adding a custom config for sdk with no analytics or sentry?