### PR TITLE
Fix: crash on mobile with `0.17.0-rc.2` due to a log causing stringify to crash with `TypedError: circular structure` 

### DIFF
--- a/src/settings/rageshake.test.ts
+++ b/src/settings/rageshake.test.ts
@@ -1,0 +1,34 @@
+/*
+Copyright 2026 Element Creations Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE in the repository root for full details.
+*/
+
+import { expect, it } from "vitest";
+
+import { init as initRageshake } from "./rageshake";
+
+it("Logger should not crash if JSON.stringify fails", async () => {
+  // JSON.stringify can throw. We want to make sure that the logger can handle this gracefully.
+  await initRageshake();
+
+  const bigIntObj = { n: 1n };
+  const notStringifiable = {
+    bigIntObj,
+  };
+  // @ts-expect-error - we want to create an object that cannot be stringified
+  notStringifiable.foo = notStringifiable; // circular reference
+
+  // ensure this cannot be stringified
+  expect(() => JSON.stringify(notStringifiable)).toThrow();
+
+  expect(() =>
+    global.mx_rage_logger.log(
+      1,
+      "test",
+      "This is a test message",
+      notStringifiable,
+    ),
+  ).not.toThrow();
+});

--- a/src/settings/rageshake.ts
+++ b/src/settings/rageshake.ts
@@ -75,7 +75,14 @@ class ConsoleLogger extends EventEmitter {
       } else if (arg instanceof Error) {
         return arg.message + (arg.stack ? `\n${arg.stack}` : "");
       } else if (typeof arg === "object") {
-        return JSON.stringify(arg, getCircularReplacer());
+        try {
+          return JSON.stringify(arg, getCircularReplacer());
+        } catch {
+          // Stringify can fail if the object has circular references or if
+          // there is a bigInt.
+          // Did happen even with our `getCircularReplacer`. In this case, just log
+          return "<$ failed to serialize object $>";
+        }
       } else {
         return arg;
       }

--- a/src/state/CallViewModel/CallViewModel.ts
+++ b/src/state/CallViewModel/CallViewModel.ts
@@ -1555,7 +1555,15 @@ export function createCallViewModel$(
       matrixLivekitMembers$.pipe(
         map((members) => members.value),
         tap((v) => {
-          logger.debug("matrixLivekitMembers$ updated (exported)", v);
+          const listForLogs = v
+            .map(
+              (m) =>
+                m.membership$.value.userId + "|" + m.membership$.value.deviceId,
+            )
+            .join(",");
+          logger.debug(
+            `matrixLivekitMembers$ updated (exported) [${listForLogs}]`,
+          );
         }),
       ),
     ),


### PR DESCRIPTION
EC on mobile (embedded as a widget on android only) was crashing in the RC.
As per sentry report it is due to a `JSON.stringify()` crash

```
Converting circular structure to JSON
    --> starting at object with constructor 'e'
    |     property '_parentage' -> object with constructor 'e'
    |     property '_finalizers' -> object with constructor 'Array'
    --- index 0 closes the circle
```

Caused by a log statement that is logging an array of objects containing several observables.

I am not sure to understand why it only crash on mobile, I am not familiar enough with the web runtime.
Anyhow it is abusive to log this full array like it is now, so I fixed that.
Also adding a defensive try/catch around the stringify for safety

fixes https://github.com/element-hq/voip-internal/issues/473