### PR TITLE
Discord features

### DIFF
--- a/src/UrlParams.ts
+++ b/src/UrlParams.ts
@@ -244,6 +244,18 @@ export interface UrlConfiguration {
    * Defaults to true.
    */
   noiseSuppression?: boolean;
+  /**
+   * Screen share resolution override (e.g. "1440p", "1080p").
+   */
+  screenShareRes?: string;
+  /**
+   * Screen share framerate override in fps.
+   */
+  screenShareFps?: number;
+  /**
+   * Screen share bitrate override in bits per second.
+   */
+  screenShareBitrate?: number;
 
   callIntent?: RTCCallIntent;
 }
@@ -506,6 +518,11 @@ export const computeUrlParams = (search = "", hash = ""): UrlParams => {
     noiseSuppression: parser.getFlagParam("noiseSuppression", true),
     echoCancellation: parser.getFlagParam("echoCancellation", true),
   };
+  const screenShareFpsRaw = parser.getParam("screenShareFps");
+  const screenShareBitrateRaw = parser.getParam("screenShareBitrate");
+  if (parser.getParam("screenShareRes")) (configuration as Record<string, unknown>).screenShareRes = parser.getParam("screenShareRes");
+  if (screenShareFpsRaw) (configuration as Record<string, unknown>).screenShareFps = Number(screenShareFpsRaw);
+  if (screenShareBitrateRaw) (configuration as Record<string, unknown>).screenShareBitrate = Number(screenShareBitrateRaw);
 
   // Log the final configuration for debugging purposes.
   // This will only log when the cache is not yet set.

--- a/src/config/ConfigOptions.ts
+++ b/src/config/ConfigOptions.ts
@@ -62,6 +62,22 @@ export interface ConfigOptions {
   };
 
   /**
+   * Screen share quality settings.
+   * Allows overriding the default screen share encoding (1080p30 / 5 Mbps).
+   */
+  screen_share?: {
+    /** Maximum resolution: "2160p", "1440p", "1080p", "720p", or "480p". */
+    max_resolution?: "2160p" | "1440p" | "1080p" | "720p" | "480p";
+    /** Maximum framerate in fps (e.g. 30, 60). */
+    max_framerate?: number;
+    /**
+     * Maximum bitrate in bits per second (e.g. 10000000 for 10 Mbps).
+     * If omitted, a sensible default is chosen based on the resolution.
+     */
+    max_bitrate?: number;
+  };
+
+  /**
    * TEMPORARY experimental features.
    */
   features?: {

--- a/src/livekit/options.ts
+++ b/src/livekit/options.ts
@@ -8,12 +8,14 @@ Please see LICENSE in the repository root for full details.
 import {
   AudioPresets,
   DefaultReconnectPolicy,
+  VideoPreset,
   type RoomOptions,
   ScreenSharePresets,
   type TrackPublishDefaults,
-  type VideoPreset,
   VideoPresets,
 } from "livekit-client";
+import { Config } from "../config/Config";
+import { getUrlParams } from "../UrlParams";
 
 const defaultLiveKitPublishOptions: TrackPublishDefaults = {
   audioPreset: AudioPresets.music,
@@ -24,31 +26,116 @@ const defaultLiveKitPublishOptions: TrackPublishDefaults = {
   forceStereo: false,
   simulcast: true,
   videoSimulcastLayers: [VideoPresets.h180, VideoPresets.h360] as VideoPreset[],
-  screenShareEncoding: ScreenSharePresets.h1080fps30.encoding,
   stopMicTrackOnMute: false,
   videoCodec: "vp8",
   videoEncoding: VideoPresets.h720.encoding,
   backupCodec: { codec: "vp8", encoding: VideoPresets.h720.encoding },
 } as const;
 
-export const defaultLiveKitOptions: RoomOptions = {
-  // automatically manage subscribed video quality
-  adaptiveStream: true,
-
-  // optimize publishing bandwidth and CPU for published tracks
-  dynacast: true,
-
-  // capture settings
-  videoCaptureDefaults: {
-    resolution: VideoPresets.h720.resolution,
-  },
-
-  // publish settings
-  publishDefaults: defaultLiveKitPublishOptions,
-
-  // default LiveKit options that seem to be sane
-  stopLocalTrackOnUnpublish: true,
-  reconnectPolicy: new DefaultReconnectPolicy(),
-  disconnectOnPageLeave: true,
-  webAudioMix: false,
+const resolutionMap: Record<string, { width: number; height: number }> = {
+  "2160p": { width: 3840, height: 2160 },
+  "1440p": { width: 2560, height: 1440 },
+  "1080p": { width: 1920, height: 1080 },
+  "720p": { width: 1280, height: 720 },
+  "480p": { width: 854, height: 480 },
 };
+
+const defaultBitrateForRes: Record<string, number> = {
+  "2160p": 16_000_000,
+  "1440p": 10_000_000,
+  "1080p": 5_000_000,
+  "720p": 2_000_000,
+  "480p": 800_000,
+};
+
+/**
+ * Resolve screen share encoding from (in priority order):
+ *   1. URL parameters (screenShareRes, screenShareFps, screenShareBitrate)
+ *   2. config.json screen_share settings
+ *   3. Hardcoded default: 1080p30 / 5 Mbps
+ */
+function resolveScreenShareEncoding(): VideoPreset {
+  const urlParams = getUrlParams();
+  let res: string | undefined = urlParams.screenShareRes;
+  let fps: number | undefined = urlParams.screenShareFps;
+  let bitrate: number | undefined = urlParams.screenShareBitrate;
+
+  // Fall back to config.json
+  try {
+    const cfg = Config.get().screen_share;
+    if (cfg) {
+      if (!res) res = cfg.max_resolution;
+      if (fps === undefined) fps = cfg.max_framerate;
+      if (bitrate === undefined) bitrate = cfg.max_bitrate;
+    }
+  } catch {
+    // Config not yet initialized — use defaults
+  }
+
+  // Apply defaults
+  const resKey = res ?? "1440p";
+  const dims = resolutionMap[resKey] ?? resolutionMap["1440p"];
+  const finalFps = fps ?? 60;
+  const finalBitrate = bitrate ?? defaultBitrateForRes[resKey] ?? 13_000_000;
+
+  return new VideoPreset(dims.width, dims.height, finalBitrate, finalFps, "medium");
+}
+
+/**
+ * Build LiveKit RoomOptions with dynamically resolved screen share encoding.
+ * Must be called (not imported as a const) so config/URL params are read at
+ * call time rather than module load time.
+ */
+/**
+ * Return screen share capture options (resolution + frameRate) for use
+ * in setScreenShareEnabled(). livekit-client has no room-level
+ * screenShareCaptureDefaults, so this must be passed explicitly.
+ */
+export function getScreenShareCaptureDefaults(): {
+  resolution: { width: number; height: number; frameRate: number };
+} {
+  const preset = resolveScreenShareEncoding();
+  // Use generous width so ultrawide displays aren't downscaled during capture.
+  const captureWidth = Math.max(preset.width, 3840);
+  return {
+    resolution: {
+      width: captureWidth,
+      height: preset.height,
+      frameRate: preset.encoding.maxFramerate ?? 30,
+    },
+  };
+}
+
+/**
+ * Build LiveKit RoomOptions with dynamically resolved screen share encoding.
+ * Must be called (not imported as a const) so config/URL params are read at
+ * call time rather than module load time.
+ */
+export function getDefaultLiveKitOptions(): RoomOptions {
+  const screenSharePreset = resolveScreenShareEncoding();
+
+  return {
+    // automatically manage subscribed video quality
+    adaptiveStream: true,
+
+    // optimize publishing bandwidth and CPU for published tracks
+    dynacast: true,
+
+    // capture settings
+    videoCaptureDefaults: {
+      resolution: VideoPresets.h720.resolution,
+    },
+
+    // publish settings
+    publishDefaults: {
+      ...defaultLiveKitPublishOptions,
+      screenShareEncoding: screenSharePreset.encoding,
+    },
+
+    // default LiveKit options that seem to be sane
+    stopLocalTrackOnUnpublish: true,
+    reconnectPolicy: new DefaultReconnectPolicy(),
+    disconnectOnPageLeave: true,
+    webAudioMix: false,
+  };
+}

--- a/src/state/CallViewModel/localMember/LocalMember.ts
+++ b/src/state/CallViewModel/localMember/LocalMember.ts
@@ -62,6 +62,7 @@ import {
 } from "../remoteMembers/Connection.ts";
 import { type HomeserverConnected } from "./HomeserverConnected.ts";
 import { and$ } from "../../../utils/observable.ts";
+import { getScreenShareCaptureDefaults } from "../../../livekit/options.ts";
 
 export enum TransportState {
   /** Not even a transport is available to the LocalMembership */
@@ -638,6 +639,7 @@ export const createLocalMembership$ = ({
   ) {
     toggleScreenSharing = (): void => {
       const screenshareSettings: ScreenShareCaptureOptions = {
+        ...getScreenShareCaptureDefaults(),
         audio: true,
         selfBrowserSurface: "include",
         surfaceSwitching: "include",

--- a/src/state/CallViewModel/remoteMembers/ConnectionFactory.ts
+++ b/src/state/CallViewModel/remoteMembers/ConnectionFactory.ts
@@ -27,7 +27,7 @@ import type {
 import type { MediaDevices } from "../../MediaDevices.ts";
 import type { Behavior } from "../../Behavior.ts";
 import type { ProcessorState } from "../../../livekit/TrackProcessorContext.tsx";
-import { defaultLiveKitOptions } from "../../../livekit/options.ts";
+import { getDefaultLiveKitOptions } from "../../../livekit/options.ts";
 
 // TODO evaluate if this should be done like the Publisher Factory
 export interface ConnectionFactory {
@@ -138,15 +138,17 @@ function generateRoomOption({
   echoCancellation: boolean;
   noiseSuppression: boolean;
 }): RoomOptions {
+  const lkOptions = getDefaultLiveKitOptions();
+
   return {
-    ...defaultLiveKitOptions,
+    ...lkOptions,
     videoCaptureDefaults: {
-      ...defaultLiveKitOptions.videoCaptureDefaults,
+      ...lkOptions.videoCaptureDefaults,
       deviceId: devices.videoInput.selected$.value?.id,
       processor: processorState.processor,
     },
     audioCaptureDefaults: {
-      ...defaultLiveKitOptions.audioCaptureDefaults,
+      ...lkOptions.audioCaptureDefaults,
       deviceId: devices.audioInput.selected$.value?.id,
       echoCancellation,
       noiseSuppression,


### PR DESCRIPTION
Add runtime-configurable screen share encoding with three layers of priority: URL params > config.json > hardcoded defaults (1440p/60fps/13Mbps).

Changes:
- ConfigOptions.ts: add screen_share config interface
- UrlParams.ts: add screenShareRes/Fps/Bitrate URL params
- options.ts: rewrite with resolveScreenShareEncoding(), export getDefaultLiveKitOptions() and getScreenShareCaptureDefaults()
- ConnectionFactory.ts: use function call instead of const import
- LocalMember.ts: pass capture resolution to setScreenShareEnabled()