### PR TITLE
Implement new Pip Layout (with control buttons)

### DIFF
--- a/playwright/widget/pip-call-button-interaction.test.ts
+++ b/playwright/widget/pip-call-button-interaction.test.ts
@@ -19,7 +19,7 @@ widgetTest("Footer interaction in PiP", async ({ addUser, browserName }) => {
   test.slow();
 
   const valere = await addUser("Valere", HOST1);
-  await valere.page.pause();
+
   const callRoom = "CallRoom";
   await TestHelpers.createRoom("CallRoom", valere.page);
 
@@ -48,20 +48,33 @@ widgetTest("Footer interaction in PiP", async ({ addUser, browserName }) => {
   {
     // Check for a bug where the video had the wrong fit in PIP
     const hangupButton = iFrame.getByRole("button", { name: "End call" });
-    const videoMuteButton = iFrame.getByRole("button", {
-      name: "Stop video",
-    });
-    const audioMuteButton = iFrame.getByRole("button", {
-      name: "Mute microphone",
-    });
+    const audioMuteButton = iFrame.getByTestId("incall_mute");
+    const videoMuteButton = iFrame.getByTestId("incall_videomute");
     await expect(hangupButton).toBeVisible();
-    await expect(videoMuteButton).toBeVisible();
     await expect(audioMuteButton).toBeVisible();
-
+    await expect(videoMuteButton).toBeVisible();
+    await expect(audioMuteButton).toHaveCSS(
+      "background-color",
+      "rgb(255, 255, 255)",
+    );
+    await expect(videoMuteButton).toHaveCSS(
+      "background-color",
+      "rgb(255, 255, 255)",
+    );
     await videoMuteButton.click();
     await audioMuteButton.click();
+    // stop hovering on any of the buttons
+    await iFrame.getByTestId("videoTile").hover();
+    await valere.page.pause();
 
-    await expect(videoMuteButton).toHaveCSS("disabled", "true");
-    await expect(audioMuteButton).toHaveCSS("disabled", "true");
+    await expect(audioMuteButton).toHaveCSS(
+      "background-color",
+      "rgb(27, 29, 34)",
+    );
+
+    await expect(videoMuteButton).toHaveCSS(
+      "background-color",
+      "rgb(27, 29, 34)",
+    );
   }
 });

--- a/playwright/widget/pip-call-button-interaction.test.ts
+++ b/playwright/widget/pip-call-button-interaction.test.ts
@@ -1,0 +1,71 @@
+/*
+Copyright 2026 Element Creations Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE in the repository root for full details.
+*/
+
+import { expect, test } from "@playwright/test";
+
+import { widgetTest } from "../fixtures/widget-user.ts";
+import { HOST1, TestHelpers } from "./test-helpers.ts";
+
+widgetTest(
+  "Footer interaction in PiP",
+  async ({ addUser, browserName, page }) => {
+    test.skip(
+      browserName === "firefox",
+      "The is test is not working on firefox CI environment. No mic/audio device inputs so cam/mic are disabled",
+    );
+
+    test.slow();
+
+    const valere = await addUser("Valere", HOST1);
+
+    const callRoom = "CallRoom";
+    await TestHelpers.createRoom("CallRoom", valere.page);
+
+    await TestHelpers.createRoom("OtherRoom", valere.page);
+
+    await TestHelpers.switchToRoomNamed(valere.page, callRoom);
+
+    // Start the call as Valere
+    await TestHelpers.startCallInCurrentRoom(valere.page, false);
+    await expect(
+      valere.page.locator('iframe[title="Element Call"]'),
+    ).toBeVisible();
+
+    await TestHelpers.joinCallFromLobby(valere.page);
+    // wait a bit so that the PIP has rendered
+    await valere.page.waitForTimeout(600);
+
+    // Switch to the other room, the call should go to PIP
+    await TestHelpers.switchToRoomNamed(valere.page, "OtherRoom");
+
+    // We should see the PIP overlay
+    const iFrame = valere.page
+      .locator('iframe[title="Element Call"]')
+      .contentFrame();
+
+    {
+      // Check for a bug where the video had the wrong fit in PIP
+      const hangupButton = iFrame.getByRole("button", { name: "End call" });
+      const videoMuteButton = iFrame.getByRole("button", {
+        name: "Stop video",
+      });
+      const audioMuteButton = iFrame.getByRole("button", {
+        name: "Mute microphone",
+      });
+      await expect(hangupButton).toBeVisible();
+      await expect(videoMuteButton).toBeVisible();
+      await expect(audioMuteButton).toBeVisible();
+
+      // TODO once we have the EW version that supports the interactive pip element we can activate those checks
+      // await videoMuteButton.click();
+      // await audioMuteButton.click();
+
+      // await expect(videoMuteButton).toHaveCSS("disabled", "true");
+      // await expect(audioMuteButton).toHaveCSS("disabled", "true");
+    }
+  },
+);

--- a/playwright/widget/pip-call-button-interaction.test.ts
+++ b/playwright/widget/pip-call-button-interaction.test.ts
@@ -10,62 +10,59 @@ import { expect, test } from "@playwright/test";
 import { widgetTest } from "../fixtures/widget-user.ts";
 import { HOST1, TestHelpers } from "./test-helpers.ts";
 
-widgetTest(
-  "Footer interaction in PiP",
-  async ({ addUser, browserName, page }) => {
-    test.skip(
-      browserName === "firefox",
-      "The is test is not working on firefox CI environment. No mic/audio device inputs so cam/mic are disabled",
-    );
+widgetTest("Footer interaction in PiP", async ({ addUser, browserName }) => {
+  test.skip(
+    browserName === "firefox",
+    "The is test is not working on firefox CI environment. No mic/audio device inputs so cam/mic are disabled",
+  );
 
-    test.slow();
+  test.slow();
 
-    const valere = await addUser("Valere", HOST1);
+  const valere = await addUser("Valere", HOST1);
+  await valere.page.pause();
+  const callRoom = "CallRoom";
+  await TestHelpers.createRoom("CallRoom", valere.page);
 
-    const callRoom = "CallRoom";
-    await TestHelpers.createRoom("CallRoom", valere.page);
+  await TestHelpers.createRoom("OtherRoom", valere.page);
 
-    await TestHelpers.createRoom("OtherRoom", valere.page);
+  await TestHelpers.switchToRoomNamed(valere.page, callRoom);
 
-    await TestHelpers.switchToRoomNamed(valere.page, callRoom);
+  // Start the call as Valere
+  await TestHelpers.startCallInCurrentRoom(valere.page, false);
+  await expect(
+    valere.page.locator('iframe[title="Element Call"]'),
+  ).toBeVisible();
 
-    // Start the call as Valere
-    await TestHelpers.startCallInCurrentRoom(valere.page, false);
-    await expect(
-      valere.page.locator('iframe[title="Element Call"]'),
-    ).toBeVisible();
+  await TestHelpers.joinCallFromLobby(valere.page);
+  // wait a bit so that the PIP has rendered
+  await valere.page.waitForTimeout(600);
 
-    await TestHelpers.joinCallFromLobby(valere.page);
-    // wait a bit so that the PIP has rendered
-    await valere.page.waitForTimeout(600);
+  // Switch to the other room, the call should go to PIP
+  await TestHelpers.switchToRoomNamed(valere.page, "OtherRoom");
 
-    // Switch to the other room, the call should go to PIP
-    await TestHelpers.switchToRoomNamed(valere.page, "OtherRoom");
+  // We should see the PIP overlay
+  const iFrame = valere.page
+    .locator('iframe[title="Element Call"]')
+    .contentFrame();
 
-    // We should see the PIP overlay
-    const iFrame = valere.page
-      .locator('iframe[title="Element Call"]')
-      .contentFrame();
+  {
+    // Check for a bug where the video had the wrong fit in PIP
+    const hangupButton = iFrame.getByRole("button", { name: "End call" });
+    const videoMuteButton = iFrame.getByRole("button", {
+      name: "Stop video",
+    });
+    const audioMuteButton = iFrame.getByRole("button", {
+      name: "Mute microphone",
+    });
+    await expect(hangupButton).toBeVisible();
+    await expect(videoMuteButton).toBeVisible();
+    await expect(audioMuteButton).toBeVisible();
 
-    {
-      // Check for a bug where the video had the wrong fit in PIP
-      const hangupButton = iFrame.getByRole("button", { name: "End call" });
-      const videoMuteButton = iFrame.getByRole("button", {
-        name: "Stop video",
-      });
-      const audioMuteButton = iFrame.getByRole("button", {
-        name: "Mute microphone",
-      });
-      await expect(hangupButton).toBeVisible();
-      await expect(videoMuteButton).toBeVisible();
-      await expect(audioMuteButton).toBeVisible();
+    // TODO once we have the EW version that supports the interactive pip element we can activate those checks
+    // await videoMuteButton.click();
+    // await audioMuteButton.click();
 
-      // TODO once we have the EW version that supports the interactive pip element we can activate those checks
-      // await videoMuteButton.click();
-      // await audioMuteButton.click();
-
-      // await expect(videoMuteButton).toHaveCSS("disabled", "true");
-      // await expect(audioMuteButton).toHaveCSS("disabled", "true");
-    }
-  },
-);
+    // await expect(videoMuteButton).toHaveCSS("disabled", "true");
+    // await expect(audioMuteButton).toHaveCSS("disabled", "true");
+  }
+});

--- a/playwright/widget/pip-call-button-interaction.test.ts
+++ b/playwright/widget/pip-call-button-interaction.test.ts
@@ -47,34 +47,22 @@ widgetTest("Footer interaction in PiP", async ({ addUser, browserName }) => {
 
   {
     // Check for a bug where the video had the wrong fit in PIP
-    const hangupButton = iFrame.getByRole("button", { name: "End call" });
-    const audioMuteButton = iFrame.getByTestId("incall_mute");
-    const videoMuteButton = iFrame.getByTestId("incall_videomute");
-    await expect(hangupButton).toBeVisible();
-    await expect(audioMuteButton).toBeVisible();
-    await expect(videoMuteButton).toBeVisible();
-    await expect(audioMuteButton).toHaveCSS(
-      "background-color",
-      "rgb(255, 255, 255)",
-    );
-    await expect(videoMuteButton).toHaveCSS(
-      "background-color",
-      "rgb(255, 255, 255)",
-    );
-    await videoMuteButton.click();
-    await audioMuteButton.click();
+    const hangupBtn = iFrame.getByRole("button", { name: "End call" });
+    const audioBtn = iFrame.getByTestId("incall_mute");
+    const videoBtn = iFrame.getByTestId("incall_videomute");
+    await expect(hangupBtn).toBeVisible();
+    await expect(audioBtn).toBeVisible();
+    await expect(videoBtn).toBeVisible();
+    await expect(audioBtn).toHaveAttribute("aria-label", /^Mute microphone$/);
+    await expect(videoBtn).toHaveAttribute("aria-label", /^Stop video$/);
+
+    await videoBtn.click();
+    await audioBtn.click();
+
     // stop hovering on any of the buttons
     await iFrame.getByTestId("videoTile").hover();
-    await valere.page.pause();
 
-    await expect(audioMuteButton).toHaveCSS(
-      "background-color",
-      "rgb(27, 29, 34)",
-    );
-
-    await expect(videoMuteButton).toHaveCSS(
-      "background-color",
-      "rgb(27, 29, 34)",
-    );
+    await expect(audioBtn).toHaveAttribute("aria-label", /^Unmute microphone$/);
+    await expect(videoBtn).toHaveAttribute("aria-label", /^Start video$/);
   }
 });

--- a/playwright/widget/pip-call-button-interaction.test.ts
+++ b/playwright/widget/pip-call-button-interaction.test.ts
@@ -58,11 +58,10 @@ widgetTest("Footer interaction in PiP", async ({ addUser, browserName }) => {
     await expect(videoMuteButton).toBeVisible();
     await expect(audioMuteButton).toBeVisible();
 
-    // TODO once we have the EW version that supports the interactive pip element we can activate those checks
-    // await videoMuteButton.click();
-    // await audioMuteButton.click();
+    await videoMuteButton.click();
+    await audioMuteButton.click();
 
-    // await expect(videoMuteButton).toHaveCSS("disabled", "true");
-    // await expect(audioMuteButton).toHaveCSS("disabled", "true");
+    await expect(videoMuteButton).toHaveCSS("disabled", "true");
+    await expect(audioMuteButton).toHaveCSS("disabled", "true");
   }
 });

--- a/playwright/widget/pip-call.test.ts
+++ b/playwright/widget/pip-call.test.ts
@@ -55,7 +55,7 @@ widgetTest("Put call in PIP", async ({ addUser, browserName }) => {
   await TestHelpers.switchToRoomNamed(valere.page, "DoubleTask");
 
   // We should see the PIP overlay
-  await expect(valere.page.locator(".mx_WidgetPip_overlay")).toBeVisible();
+  await expect(valere.page.getByTestId("widget-pip-container")).toBeVisible();
 
   {
     // wait a bit so that the PIP has rendered the video

--- a/src/button/Button.tsx
+++ b/src/button/Button.tsx
@@ -23,6 +23,7 @@ import styles from "./Button.module.css";
 
 interface MicButtonProps extends ComponentPropsWithoutRef<"button"> {
   muted: boolean;
+  size: "sm" | "lg";
 }
 
 export const MicButton: FC<MicButtonProps> = ({ muted, ...props }) => {
@@ -47,6 +48,7 @@ export const MicButton: FC<MicButtonProps> = ({ muted, ...props }) => {
 
 interface VideoButtonProps extends ComponentPropsWithoutRef<"button"> {
   muted: boolean;
+  size: "sm" | "lg";
 }
 
 export const VideoButton: FC<VideoButtonProps> = ({ muted, ...props }) => {
@@ -71,6 +73,7 @@ export const VideoButton: FC<VideoButtonProps> = ({ muted, ...props }) => {
 
 interface ShareScreenButtonProps extends ComponentPropsWithoutRef<"button"> {
   enabled: boolean;
+  size: "sm" | "lg";
 }
 
 export const ShareScreenButton: FC<ShareScreenButtonProps> = ({
@@ -94,7 +97,11 @@ export const ShareScreenButton: FC<ShareScreenButtonProps> = ({
   );
 };
 
-export const EndCallButton: FC<ComponentPropsWithoutRef<"button">> = ({
+interface EndCallButtonProps extends ComponentPropsWithoutRef<"button"> {
+  size: "sm" | "lg";
+}
+
+export const EndCallButton: FC<EndCallButtonProps> = ({
   className,
   ...props
 }) => {

--- a/src/button/Button.tsx
+++ b/src/button/Button.tsx
@@ -23,7 +23,7 @@ import styles from "./Button.module.css";
 
 interface MicButtonProps extends ComponentPropsWithoutRef<"button"> {
   muted: boolean;
-  size: "sm" | "lg";
+  size?: "sm" | "lg";
 }
 
 export const MicButton: FC<MicButtonProps> = ({ muted, ...props }) => {
@@ -48,7 +48,7 @@ export const MicButton: FC<MicButtonProps> = ({ muted, ...props }) => {
 
 interface VideoButtonProps extends ComponentPropsWithoutRef<"button"> {
   muted: boolean;
-  size: "sm" | "lg";
+  size?: "sm" | "lg";
 }
 
 export const VideoButton: FC<VideoButtonProps> = ({ muted, ...props }) => {
@@ -98,7 +98,7 @@ export const ShareScreenButton: FC<ShareScreenButtonProps> = ({
 };
 
 interface EndCallButtonProps extends ComponentPropsWithoutRef<"button"> {
-  size: "sm" | "lg";
+  size?: "sm" | "lg";
 }
 
 export const EndCallButton: FC<EndCallButtonProps> = ({
@@ -122,7 +122,7 @@ export const EndCallButton: FC<EndCallButtonProps> = ({
 };
 
 interface SettingsButtonProps extends ComponentPropsWithoutRef<"button"> {
-  size: "sm" | "lg";
+  size?: "sm" | "lg";
 }
 export const SettingsButton: FC<SettingsButtonProps> = (props) => {
   const { t } = useTranslation();

--- a/src/button/Button.tsx
+++ b/src/button/Button.tsx
@@ -121,9 +121,10 @@ export const EndCallButton: FC<EndCallButtonProps> = ({
   );
 };
 
-export const SettingsButton: FC<ComponentPropsWithoutRef<"button">> = (
-  props,
-) => {
+interface SettingsButtonProps extends ComponentPropsWithoutRef<"button"> {
+  size: "sm" | "lg";
+}
+export const SettingsButton: FC<SettingsButtonProps> = (props) => {
   const { t } = useTranslation();
 
   return (

--- a/src/button/ReactionToggleButton.tsx
+++ b/src/button/ReactionToggleButton.tsx
@@ -166,6 +166,7 @@ export function ReactionPopupMenu({
 interface ReactionToggleButtonProps extends ComponentPropsWithoutRef<"button"> {
   identifier: string;
   vm: CallViewModel;
+  size: "sm" | "lg";
 }
 
 export function ReactionToggleButton({

--- a/src/button/ReactionToggleButton.tsx
+++ b/src/button/ReactionToggleButton.tsx
@@ -166,7 +166,7 @@ export function ReactionPopupMenu({
 interface ReactionToggleButtonProps extends ComponentPropsWithoutRef<"button"> {
   identifier: string;
   vm: CallViewModel;
-  size: "sm" | "lg";
+  size?: "sm" | "lg";
 }
 
 export function ReactionToggleButton({

--- a/src/room/InCallView.module.css
+++ b/src/room/InCallView.module.css
@@ -108,22 +108,9 @@ Please see LICENSE in the repository root for full details.
   }
 }
 
-@media (max-width: 370px) {
-  .shareScreen {
-    display: none;
-  }
-
-  @media (max-height: 400px) {
-    .footer {
-      display: none;
-    }
-  }
-}
-
-@media (max-width: 320px) {
-  .invite,
-  .raiseHand {
-    display: none;
+@media (max-height: 800px) {
+  .footer {
+    padding-block: var(--cpd-space-8x);
   }
 }
 
@@ -133,9 +120,27 @@ Please see LICENSE in the repository root for full details.
   }
 }
 
-@media (max-height: 800px) {
-  .footer {
-    padding-block: var(--cpd-space-8x);
+@media (max-width: 370px) {
+  .shareScreen {
+    display: none;
+  }
+
+  /* PIP custom css */
+  @media (max-height: 400px) {
+    .shareScreen {
+      display: flex;
+    }
+    .footer {
+      padding-block-start: var(--cpd-space-3x);
+      padding-block-end: var(--cpd-space-2x);
+    }
+  }
+}
+
+@media (max-width: 320px) {
+  .invite,
+  .raiseHand {
+    display: none;
   }
 }
 

--- a/src/room/InCallView.tsx
+++ b/src/room/InCallView.tsx
@@ -640,8 +640,10 @@ export const InCallView: FC<InCallViewProps> = ({
 
   const buttons: JSX.Element[] = [];
 
+  const buttonSize = layout.type === "pip" ? "sm" : "lg";
   buttons.push(
     <MicButton
+      size={buttonSize}
       key="audio"
       muted={!audioEnabled}
       onClick={toggleAudio ?? undefined}
@@ -649,6 +651,7 @@ export const InCallView: FC<InCallViewProps> = ({
       data-testid="incall_mute"
     />,
     <VideoButton
+      size={buttonSize}
       key="video"
       muted={!videoEnabled}
       onClick={toggleVideo ?? undefined}
@@ -659,6 +662,7 @@ export const InCallView: FC<InCallViewProps> = ({
   if (vm.toggleScreenSharing !== null) {
     buttons.push(
       <ShareScreenButton
+        size={buttonSize}
         key="share_screen"
         className={styles.shareScreen}
         enabled={sharingScreen}
@@ -670,6 +674,7 @@ export const InCallView: FC<InCallViewProps> = ({
   if (supportsReactions) {
     buttons.push(
       <ReactionToggleButton
+        size={buttonSize}
         vm={vm}
         key="raise_hand"
         className={styles.raiseHand}
@@ -678,10 +683,17 @@ export const InCallView: FC<InCallViewProps> = ({
     );
   }
   if (layout.type !== "pip")
-    buttons.push(<SettingsButton key="settings" onClick={openSettings} />);
+    buttons.push(
+      <SettingsButton
+        size={buttonSize}
+        key="settings"
+        onClick={openSettings}
+      />,
+    );
 
   buttons.push(
     <EndCallButton
+      size={buttonSize}
       key="end_call"
       onClick={function (): void {
         vm.hangup();

--- a/src/state/CallViewModel/CallViewModel.ts
+++ b/src/state/CallViewModel/CallViewModel.ts
@@ -63,7 +63,7 @@ import {
   playReactionsSound,
   showReactions,
 } from "../../settings/settings";
-import { isFirefox } from "../../Platform";
+import { isFirefox, platform } from "../../Platform";
 import { setPipEnabled$ } from "../../controls";
 import { TileStore } from "../TileStore";
 import { gridLikeLayout } from "../GridLikeLayout";
@@ -1271,7 +1271,7 @@ export function createCallViewModel$(
       switchMap((mode) => {
         switch (mode) {
           case "pip":
-            return of(true);
+            return of(platform === "desktop" ? true : false);
           case "normal":
           case "narrow":
             return of(true);

--- a/src/state/CallViewModel/CallViewModel.ts
+++ b/src/state/CallViewModel/CallViewModel.ts
@@ -1271,7 +1271,7 @@ export function createCallViewModel$(
       switchMap((mode) => {
         switch (mode) {
           case "pip":
-            return of(false);
+            return of(true);
           case "normal":
           case "narrow":
             return of(true);

--- a/src/state/PipLayout.ts
+++ b/src/state/PipLayout.ts
@@ -16,7 +16,8 @@ export function pipLayout(
   prevTiles: TileStore,
 ): [PipLayout, TileStore] {
   const update = prevTiles.from(0);
-  update.registerSpotlight(media.spotlight, true);
+  // Dont maximise in pip since we want the rounded corners and the footer
+  update.registerSpotlight(media.spotlight, false);
   const tiles = update.build();
   return [
     {

--- a/src/state/PipLayout.ts
+++ b/src/state/PipLayout.ts
@@ -5,6 +5,7 @@ SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
 Please see LICENSE in the repository root for full details.
 */
 
+import { platform } from "../Platform.ts";
 import { type PipLayout, type PipLayoutMedia } from "./layout-types.ts";
 import { type TileStore } from "./TileStore";
 
@@ -16,8 +17,11 @@ export function pipLayout(
   prevTiles: TileStore,
 ): [PipLayout, TileStore] {
   const update = prevTiles.from(0);
-  // Dont maximise in pip since we want the rounded corners and the footer
-  update.registerSpotlight(media.spotlight, false);
+  // Dont maximise in pip on EW since we want the rounded corners and the footer
+  update.registerSpotlight(
+    media.spotlight,
+    platform === "desktop" ? false : true,
+  );
   const tiles = update.build();
   return [
     {


### PR DESCRIPTION
Fixes: https://github.com/element-hq/voip-internal/issues/488
Also fixes: https://github.com/element-hq/element-call/issues/3620

_copied upcoming PR Template_

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Content

Update the desktop pip call layout:
 - dont hide footer
 - dont use fullscreen video tiles
 - adjust css to match margins and layout.
 
 This allows us to achive the UX described here: https://github.com/element-hq/voip-internal/issues/488

## Motivation and context

We want to update the UX for pip:
 - allow mute unmute
 - use webview hangup button
 - show mute state while in pip
 - simplify pip by removing custom overlay buttons and actions to hangup

## Screenshots / GIFs


|Before|After|
|-|-|
|<img width="338" height="238" alt="Screenshot 2026-03-10 at 11 12 00" src="https://github.com/user-attachments/assets/f6ab26be-177c-48ff-b51e-74dfaa1b5168" />|<img width="338" height="238" alt="Screenshot 2026-03-10 at 11 14 27" src="https://github.com/user-attachments/assets/9759e661-bb0a-48d7-83b9-949f7da9d4b3" /> <img width="338" height="238" alt="Screenshot 2026-03-10 at 11 15 46" src="https://github.com/user-attachments/assets/0b94a66c-20b5-4c58-8234-a9c001bf6e8d" />|

(_The bottom after image is on hover_)
Be aware that this is WIHTOUT the associated EW changes!
-> This just proves that things are not completely broken in case we fail on shipping them simultaneously.

**With EW patches:**

|Before|After|
|-|-|
|<img width="347" height="318" alt="Screenshot 2026-03-10 at 11 23 50" src="https://github.com/user-attachments/assets/2c6464a6-e8e2-4a3d-8f70-0557ce5e3238" />|<img width="347" height="318" alt="Screenshot 2026-03-10 at 11 22 29" src="https://github.com/user-attachments/assets/80b17df5-7a55-4797-a857-85384cf0c19b" /><img width="347" height="318" alt="Screenshot 2026-03-10 at 11 22 34" src="https://github.com/user-attachments/assets/489e294b-4f27-4095-9861-7d318b9c8bae" />|

Proving that things are not broken in case we fail on shipping them simultaneously.

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...
-

## Checklist

- [x] I have read through [CONTRIBUTING.md](https://github.com/element-hq/element-call/blob/livekit/CONTRIBUTING.md).
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Tests written for new code (and old code if feasible).
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-call)




 - [x] test on mobile (dont regress mobile pip)