### PR TITLE
Download avatars using the MC4039 Widget API

### DIFF
--- a/src/Avatar.test.tsx
+++ b/src/Avatar.test.tsx
@@ -14,7 +14,13 @@ import { ClientContextProvider } from "./ClientContext";
 import { Avatar } from "./Avatar";
 import { mockMatrixRoomMember, mockRtcMembership } from "./utils/test";
 import { widget } from "./widget";
-import { WidgetApi } from "matrix-widget-api";
+import { type FC, type PropsWithChildren } from "react";
+import { type WidgetApi } from "matrix-widget-api";
+
+import { ClientContextProvider } from "./ClientContext";
+import { Avatar } from "./Avatar";
+import { mockMatrixRoomMember, mockRtcMembership } from "./utils/test";
+import { widget } from "./widget";
 
 const TestComponent: FC<
   PropsWithChildren<{

--- a/src/Avatar.test.tsx
+++ b/src/Avatar.test.tsx
@@ -17,8 +17,15 @@ import EventEmitter from "events";
 import { widget } from "./widget";
 
 const TestComponent: FC<
-  PropsWithChildren<{ client: MatrixClient; supportsThumbnails?: boolean }>
-> = ({ client, children, supportsThumbnails }) => {
+  PropsWithChildren<{
+    client: MatrixClient;
+    supportsAuthenticatedMedia?: boolean;
+  }>
+> = ({
+  client,
+  children,
+  supportsAuthenticatedMedia: supportsAuthenticatedMedia,
+}) => {
   return (
     <ClientContextProvider
       value={{
@@ -26,7 +33,7 @@ const TestComponent: FC<
         disconnected: false,
         supportedFeatures: {
           reactions: true,
-          thumbnails: supportsThumbnails ?? true,
+          authenticatedMedia: supportsAuthenticatedMedia ?? true,
         },
         setClient: vi.fn(),
         authenticated: {
@@ -81,36 +88,7 @@ test("should just render a placeholder when the user has no avatar", () => {
   expect(client.mxcUrlToHttp).toBeCalledTimes(0);
 });
 
-test("should just render a placeholder when thumbnails are not supported", () => {
-  const client = vi.mocked<MatrixClient>({
-    getAccessToken: () => "my-access-token",
-    mxcUrlToHttp: () => vi.fn(),
-  } as unknown as MatrixClient);
-
-  vi.spyOn(client, "mxcUrlToHttp");
-  const member = mockMatrixRoomMember(
-    mockRtcMembership("@alice:example.org", "AAAA"),
-    {
-      getMxcAvatarUrl: () => "mxc://example.org/alice-avatar",
-    },
-  );
-  const displayName = "Alice";
-  render(
-    <TestComponent client={client} supportsThumbnails={false}>
-      <Avatar
-        id={member.userId}
-        name={displayName}
-        size={96}
-        src={member.getMxcAvatarUrl()}
-      />
-    </TestComponent>,
-  );
-  const element = screen.getByRole("img", { name: "@alice:example.org" });
-  expect(element.tagName).toEqual("SPAN");
-  expect(client.mxcUrlToHttp).toBeCalledTimes(0);
-});
-
-test("should attempt to fetch authenticated media", async () => {
+test("should attempt to fetch authenticated media if supported", async () => {
   const expectedAuthUrl = "http://example.org/media/alice-avatar";
   const expectedObjectURL = "my-object-url";
   const accessToken = "my-access-token";
@@ -142,7 +120,7 @@ test("should attempt to fetch authenticated media", async () => {
   );
   const displayName = "Alice";
   render(
-    <TestComponent client={client}>
+    <TestComponent client={client} supportsAuthenticatedMedia={true}>
       <Avatar
         id={member.userId}
         name={displayName}
@@ -163,7 +141,7 @@ test("should attempt to fetch authenticated media", async () => {
   });
 });
 
-test("should use widget API when unable to authenticate media", async () => {
+test("should attempt to use widget API if authenticate media is not supported", async () => {
   const expectedMXCUrl = "mxc://example.org/alice-avatar";
   const expectedObjectURL = "my-object-url";
   const theBlob = new Blob([]);
@@ -188,7 +166,7 @@ test("should use widget API when unable to authenticate media", async () => {
   );
   const displayName = "Alice";
   render(
-    <TestComponent client={client}>
+    <TestComponent client={client} supportsAuthenticatedMedia={false}>
       <Avatar
         id={member.userId}
         name={displayName}

--- a/src/Avatar.test.tsx
+++ b/src/Avatar.test.tsx
@@ -13,6 +13,8 @@ import { type FC, type PropsWithChildren } from "react";
 import { ClientContextProvider } from "./ClientContext";
 import { Avatar } from "./Avatar";
 import { mockMatrixRoomMember, mockRtcMembership } from "./utils/test";
+import EventEmitter from "events";
+import { widget } from "./widget";
 
 const TestComponent: FC<
   PropsWithChildren<{ client: MatrixClient; supportsThumbnails?: boolean }>
@@ -39,6 +41,12 @@ const TestComponent: FC<
     </ClientContextProvider>
   );
 };
+
+vi.mock("./widget", () => ({
+  widget: {
+    api: { downloadFile: vi.fn() },
+  },
+}));
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -153,4 +161,47 @@ test("should attempt to fetch authenticated media", async () => {
   expect(globalThis.fetch).toBeCalledWith(expectedAuthUrl, {
     headers: { Authorization: `Bearer ${accessToken}` },
   });
+});
+
+test("should use widget API when unable to authenticate media", async () => {
+  const expectedMXCUrl = "mxc://example.org/alice-avatar";
+  const expectedObjectURL = "my-object-url";
+  const theBlob = new Blob([]);
+
+  // vitest doesn't have a implementation of create/revokeObjectURL, so we need
+  // to delete the property. It's a bit odd, but it works.
+  Reflect.deleteProperty(global.window.URL, "createObjectURL");
+  globalThis.URL.createObjectURL = vi.fn().mockReturnValue(expectedObjectURL);
+  Reflect.deleteProperty(global.window.URL, "revokeObjectURL");
+  globalThis.URL.revokeObjectURL = vi.fn();
+
+  const client = vi.mocked<MatrixClient>({
+    getAccessToken: () => undefined,
+  } as unknown as MatrixClient);
+
+  vi.spyOn(widget!.api, "downloadFile").mockResolvedValue({ file: theBlob });
+  const member = mockMatrixRoomMember(
+    mockRtcMembership("@alice:example.org", "AAAA"),
+    {
+      getMxcAvatarUrl: () => expectedMXCUrl,
+    },
+  );
+  const displayName = "Alice";
+  render(
+    <TestComponent client={client}>
+      <Avatar
+        id={member.userId}
+        name={displayName}
+        size={96}
+        src={member.getMxcAvatarUrl()}
+      />
+    </TestComponent>,
+  );
+
+  // Fetch is asynchronous, so wait for this to resolve.
+  await vi.waitUntil(() =>
+    document.querySelector(`img[src='${expectedObjectURL}']`),
+  );
+
+  expect(widget!.api.downloadFile).toBeCalledWith(expectedMXCUrl);
 });

--- a/src/Avatar.test.tsx
+++ b/src/Avatar.test.tsx
@@ -9,12 +9,6 @@ import { afterEach, expect, test, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { type MatrixClient } from "matrix-js-sdk";
 import { type FC, type PropsWithChildren } from "react";
-
-import { ClientContextProvider } from "./ClientContext";
-import { Avatar } from "./Avatar";
-import { mockMatrixRoomMember, mockRtcMembership } from "./utils/test";
-import { widget } from "./widget";
-import { type FC, type PropsWithChildren } from "react";
 import { type WidgetApi } from "matrix-widget-api";
 
 import { ClientContextProvider } from "./ClientContext";

--- a/src/Avatar.test.tsx
+++ b/src/Avatar.test.tsx
@@ -13,19 +13,14 @@ import { type FC, type PropsWithChildren } from "react";
 import { ClientContextProvider } from "./ClientContext";
 import { Avatar } from "./Avatar";
 import { mockMatrixRoomMember, mockRtcMembership } from "./utils/test";
-import EventEmitter from "events";
 import { widget } from "./widget";
+import { WidgetApi } from "matrix-widget-api";
 
 const TestComponent: FC<
   PropsWithChildren<{
     client: MatrixClient;
-    supportsAuthenticatedMedia?: boolean;
   }>
-> = ({
-  client,
-  children,
-  supportsAuthenticatedMedia: supportsAuthenticatedMedia,
-}) => {
+> = ({ client, children }) => {
   return (
     <ClientContextProvider
       value={{
@@ -33,7 +28,6 @@ const TestComponent: FC<
         disconnected: false,
         supportedFeatures: {
           reactions: true,
-          authenticatedMedia: supportsAuthenticatedMedia ?? true,
         },
         setClient: vi.fn(),
         authenticated: {
@@ -51,7 +45,7 @@ const TestComponent: FC<
 
 vi.mock("./widget", () => ({
   widget: {
-    api: { downloadFile: vi.fn() },
+    api: null, // Ideally we'd only mock this in the as a widget test so the whole module is otherwise null, but just nulling `api` by default works well enough
   },
 }));
 
@@ -88,7 +82,7 @@ test("should just render a placeholder when the user has no avatar", () => {
   expect(client.mxcUrlToHttp).toBeCalledTimes(0);
 });
 
-test("should attempt to fetch authenticated media if supported", async () => {
+test("should attempt to fetch authenticated media from the server", async () => {
   const expectedAuthUrl = "http://example.org/media/alice-avatar";
   const expectedObjectURL = "my-object-url";
   const accessToken = "my-access-token";
@@ -120,7 +114,7 @@ test("should attempt to fetch authenticated media if supported", async () => {
   );
   const displayName = "Alice";
   render(
-    <TestComponent client={client} supportsAuthenticatedMedia={true}>
+    <TestComponent client={client}>
       <Avatar
         id={member.userId}
         name={displayName}
@@ -141,7 +135,7 @@ test("should attempt to fetch authenticated media if supported", async () => {
   });
 });
 
-test("should attempt to use widget API if authenticate media is not supported", async () => {
+test("should attempt to use widget API if running as a widget", async () => {
   const expectedMXCUrl = "mxc://example.org/alice-avatar";
   const expectedObjectURL = "my-object-url";
   const theBlob = new Blob([]);
@@ -157,6 +151,7 @@ test("should attempt to use widget API if authenticate media is not supported", 
     getAccessToken: () => undefined,
   } as unknown as MatrixClient);
 
+  widget!.api = { downloadFile: vi.fn() } as unknown as WidgetApi;
   vi.spyOn(widget!.api, "downloadFile").mockResolvedValue({ file: theBlob });
   const member = mockMatrixRoomMember(
     mockRtcMembership("@alice:example.org", "AAAA"),
@@ -166,7 +161,7 @@ test("should attempt to use widget API if authenticate media is not supported", 
   );
   const displayName = "Alice";
   render(
-    <TestComponent client={client} supportsAuthenticatedMedia={false}>
+    <TestComponent client={client}>
       <Avatar
         id={member.userId}
         name={displayName}

--- a/src/Avatar.tsx
+++ b/src/Avatar.tsx
@@ -15,7 +15,9 @@ import {
 import { Avatar as CompoundAvatar } from "@vector-im/compound-web";
 import { type MatrixClient } from "matrix-js-sdk";
 
-import { useClientState } from "./ClientContext";
+import { ClientState, useClientState } from "./ClientContext";
+import { widget } from "./widget";
+import { WidgetApi } from "matrix-widget-api";
 
 export enum Size {
   XS = "xs",
@@ -86,33 +88,17 @@ export const Avatar: FC<Props> = ({
   const [avatarUrl, setAvatarUrl] = useState<string | undefined>(undefined);
 
   useEffect(() => {
-    if (clientState?.state !== "valid") {
-      return;
-    }
-    const { authenticated, supportedFeatures } = clientState;
-    const client = authenticated?.client;
-
-    if (!client || !src || !sizePx || !supportedFeatures.thumbnails) {
-      return;
-    }
-
-    const token = client.getAccessToken();
-    if (!token) {
-      return;
-    }
-    const resolveSrc = getAvatarUrl(client, src, sizePx);
-    if (!resolveSrc) {
+    if (!src) {
       setAvatarUrl(undefined);
       return;
     }
 
     let objectUrl: string | undefined;
-    fetch(resolveSrc, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-    })
-      .then(async (req) => req.blob())
+
+    getAvatarFromServer(clientState, src, sizePx) // Try to download directly from the mxc://
+      .catch((ex) => {
+        return getAvatarFromWidget(widget?.api, src); // Fallback to trying to use the MSC4039 Widget API
+      })
       .then((blob) => {
         objectUrl = URL.createObjectURL(blob);
         setAvatarUrl(objectUrl);
@@ -140,3 +126,64 @@ export const Avatar: FC<Props> = ({
     />
   );
 };
+
+async function getAvatarFromServer(
+  clientState: ClientState | undefined,
+  src: string,
+  sizePx: number | undefined,
+): Promise<Blob> {
+  if (clientState?.state !== "valid") {
+    throw new Error("Client state must be valid");
+  }
+  if (!sizePx) {
+    throw new Error("size must be supplied");
+  }
+
+  const { authenticated, supportedFeatures } = clientState;
+  const client = authenticated?.client;
+  if (!client) {
+    throw new Error("Client must be supplied");
+  }
+  if (!supportedFeatures.thumbnails) {
+    throw new Error("Thumbnails are not supported");
+  }
+
+  const httpSrc = getAvatarUrl(client, src, sizePx);
+  if (!httpSrc) {
+    throw new Error("Failed to get http avatar URL");
+  }
+
+  const token = client.getAccessToken();
+  if (!token) {
+    throw new Error("Failed to get access token");
+  }
+
+  const request = await fetch(httpSrc, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  const blob = await request.blob();
+
+  return blob;
+}
+
+async function getAvatarFromWidget(
+  api: WidgetApi | undefined,
+  src: string,
+): Promise<Blob> {
+  if (!api) {
+    throw new Error("No widget api given");
+  }
+
+  const response = await api.downloadFile(src);
+  const file = response.file;
+
+  // element-web sends a Blob, and the MSC4039 is considering changing the spec to strictly Blob, so only handling that
+  if (!(file instanceof Blob)) {
+    throw new Error("Downloaded file is not a Blob");
+  }
+
+  return file;
+}

--- a/src/Avatar.tsx
+++ b/src/Avatar.tsx
@@ -110,16 +110,24 @@ export const Avatar: FC<Props> = ({
     }
 
     let objectUrl: string | undefined;
+    let stale = false;
     blob
       .then((blob) => {
+        if (stale) {
+          return;
+        }
         objectUrl = URL.createObjectURL(blob);
         setAvatarUrl(objectUrl);
       })
       .catch((ex) => {
+        if (stale) {
+          return;
+        }
         setAvatarUrl(undefined);
       });
 
     return (): void => {
+      stale = true;
       if (objectUrl) {
         URL.revokeObjectURL(objectUrl);
       }

--- a/src/Avatar.tsx
+++ b/src/Avatar.tsx
@@ -14,10 +14,10 @@ import {
 } from "react";
 import { Avatar as CompoundAvatar } from "@vector-im/compound-web";
 import { type MatrixClient } from "matrix-js-sdk";
+import { type WidgetApi } from "matrix-widget-api";
 
 import { useClientState } from "./ClientContext";
 import { widget } from "./widget";
-import { WidgetApi } from "matrix-widget-api";
 
 export enum Size {
   XS = "xs",

--- a/src/Avatar.tsx
+++ b/src/Avatar.tsx
@@ -87,23 +87,23 @@ export const Avatar: FC<Props> = ({
 
   const [avatarUrl, setAvatarUrl] = useState<string | undefined>(undefined);
 
+  // In theory, a change in `clientState` or `sizePx` could run extra getAvatarFromWidgetAPI calls, but in practice they should be stable long before this code runs.
   useEffect(() => {
-    if (!src || clientState?.state !== "valid") {
+    if (!src) {
       setAvatarUrl(undefined);
       return;
     }
 
-    const { authenticated, supportedFeatures } = clientState;
     let blob: Promise<Blob>;
 
-    if (
-      supportedFeatures.authenticatedMedia &&
-      authenticated?.client &&
+    if (widget?.api) {
+      blob = getAvatarFromWidgetAPI(widget.api, src);
+    } else if (
+      clientState?.state === "valid" &&
+      clientState.authenticated?.client &&
       sizePx
     ) {
-      blob = getAvatarFromServer(authenticated.client, src, sizePx);
-    } else if (widget?.api) {
-      blob = getAvatarFromWidgetAPI(widget.api, src);
+      blob = getAvatarFromServer(clientState.authenticated.client, src, sizePx);
     } else {
       setAvatarUrl(undefined);
       return;

--- a/src/Avatar.tsx
+++ b/src/Avatar.tsx
@@ -15,7 +15,7 @@ import {
 import { Avatar as CompoundAvatar } from "@vector-im/compound-web";
 import { type MatrixClient } from "matrix-js-sdk";
 
-import { ClientState, useClientState } from "./ClientContext";
+import { useClientState } from "./ClientContext";
 import { widget } from "./widget";
 import { WidgetApi } from "matrix-widget-api";
 
@@ -80,7 +80,7 @@ export const Avatar: FC<Props> = ({
   const sizePx = useMemo(
     () =>
       Object.values(Size).includes(size as Size)
-        ? sizes.get(size as Size)
+        ? sizes.get(size as Size)!
         : (size as number),
     [size],
   );
@@ -88,17 +88,29 @@ export const Avatar: FC<Props> = ({
   const [avatarUrl, setAvatarUrl] = useState<string | undefined>(undefined);
 
   useEffect(() => {
-    if (!src) {
+    if (!src || clientState?.state !== "valid") {
+      setAvatarUrl(undefined);
+      return;
+    }
+
+    const { authenticated, supportedFeatures } = clientState;
+    let blob: Promise<Blob>;
+
+    if (
+      supportedFeatures.authenticatedMedia &&
+      authenticated?.client &&
+      sizePx
+    ) {
+      blob = getAvatarFromServer(authenticated.client, src, sizePx);
+    } else if (widget?.api) {
+      blob = getAvatarFromWidgetAPI(widget.api, src);
+    } else {
       setAvatarUrl(undefined);
       return;
     }
 
     let objectUrl: string | undefined;
-
-    getAvatarFromServer(clientState, src, sizePx) // Try to download directly from the mxc://
-      .catch((ex) => {
-        return getAvatarFromWidget(widget?.api, src); // Fallback to trying to use the MSC4039 Widget API
-      })
+    blob
       .then((blob) => {
         objectUrl = URL.createObjectURL(blob);
         setAvatarUrl(objectUrl);
@@ -128,26 +140,10 @@ export const Avatar: FC<Props> = ({
 };
 
 async function getAvatarFromServer(
-  clientState: ClientState | undefined,
+  client: MatrixClient,
   src: string,
-  sizePx: number | undefined,
+  sizePx: number,
 ): Promise<Blob> {
-  if (clientState?.state !== "valid") {
-    throw new Error("Client state must be valid");
-  }
-  if (!sizePx) {
-    throw new Error("size must be supplied");
-  }
-
-  const { authenticated, supportedFeatures } = clientState;
-  const client = authenticated?.client;
-  if (!client) {
-    throw new Error("Client must be supplied");
-  }
-  if (!supportedFeatures.thumbnails) {
-    throw new Error("Thumbnails are not supported");
-  }
-
   const httpSrc = getAvatarUrl(client, src, sizePx);
   if (!httpSrc) {
     throw new Error("Failed to get http avatar URL");
@@ -169,14 +165,10 @@ async function getAvatarFromServer(
   return blob;
 }
 
-async function getAvatarFromWidget(
-  api: WidgetApi | undefined,
+async function getAvatarFromWidgetAPI(
+  api: WidgetApi,
   src: string,
 ): Promise<Blob> {
-  if (!api) {
-    throw new Error("No widget api given");
-  }
-
   const response = await api.downloadFile(src);
   const file = response.file;
 

--- a/src/ClientContext.tsx
+++ b/src/ClientContext.tsx
@@ -48,7 +48,7 @@ export type ValidClientState = {
   disconnected: boolean;
   supportedFeatures: {
     reactions: boolean;
-    thumbnails: boolean;
+    authenticatedMedia: boolean;
   };
   setClient: (client: MatrixClient, session: Session) => void;
 };
@@ -249,7 +249,8 @@ export const ClientProvider: FC<Props> = ({ children }) => {
 
   const [isDisconnected, setIsDisconnected] = useState(false);
   const [supportsReactions, setSupportsReactions] = useState(false);
-  const [supportsThumbnails, setSupportsThumbnails] = useState(false);
+  const [supportsAuthenticatedMedia, setSupportsAuthenticatedMedia] =
+    useState(false);
 
   const state: ClientState | undefined = useMemo(() => {
     if (alreadyOpenedErr) {
@@ -275,7 +276,7 @@ export const ClientProvider: FC<Props> = ({ children }) => {
       disconnected: isDisconnected,
       supportedFeatures: {
         reactions: supportsReactions,
-        thumbnails: supportsThumbnails,
+        authenticatedMedia: supportsAuthenticatedMedia,
       },
     };
   }, [
@@ -286,7 +287,7 @@ export const ClientProvider: FC<Props> = ({ children }) => {
     setClient,
     isDisconnected,
     supportsReactions,
-    supportsThumbnails,
+    supportsAuthenticatedMedia,
   ]);
 
   const onSync = useCallback(
@@ -312,8 +313,8 @@ export const ClientProvider: FC<Props> = ({ children }) => {
     }
 
     if (initClientState.widgetApi) {
-      // There is currently no widget API for authenticated media thumbnails.
-      setSupportsThumbnails(false);
+      // There is currently no way for widgets to request authenticated media directly from the server.
+      setSupportsAuthenticatedMedia(false);
       const reactSend = initClientState.widgetApi.hasCapability(
         "org.matrix.msc2762.send.event:m.reaction",
       );
@@ -335,7 +336,7 @@ export const ClientProvider: FC<Props> = ({ children }) => {
       }
     } else {
       setSupportsReactions(true);
-      setSupportsThumbnails(true);
+      setSupportsAuthenticatedMedia(true);
     }
 
     return (): void => {

--- a/src/ClientContext.tsx
+++ b/src/ClientContext.tsx
@@ -48,7 +48,6 @@ export type ValidClientState = {
   disconnected: boolean;
   supportedFeatures: {
     reactions: boolean;
-    authenticatedMedia: boolean;
   };
   setClient: (client: MatrixClient, session: Session) => void;
 };
@@ -249,8 +248,6 @@ export const ClientProvider: FC<Props> = ({ children }) => {
 
   const [isDisconnected, setIsDisconnected] = useState(false);
   const [supportsReactions, setSupportsReactions] = useState(false);
-  const [supportsAuthenticatedMedia, setSupportsAuthenticatedMedia] =
-    useState(false);
 
   const state: ClientState | undefined = useMemo(() => {
     if (alreadyOpenedErr) {
@@ -276,7 +273,6 @@ export const ClientProvider: FC<Props> = ({ children }) => {
       disconnected: isDisconnected,
       supportedFeatures: {
         reactions: supportsReactions,
-        authenticatedMedia: supportsAuthenticatedMedia,
       },
     };
   }, [
@@ -287,7 +283,6 @@ export const ClientProvider: FC<Props> = ({ children }) => {
     setClient,
     isDisconnected,
     supportsReactions,
-    supportsAuthenticatedMedia,
   ]);
 
   const onSync = useCallback(
@@ -313,8 +308,6 @@ export const ClientProvider: FC<Props> = ({ children }) => {
     }
 
     if (initClientState.widgetApi) {
-      // There is currently no way for widgets to request authenticated media directly from the server.
-      setSupportsAuthenticatedMedia(false);
       const reactSend = initClientState.widgetApi.hasCapability(
         "org.matrix.msc2762.send.event:m.reaction",
       );
@@ -336,7 +329,6 @@ export const ClientProvider: FC<Props> = ({ children }) => {
       }
     } else {
       setSupportsReactions(true);
-      setSupportsAuthenticatedMedia(true);
     }
 
     return (): void => {

--- a/src/settings/useSubmitRageshake.test.tsx
+++ b/src/settings/useSubmitRageshake.test.tsx
@@ -78,7 +78,7 @@ function renderWithMockClient(
         disconnected: false,
         supportedFeatures: {
           reactions: true,
-          thumbnails: true,
+          authenticatedMedia: true,
         },
         setClient: vi.fn(),
         authenticated: {

--- a/src/settings/useSubmitRageshake.test.tsx
+++ b/src/settings/useSubmitRageshake.test.tsx
@@ -78,7 +78,6 @@ function renderWithMockClient(
         disconnected: false,
         supportedFeatures: {
           reactions: true,
-          authenticatedMedia: true,
         },
         setClient: vi.fn(),
         authenticated: {

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -93,6 +93,7 @@ export const initializeWidget = (
       logger.info("Widget API is available");
       const api = new WidgetApi(widgetId, parentOrigin);
       api.requestCapability(MatrixCapabilities.AlwaysOnScreen);
+      api.requestCapability(MatrixCapabilities.MSC4039DownloadFile);
 
       // Set up the lazy action emitter, but only for select actions that we
       // intend for the app to handle


### PR DESCRIPTION
This adds the ability to download avatar images using the MC4039 widget API if we can't directly fetch from the server.

Fixes #2876