### PR TITLE
avatars with auth and not

### DIFF
--- a/src/Avatar.test.tsx
+++ b/src/Avatar.test.tsx
@@ -15,8 +15,12 @@ import { Avatar } from "./Avatar";
 import { mockMatrixRoomMember, mockRtcMembership } from "./utils/test";
 
 const TestComponent: FC<
-  PropsWithChildren<{ client: MatrixClient; supportsThumbnails?: boolean }>
-> = ({ client, children, supportsThumbnails }) => {
+  PropsWithChildren<{
+    client: MatrixClient;
+    supportsThumbnails?: boolean;
+    mediaProxy?: boolean;
+  }>
+> = ({ client, children, supportsThumbnails, mediaProxy }) => {
   return (
     <ClientContextProvider
       value={{
@@ -25,6 +29,7 @@ const TestComponent: FC<
         supportedFeatures: {
           reactions: true,
           thumbnails: supportsThumbnails ?? true,
+          mediaProxy: mediaProxy ?? false,
         },
         setClient: vi.fn(),
         authenticated: {

--- a/src/Avatar.tsx
+++ b/src/Avatar.tsx
@@ -46,6 +46,7 @@ export function getAvatarUrl(
   client: MatrixClient,
   mxcUrl: string | null,
   avatarSize = 96,
+  useAuthentication = true,
 ): string | null {
   const width = Math.floor(avatarSize * window.devicePixelRatio);
   const height = Math.floor(avatarSize * window.devicePixelRatio);
@@ -59,7 +60,7 @@ export function getAvatarUrl(
         resizeMethod,
         false,
         true,
-        true,
+        useAuthentication,
       )
     : null;
 }
@@ -97,21 +98,22 @@ export const Avatar: FC<Props> = ({
     }
 
     const token = client.getAccessToken();
-    if (!token) {
-      return;
-    }
-    const resolveSrc = getAvatarUrl(client, src, sizePx);
+    const useAuth = token != null || supportedFeatures.mediaProxy;
+    // if we have no auth, try to use old deprecated endpoint
+    const resolveSrc = getAvatarUrl(client, src, sizePx, useAuth);
     if (!resolveSrc) {
       setAvatarUrl(undefined);
       return;
     }
 
     let objectUrl: string | undefined;
-    fetch(resolveSrc, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-    })
+    // attach token if we have one already.
+    // otherwise, we are using the unauthenticated endpoint
+    // or we are counting on the host to add it in
+    const fetchOpts: RequestInit = token
+      ? { headers: { Authorization: `Bearer ${token}` } }
+      : {};
+    fetch(resolveSrc, fetchOpts)
       .then(async (req) => req.blob())
       .then((blob) => {
         objectUrl = URL.createObjectURL(blob);

--- a/src/ClientContext.tsx
+++ b/src/ClientContext.tsx
@@ -49,6 +49,7 @@ export type ValidClientState = {
   supportedFeatures: {
     reactions: boolean;
     thumbnails: boolean;
+    mediaProxy: boolean;
   };
   setClient: (client: MatrixClient, session: Session) => void;
 };
@@ -250,6 +251,7 @@ export const ClientProvider: FC<Props> = ({ children }) => {
   const [isDisconnected, setIsDisconnected] = useState(false);
   const [supportsReactions, setSupportsReactions] = useState(false);
   const [supportsThumbnails, setSupportsThumbnails] = useState(false);
+  const [supportsMediaProxy, setSupportsMediaProxy] = useState(false);
 
   const state: ClientState | undefined = useMemo(() => {
     if (alreadyOpenedErr) {
@@ -276,6 +278,7 @@ export const ClientProvider: FC<Props> = ({ children }) => {
       supportedFeatures: {
         reactions: supportsReactions,
         thumbnails: supportsThumbnails,
+        mediaProxy: supportsMediaProxy,
       },
     };
   }, [
@@ -287,6 +290,7 @@ export const ClientProvider: FC<Props> = ({ children }) => {
     isDisconnected,
     supportsReactions,
     supportsThumbnails,
+    supportsMediaProxy,
   ]);
 
   const onSync = useCallback(
@@ -312,8 +316,17 @@ export const ClientProvider: FC<Props> = ({ children }) => {
     }
 
     if (initClientState.widgetApi) {
-      // There is currently no widget API for authenticated media thumbnails.
-      setSupportsThumbnails(false);
+      const hasMediaProxy = initClientState.widgetApi.hasCapability(
+        "moe.sable.media_proxy",
+      );
+      const hasThumbnails = initClientState.widgetApi.hasCapability(
+        "moe.sable.thumbnails",
+      );
+      // maybe slightly weird to do it this way.
+      // if there's ever media besides thumbnails in the future
+      // these ought to to be decoupled
+      setSupportsThumbnails(hasThumbnails || hasMediaProxy);
+      setSupportsMediaProxy(hasMediaProxy);
       const reactSend = initClientState.widgetApi.hasCapability(
         "org.matrix.msc2762.send.event:m.reaction",
       );
@@ -334,8 +347,8 @@ export const ClientProvider: FC<Props> = ({ children }) => {
         setSupportsReactions(true);
       }
     } else {
-      setSupportsReactions(true);
       setSupportsThumbnails(true);
+      setSupportsReactions(true);
     }
 
     return (): void => {

--- a/src/settings/useSubmitRageshake.test.tsx
+++ b/src/settings/useSubmitRageshake.test.tsx
@@ -79,6 +79,7 @@ function renderWithMockClient(
         supportedFeatures: {
           reactions: true,
           thumbnails: true,
+          mediaProxy: false,
         },
         setClient: vi.fn(),
         authenticated: {

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -93,6 +93,14 @@ export const initializeWidget = (
       logger.info("Widget API is available");
       const api = new WidgetApi(widgetId, parentOrigin);
       api.requestCapability(MatrixCapabilities.AlwaysOnScreen);
+      // asks if it wants thumbnails at all. if this
+      // is on but media proxy isn't,
+      // will try on the unathenticated media endpoint for them
+      api.requestCapability("moe.sable.thumbnails");
+      // asks if it can support authenticated thumbnails via proxy
+      // this will enable thumbnails automatically for now
+      // as that's the only thing this would be used for anyway
+      api.requestCapability("moe.sable.media_proxy");
 
       // Set up the lazy action emitter, but only for select actions that we
       // intend for the app to handle

--- a/vite-embedded.config.ts
+++ b/vite-embedded.config.ts
@@ -19,6 +19,9 @@ export default defineConfig((env) =>
     defineConfig({
       base, // Use relative URLs to allow the app to be hosted under any path
       publicDir: false, // Don't serve the public directory which only contains the favicon
+      build: {
+        outDir: "embedded/web/dist",
+      },
       plugins: [
         generateFile([
           {


### PR DESCRIPTION
Adds two new capabilities for element call as a widget!

moe.sable.thumbnails
moe.sable.media_proxy

If neither is set, fallback thumbnails will be used: the letter over color sort.
If moe.sable.thumbnails is set, element call will attempt to use the old unauthenticated media endpoint to grab thumbnails.
If moe.sable.media_proxy or both are set, will shoot for the authenticated hope and pray the client hosting the widget keeps its promise: adding authentication to the request, via a service worker or something.