### PR TITLE
Activate click tests for pip buttons

### DIFF
--- a/playwright/widget/pip-call-button-interaction.test.ts
+++ b/playwright/widget/pip-call-button-interaction.test.ts
@@ -58,11 +58,10 @@ widgetTest("Footer interaction in PiP", async ({ addUser, browserName }) => {
     await expect(videoMuteButton).toBeVisible();
     await expect(audioMuteButton).toBeVisible();
 
-    // TODO once we have the EW version that supports the interactive pip element we can activate those checks
-    // await videoMuteButton.click();
-    // await audioMuteButton.click();
+    await videoMuteButton.click();
+    await audioMuteButton.click();
 
-    // await expect(videoMuteButton).toHaveCSS("disabled", "true");
-    // await expect(audioMuteButton).toHaveCSS("disabled", "true");
+    await expect(videoMuteButton).toHaveCSS("disabled", "true");
+    await expect(audioMuteButton).toHaveCSS("disabled", "true");
   }
 });


### PR DESCRIPTION
This activates the PIP view click tests that was disabled due to missing docker for EW.
We need: https://github.com/element-hq/element-web/pull/32654

To be published here: https://github.com/element-hq/element-web/pkgs/container/element-web