### PR TITLE
add simple enable and disable test for fkwp/feature_deepfilternet

### DIFF
--- a/playwright/spa-helpers.ts
+++ b/playwright/spa-helpers.ts
@@ -90,7 +90,7 @@ async function joinCallFromInviteLink(
   }
 
   await switchNoiseSuppressionFromSettings(page);
-  
+
   await page.getByTestId("lobby_joinCall").click();
   await page.getByRole("radio", { name: "Spotlight" }).check();
 }
@@ -121,7 +121,7 @@ async function switchNoiseSuppressionFromSettings(page: Page): Promise<void> {
   await page.getByRole("button", { name: "Settings" }).click();
   await page.getByRole("tab", { name: "Audio" }).click();
   await page.getByText("Noise suppression", { exact: true }).uncheck();
-  
+
   // wait for short time before checking the box again
   await page.waitForTimeout(1000);
   await page.getByText("Noise suppression", { exact: true }).check();

--- a/playwright/spa-helpers.ts
+++ b/playwright/spa-helpers.ts
@@ -117,9 +117,7 @@ async function setRtcModeFromSettings(
   await page.getByTestId("modal_close").click();
 }
 
-async function switchNoiseSuppressionFromSettings(
-  page: Page,
-): Promise<void> {
+async function switchNoiseSuppressionFromSettings(page: Page): Promise<void> {
   await page.getByRole("button", { name: "Settings" }).click();
   await page.getByRole("tab", { name: "Audio" }).click();
   await page.getByText("Noise suppression", { exact: true }).uncheck();

--- a/playwright/spa-helpers.ts
+++ b/playwright/spa-helpers.ts
@@ -38,6 +38,8 @@ async function createCall(
     await setRtcModeFromSettings(page, mode);
   }
 
+  await switchNoiseSuppressionFromSettings(page);
+
   if (autoJoin) {
     // Join the call
     await page.getByTestId("lobby_joinCall").click();
@@ -87,6 +89,8 @@ async function joinCallFromInviteLink(
     await setRtcModeFromSettings(page, mode);
   }
 
+  await switchNoiseSuppressionFromSettings(page);
+  
   await page.getByTestId("lobby_joinCall").click();
   await page.getByRole("radio", { name: "Spotlight" }).check();
 }
@@ -109,6 +113,23 @@ async function setRtcModeFromSettings(
     // compat
     await page.getByText("Compatibility: state events").click();
   }
+
+  await page.getByTestId("modal_close").click();
+}
+
+async function switchNoiseSuppressionFromSettings(
+  page: Page,
+): Promise<void> {
+  await page.getByRole("button", { name: "Settings" }).click();
+  await page.getByRole("tab", { name: "Audio" }).click();
+  await page.getByText("Noise suppression", { exact: true }).uncheck();
+  
+  // wait for short time before checking the box again
+  await page.waitForTimeout(1000);
+  await page.getByText("Noise suppression", { exact: true }).check();
+
+  // wait again for a short time
+  await page.waitForTimeout(1000);
 
   await page.getByTestId("modal_close").click();
 }


### PR DESCRIPTION
## Content

I added a simple enable and disable test for the fkwp/feature_deepfilternet branch (#3819 ), so that Code Coverage is happy.

## Motivation and context

The original branch wasn't fulfilling the Code Coverage test, so I hope this fixes it


## Checklist

- [x] I have read through [CONTRIBUTING.md](https://github.com/element-hq/element-call/blob/livekit/CONTRIBUTING.md).
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] Tests written for new code (and old code if feasible).
- [x] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-call)
