### PR TITLE
Possible fix for avatars showing stale image data

### DIFF
--- a/src/Avatar.tsx
+++ b/src/Avatar.tsx
@@ -136,6 +136,7 @@ export const Avatar: FC<Props> = ({
 
   return (
     <CompoundAvatar
+      key={id}
       className={className}
       id={id}
       name={name}


### PR DESCRIPTION
By giving React a different key for different users' avatars, this hopefully ensures that a new \<img\> element will be created when the avatar component switches to a different user.

Possible fix for https://github.com/element-hq/voip-internal/issues/525 - needs real-world testing.