### PR TITLE
Workaround: EW has not yet merged the download file permission for EC

### DIFF
--- a/playwright/widget/simple-create.spec.ts
+++ b/playwright/widget/simple-create.spec.ts
@@ -8,6 +8,7 @@ Please see LICENSE in the repository root for full details.
 import { expect, test } from "@playwright/test";
 
 import { widgetTest } from "../fixtures/widget-user.ts";
+import { TestHelpers } from "./test-helpers.ts";
 
 // Skip test, including Fixtures
 widgetTest.skip(
@@ -20,19 +21,7 @@ widgetTest("Start a new call as widget", async ({ asWidget, browserName }) => {
 
   const { brooks, whistler } = asWidget;
 
-  await expect(
-    brooks.page.getByRole("button", { name: "Video call" }),
-  ).toBeVisible();
-  await brooks.page.getByRole("button", { name: "Video call" }).click();
-
-  await expect(
-    brooks.page.getByRole("menuitem", { name: "Legacy Call" }),
-  ).toBeVisible();
-  await expect(
-    brooks.page.getByRole("menuitem", { name: "Element Call" }),
-  ).toBeVisible();
-
-  await brooks.page.getByRole("menuitem", { name: "Element Call" }).click();
+  await TestHelpers.startCallInCurrentRoom(brooks.page, false);
 
   await expect(
     brooks.page
@@ -56,11 +45,7 @@ widgetTest("Start a new call as widget", async ({ asWidget, browserName }) => {
   ).toBeVisible();
 
   // Join from the other side
-  await expect(whistler.page.getByText("Video call started")).toBeVisible();
-  await expect(
-    whistler.page.getByRole("button", { name: "Join" }),
-  ).toBeVisible();
-  await whistler.page.getByRole("button", { name: "Join" }).click();
+  await TestHelpers.joinCallInCurrentRoom(whistler.page);
 
   // Currently disabled due to recent Element Web is bypassing Lobby
   // await expect(

--- a/playwright/widget/test-helpers.ts
+++ b/playwright/widget/test-helpers.ts
@@ -34,6 +34,9 @@ export class TestHelpers {
     ).toBeVisible();
 
     await page.getByRole("menuitem", { name: "Element Call" }).click();
+
+    // TODO: Remove as soon as web merges https://github.com/element-hq/element-web/pull/32755
+    await this.dismissFileDialogPermissionIfNeeded(page);
   }
 
   public static async joinCallFromLobby(page: Page): Promise<void> {
@@ -60,6 +63,9 @@ export class TestHelpers {
     await expect(page.getByText(label)).toBeVisible();
     await expect(page.getByRole("button", { name: "Join" })).toBeVisible();
     await page.getByRole("button", { name: "Join" }).click();
+
+    // TODO: Remove as soon as web merges https://github.com/element-hq/element-web/pull/32755
+    await this.dismissFileDialogPermissionIfNeeded(page);
   }
 
   /**
@@ -235,9 +241,30 @@ export class TestHelpers {
   ): Promise<void> {
     await page.getByRole("button", { name: "Video call" }).click();
     await page.getByRole("menuitem", { name: "Element Call" }).click();
+
+    // TODO: Remove as soon as web merges https://github.com/element-hq/element-web/pull/32755
+    await this.dismissFileDialogPermissionIfNeeded(page);
+
     await TestHelpers.setEmbeddedElementCallRtcMode(page, mode);
     await page.getByRole("button", { name: "Close lobby" }).click();
   }
+
+  // TODO: Remove as soon as web merges https://github.com/element-hq/element-web/pull/32755
+  private static async dismissFileDialogPermissionIfNeeded(
+    page: Page,
+  ): Promise<void> {
+    const dialogHeading = page.getByRole("heading", {
+      name: "Approve widget permissions",
+    });
+
+    try {
+      await expect(dialogHeading).toBeVisible({ timeout: 3000 });
+      await page.getByRole("button", { name: "Approve" }).click();
+    } catch {
+      // Dialog did not appear, that's fine
+    }
+  }
+
   /**
    * Goes to the settings to set the RTC mode.
    * then closes the settings modal.

--- a/playwright/widget/test-helpers.ts
+++ b/playwright/widget/test-helpers.ts
@@ -250,7 +250,7 @@ export class TestHelpers {
   }
 
   // TODO: Remove as soon as web merges https://github.com/element-hq/element-web/pull/32755
-  private static async dismissFileDialogPermissionIfNeeded(
+  public static async dismissFileDialogPermissionIfNeeded(
     page: Page,
   ): Promise<void> {
     const dialogHeading = page.getByRole("heading", {

--- a/playwright/widget/voice-call-dm.spec.ts
+++ b/playwright/widget/voice-call-dm.spec.ts
@@ -45,6 +45,8 @@ widgetTest(
     await expect(whistler.page.getByText("Incoming voice call")).toBeVisible();
     await whistler.page.getByRole("button", { name: "Accept" }).click();
 
+    await TestHelpers.dismissFileDialogPermissionIfNeeded(whistler.page);
+
     await expect(
       whistler.page.locator('iframe[title="Element Call"]'),
     ).toBeVisible();
@@ -137,6 +139,8 @@ widgetTest(
 
     await expect(whistler.page.getByText("Incoming video call")).toBeVisible();
     await whistler.page.getByRole("button", { name: "Accept" }).click();
+
+    await TestHelpers.dismissFileDialogPermissionIfNeeded(whistler.page);
 
     await expect(
       whistler.page.locator('iframe[title="Element Call"]'),


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

Web has not yet merged https://github.com/element-hq/element-web/pull/32755
But EC already supports downloading avatars. 

This is breaking the playwright test.
This is a tmp work around to allow the permission and unblock our CI

## Content

<!-- Describe shortly what has been changed -->

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!--

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...
-

## Checklist

- [ ] I have read through [CONTRIBUTING.md](https://github.com/element-hq/element-call/blob/livekit/CONTRIBUTING.md).
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Tests written for new code (and old code if feasible).
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-call)
