### PR TITLE
revert workaround for widget permission dialog, not needed anymore

### DIFF
--- a/playwright/widget/test-helpers.ts
+++ b/playwright/widget/test-helpers.ts
@@ -34,9 +34,6 @@ export class TestHelpers {
     ).toBeVisible();
 
     await page.getByRole("menuitem", { name: "Element Call" }).click();
-
-    // TODO: Remove as soon as web merges https://github.com/element-hq/element-web/pull/32755
-    await this.dismissFileDialogPermissionIfNeeded(page);
   }
 
   public static async joinCallFromLobby(page: Page): Promise<void> {
@@ -63,9 +60,6 @@ export class TestHelpers {
     await expect(page.getByText(label)).toBeVisible();
     await expect(page.getByRole("button", { name: "Join" })).toBeVisible();
     await page.getByRole("button", { name: "Join" }).click();
-
-    // TODO: Remove as soon as web merges https://github.com/element-hq/element-web/pull/32755
-    await this.dismissFileDialogPermissionIfNeeded(page);
   }
 
   /**
@@ -242,27 +236,8 @@ export class TestHelpers {
     await page.getByRole("button", { name: "Video call" }).click();
     await page.getByRole("menuitem", { name: "Element Call" }).click();
 
-    // TODO: Remove as soon as web merges https://github.com/element-hq/element-web/pull/32755
-    await this.dismissFileDialogPermissionIfNeeded(page);
-
     await TestHelpers.setEmbeddedElementCallRtcMode(page, mode);
     await page.getByRole("button", { name: "Close lobby" }).click();
-  }
-
-  // TODO: Remove as soon as web merges https://github.com/element-hq/element-web/pull/32755
-  public static async dismissFileDialogPermissionIfNeeded(
-    page: Page,
-  ): Promise<void> {
-    const dialogHeading = page.getByRole("heading", {
-      name: "Approve widget permissions",
-    });
-
-    try {
-      await expect(dialogHeading).toBeVisible({ timeout: 3000 });
-      await page.getByRole("button", { name: "Approve" }).click();
-    } catch {
-      // Dialog did not appear, that's fine
-    }
   }
 
   /**

--- a/playwright/widget/voice-call-dm.spec.ts
+++ b/playwright/widget/voice-call-dm.spec.ts
@@ -45,8 +45,6 @@ widgetTest(
     await expect(whistler.page.getByText("Incoming voice call")).toBeVisible();
     await whistler.page.getByRole("button", { name: "Accept" }).click();
 
-    await TestHelpers.dismissFileDialogPermissionIfNeeded(whistler.page);
-
     await expect(
       whistler.page.locator('iframe[title="Element Call"]'),
     ).toBeVisible();
@@ -139,8 +137,6 @@ widgetTest(
 
     await expect(whistler.page.getByText("Incoming video call")).toBeVisible();
     await whistler.page.getByRole("button", { name: "Accept" }).click();
-
-    await TestHelpers.dismissFileDialogPermissionIfNeeded(whistler.page);
 
     await expect(
       whistler.page.locator('iframe[title="Element Call"]'),


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

Revert https://github.com/element-hq/element-call/pull/3830
Should not be needed anymore. Web develop is updated

## Content

<!-- Describe shortly what has been changed -->

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!--

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...
-

## Checklist

- [ ] I have read through [CONTRIBUTING.md](https://github.com/element-hq/element-call/blob/livekit/CONTRIBUTING.md).
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Tests written for new code (and old code if feasible).
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-call)
