### PR TITLE
Reconfirm that a PR has a changelog label when new commits are pushed

### DIFF
--- a/.github/workflows/changelog-label.yml
+++ b/.github/workflows/changelog-label.yml
@@ -5,7 +5,7 @@ on:
   # This is safe because we do not use actions/checkout or execute untrusted code.
   # Using pull_request_target is necessary to allow status writes for PRs from forks.
   pull_request_target:
-    types: [labeled, unlabeled, opened]
+    types: [labeled, unlabeled, opened, synchronize]
 
 permissions:
   pull-requests: read


### PR DESCRIPTION
Without re-running the changelog label workflow on new commits, PRs get stuck waiting for the check after new commits are pushed.