### PR TITLE
Make the footer move floating tiles out of the way when shown

### DIFF
--- a/src/room/InCallView.module.css
+++ b/src/room/InCallView.module.css
@@ -55,9 +55,8 @@ Please see LICENSE in the repository root for full details.
 }
 
 .footer.overlay {
-  position: absolute;
-  inset-block-end: 0;
-  inset-inline: 0;
+  /* Note that the footer is still position: sticky in this case so that certain
+  tiles can move up out of the way of the footer when visible. */
   opacity: 1;
   transition: opacity 0.15s;
 }
@@ -66,6 +65,11 @@ Please see LICENSE in the repository root for full details.
   display: grid;
   opacity: 0;
   pointer-events: none;
+  /* Switch to position: absolute so the footer takes up no space in the layout
+  when hidden. */
+  position: absolute;
+  inset-block-end: 0;
+  inset-inline: 0;
 }
 
 .footer.overlay:has(:focus-visible) {


### PR DESCRIPTION
If you manage to move your floating video tile to the bottom of the screen in a small landscape window, the footer obscures the tile when shown. The designs want us to smoothly move the floating tile out of the way in this case.

**Before**

[Screencast From 2026-04-13 12-46-28.webm](https://github.com/user-attachments/assets/7b3e4c86-ab5c-48ad-96c0-b1dd4f021282)

**After**

[Screencast From 2026-04-13 12-47-12.webm](https://github.com/user-attachments/assets/16951ad1-05f0-473a-a52c-05215d098981)

For https://github.com/element-hq/voip-internal/issues/528