### PR TITLE
Fix race in playwright sticky test

### DIFF
--- a/playwright/spa-call-sticky.spec.ts
+++ b/playwright/spa-call-sticky.spec.ts
@@ -28,7 +28,7 @@ async function setupTwoUserSpaCall(
   await page.goto("/");
 
   let androlHasSentStickyEvent = false;
-
+  const androlResolver = Promise.withResolvers<void>();
   await interceptEventSend(
     page,
     // This room is not encrypted, so the event is sent in clear
@@ -36,6 +36,7 @@ async function setupTwoUserSpaCall(
     (req) => {
       androlHasSentStickyEvent =
         androlHasSentStickyEvent || isStickySend(req.url());
+      androlResolver.resolve();
     },
   );
 
@@ -53,6 +54,7 @@ async function setupTwoUserSpaCall(
 
   let pevaraHasSentStickyEvent = false;
 
+  const paveraResolver = Promise.withResolvers<void>();
   await interceptEventSend(
     guestPage,
     // This room is not encrypted, so the event is sent in clear
@@ -60,6 +62,7 @@ async function setupTwoUserSpaCall(
     (req) => {
       pevaraHasSentStickyEvent =
         pevaraHasSentStickyEvent || isStickySend(req.url());
+      paveraResolver.resolve();
     },
   );
 
@@ -70,7 +73,9 @@ async function setupTwoUserSpaCall(
     "2_0",
   );
   // Assert both sides have sent sticky membership events
+  await androlResolver.promise;
   expect(androlHasSentStickyEvent).toEqual(true);
+  await paveraResolver.promise;
   expect(pevaraHasSentStickyEvent).toEqual(true);
 
   return { guestPage };

--- a/playwright/spa-call-sticky.spec.ts
+++ b/playwright/spa-call-sticky.spec.ts
@@ -54,7 +54,7 @@ async function setupTwoUserSpaCall(
 
   let pevaraHasSentStickyEvent = false;
 
-  const paveraResolver = Promise.withResolvers<void>();
+  const pevaraResolver = Promise.withResolvers<void>();
   await interceptEventSend(
     guestPage,
     // This room is not encrypted, so the event is sent in clear
@@ -62,7 +62,7 @@ async function setupTwoUserSpaCall(
     (req) => {
       pevaraHasSentStickyEvent =
         pevaraHasSentStickyEvent || isStickySend(req.url());
-      paveraResolver.resolve();
+      pevaraResolver.resolve();
     },
   );
 
@@ -75,7 +75,7 @@ async function setupTwoUserSpaCall(
   // Assert both sides have sent sticky membership events
   await androlResolver.promise;
   expect(androlHasSentStickyEvent).toEqual(true);
-  await paveraResolver.promise;
+  await pevaraResolver.promise;
   expect(pevaraHasSentStickyEvent).toEqual(true);
 
   return { guestPage };


### PR DESCRIPTION
I was running into a CI error where `expect(pevaraHasSentStickyEvent).toEqual(true);` was false.
This seemed to be not correct since the logs mention the request that we intercept and should be called.
This change seems to fix it which makes me conclude that the check `expect(pevaraHasSentStickyEvent).toEqual(true);` can be executed to eagerly.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Content

<!-- Describe shortly what has been changed -->

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!--

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...
-

## Checklist

- [ ] I have read through [CONTRIBUTING.md](https://github.com/element-hq/element-call/blob/livekit/CONTRIBUTING.md).
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Tests written for new code (and old code if feasible).
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-call)
