### PR TITLE
Update CI to ignore pnpmfile

### DIFF
--- a/.github/workflows/build-element-call.yaml
+++ b/.github/workflows/build-element-call.yaml
@@ -43,7 +43,9 @@ jobs:
           cache: "pnpm"
           node-version-file: ".node-version"
       - name: Install dependencies
-        run: "pnpm install --frozen-lockfile"
+        # ignore-pnpmfile will make CI never executes the pnpmfile.cjs. This is acceptable since only need it for local dev linking.
+        # renovate will remove a checksum in pnpm-lock.yaml. So without this every renovate PR will fail CI.
+        run: "pnpm install --frozen-lockfile --ignore-pnpmfile"
       - name: Build Element Call
         run: pnpm run build:"$PACKAGE":"$BUILD_MODE"
         env:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,7 +18,9 @@ jobs:
           cache: "pnpm"
           node-version-file: ".node-version"
       - name: Install dependencies
-        run: "pnpm install --frozen-lockfile"
+        # ignore-pnpmfile will make CI never executes the pnpmfile.cjs. This is acceptable since only need it for local dev linking.
+        # renovate will remove a checksum in pnpm-lock.yaml. So without this every renovate PR will fail CI.
+        run: "pnpm install --frozen-lockfile --ignore-pnpmfile"
       - name: Prettier
         run: "pnpm run prettier:check"
       - name: i18n

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,7 +20,9 @@ jobs:
           cache: "pnpm"
           node-version-file: ".node-version"
       - name: Install dependencies
-        run: "pnpm install --frozen-lockfile"
+        # ignore-pnpmfile will make CI never executes the pnpmfile.cjs. This is acceptable since only need it for local dev linking.
+        # renovate will remove a checksum in pnpm-lock.yaml. So without this every renovate PR will fail CI.
+        run: "pnpm install --frozen-lockfile --ignore-pnpmfile"
       - name: Vitest
         run: "pnpm run test:coverage"
       - name: Upload to codecov
@@ -45,7 +47,9 @@ jobs:
           cache: "pnpm"
           node-version-file: ".node-version"
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        # ignore-pnpmfile will make CI never executes the pnpmfile.cjs. This is acceptable since only need it for local dev linking.
+        # renovate will remove a checksum in pnpm-lock.yaml. So without this every renovate PR will fail CI.
+        run: pnpm install --frozen-lockfile --ignore-pnpmfile
       - name: Install Playwright Browsers
         run: pnpm exec playwright install --with-deps
       - name: Run backend components

--- a/.github/workflows/translations-download.yaml
+++ b/.github/workflows/translations-download.yaml
@@ -26,7 +26,9 @@ jobs:
           node-version-file: ".node-version"
 
       - name: Install Deps
-        run: "pnpm install --frozen-lockfile"
+        # ignore-pnpmfile will make CI never executes the pnpmfile.cjs. This is acceptable since only need it for local dev linking.
+        # renovate will remove a checksum in pnpm-lock.yaml. So without this every renovate PR will fail CI.
+        run: "pnpm install --frozen-lockfile --ignore-pnpmfile"
 
       - name: Prune i18n
         run: "rm -R locales"


### PR DESCRIPTION
 - This is save since we never run pnpmfiles in ci
 - We can still run it locally
 - pnpm will not crash if checksum is missing, wrong, or correct since it is ignoring it.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Content

<!-- Describe shortly what has been changed -->

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!--

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...
-

## Checklist

- [ ] I have read through [CONTRIBUTING.md](https://github.com/element-hq/element-call/blob/livekit/CONTRIBUTING.md).
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Tests written for new code (and old code if feasible).
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-call)
