### PR TITLE
Add Promise.withResolvers polyfill for older WebViews (Chrome < 119)

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,19 @@
     <script>
       window.global = window;
     </script>
+    <!-- Polyfill for Chrome < 119 (Huawei WebView, etc.) -->
+    <script>
+      if (!Promise.withResolvers) {
+        Promise.withResolvers = function () {
+          var resolve, reject;
+          var promise = new Promise(function (a, b) {
+            resolve = a;
+            reject = b;
+          });
+          return { promise: promise, resolve: resolve, reject: reject };
+        };
+      }
+    </script>
 
     <% if (packageType === "full") { %>
     <!-- Open graph meta tags -->


### PR DESCRIPTION
## Problem

Element Call does not work on devices with WebView based on Chromium < 119 (Huawei, some Xiaomi/Redmi devices). The page shows "Join as guest" instead of the call UI.

The bundled JS uses `Promise.withResolvers()` (ES2024, Chrome 119+) in several places via dependencies (`matrix-js-sdk`, `livekit-client`). On older WebViews the ES module silently fails to load because `<script type="module">` errors are not catchable with `window.onerror`. Element Call never initializes.

Huawei ships a system WebView based on Chromium 114 and does not allow users to change the WebView provider. This affects all current Huawei devices.

`tsconfig.json` targets ES2022 but `Promise.withResolvers` is a runtime API that is not downleveled by TypeScript or esbuild.

## Fix

Add a `Promise.withResolvers` polyfill in `index.html` before the module script tag. The polyfill is guarded by `if (!Promise.withResolvers)` so it has zero impact on modern browsers.

The polyfill must be in `index.html` (not in a `.ts` source file) because the module itself fails to load before any application code runs.

## Affected devices

Any device with system WebView older than Chrome 119. Confirmed on:
- Huawei P40 Lite (WebView 114)
- Huawei (WebView 114.05.302)
- Redmi Note 12 Turbo (WebView 118), see element-hq/element-x-android#6298

Related: element-hq/element-x-android#6632