### PR TITLE
Make controls show up on tap on iOS

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -125,6 +125,12 @@ body[data-platform="ios"] {
     -apple-system, BlinkMacSystemFont, "Inter", sans-serif;
 }
 
+body[data-platform="ios"] * {
+  /* This makes click events bubble properly on iOS
+  https://www.quirksmode.org/blog/archives/2014/02/mouse_event_bub.html */
+  cursor: pointer;
+}
+
 @layer compound-legacy {
   h1,
   h2,

--- a/src/initializer.tsx
+++ b/src/initializer.tsx
@@ -189,6 +189,7 @@ export class Initializer {
 
     // Add the platform to the DOM, so CSS can query it
     document.body.setAttribute("data-platform", platform);
+    logger.info(`Platform: ${platform}`);
   }
 
   public static init(): Promise<void> | null {


### PR DESCRIPTION
As documented at https://www.quirksmode.org/blog/archives/2014/02/mouse_event_bub.html, the fact that click events do not bubble by default is a longstanding quirk of iOS Safari.

Assuming the hack works, this closes https://github.com/element-hq/element-call/issues/3943