### PR TITLE
bugfix: When starting muted, have to click twice to unmute in call

### DIFF
--- a/playwright/create-call.spec.ts
+++ b/playwright/create-call.spec.ts
@@ -58,3 +58,38 @@ test("Start a new call then leave and show the feedback screen", async ({
     page.getByRole("link", { name: "Not now, return to home screen" }),
   ).toBeVisible();
 });
+
+test("BugFix: When unmuting in lobby, you had to click twice to unmute in call", async ({
+  page,
+}) => {
+  await page.goto("/");
+
+  await page.getByTestId("home_callName").click();
+  await page.getByTestId("home_callName").fill("DoubleUnMute");
+  await page.getByTestId("home_displayName").click();
+  await page.getByTestId("home_displayName").fill("me");
+  await page.getByTestId("home_go").click();
+
+  const microphoneButton = page.getByTestId("incall_mute");
+  const cameraButton = page.getByTestId("incall_videomute");
+
+  await microphoneButton.click();
+  await cameraButton.click();
+
+  // Should be muted now
+  await expect(microphoneButton).toHaveAccessibleName("Unmute microphone");
+  await expect(cameraButton).toHaveAccessibleName("Start video");
+
+  // Create the call and join
+  await page.getByTestId("lobby_joinCall").click();
+
+  // Give sometime for the all to be connected
+  // Check the number of participants
+  await expect(page.locator("div").filter({ hasText: /^1$/ })).toBeVisible();
+
+  // Click again on the mute button. it should unmute
+  await microphoneButton.click();
+  await expect(microphoneButton).toHaveAccessibleName("Mute microphone");
+  await cameraButton.click();
+  await expect(cameraButton).toHaveAccessibleName("Stop video");
+});

--- a/src/state/CallViewModel/localMember/Publisher.ts
+++ b/src/state/CallViewModel/localMember/Publisher.ts
@@ -379,10 +379,11 @@ export class Publisher {
         if (!this.shouldPublish && enable) {
           await this.pauseUpstreams(lkRoom, [Track.Source.Microphone]);
         }
+        return enable;
       } catch (e) {
         this.logger.error("Failed to update LiveKit audio input mute state", e);
+        return lkRoom.localParticipant.isMicrophoneEnabled;
       }
-      return lkRoom.localParticipant.isMicrophoneEnabled;
     });
     this.muteStates.video.setHandler(async (enable) => {
       try {
@@ -393,10 +394,11 @@ export class Publisher {
         if (!this.shouldPublish && enable) {
           await this.pauseUpstreams(lkRoom, [Track.Source.Camera]);
         }
+        return enable;
       } catch (e) {
         this.logger.error("Failed to update LiveKit video input mute state", e);
+        return lkRoom.localParticipant.isCameraEnabled;
       }
-      return lkRoom.localParticipant.isCameraEnabled;
     });
   }
 


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Content

Fixes https://github.com/element-hq/element-call/issues/3929

Problem was that when the track is not yet created, the livekitParticipant [isCameraEnabled](https://github.com/livekit/client-sdk-js/blob/5d8264565f1b0108c301214c838333fb5593c5aa/src/room/participant/Participant.ts#L216) or `isMicrophoneEnabled` always returns false `!(track?.isMuted ?? true)`

The publisher then thinks that the handler failed to sync the mute state and then revert to the previous state.

As a fix, the handler should always return the requested change if no error occurs. Livekit will properly manage the publication in the correct state. 


<!-- Describe shortly what has been changed -->

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!--

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...
-

## Checklist

- [ ] I have read through [CONTRIBUTING.md](https://github.com/element-hq/element-call/blob/livekit/CONTRIBUTING.md).
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Tests written for new code (and old code if feasible).
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-call)
