### PR TITLE
Allow PostHog dependency updates again

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -50,6 +50,11 @@
       "prHeader": "Please review modals on mobile for visual regressions."
     },
     {
+      "groupName": "PostHog",
+      "matchDepNames": ["posthog-js"],
+      "prHeader": "Please ensure that all analytics data is still appropriately sanitized."
+    },
+    {
       "groupName": "embedded package dependencies",
       "matchFileNames": ["embedded/**/*"]
     },
@@ -59,7 +64,7 @@
     }
   ],
   "semanticCommits": "disabled",
-  "ignoreDeps": ["posthog-js", "eslint-plugin-matrix-org"],
+  "ignoreDeps": ["eslint-plugin-matrix-org"],
   "vulnerabilityAlerts": {
     "schedule": ["at any time"],
     "prHourlyLimit": 0,


### PR DESCRIPTION
The motivation for pausing these updates was https://github.com/PostHog/posthog-js/issues/1437, which has since resolved itself.