### PR TITLE
Fix a couple more regressions due to the one-on-one portrait layout

### DIFF
--- a/src/room/InCallView.tsx
+++ b/src/room/InCallView.tsx
@@ -516,11 +516,11 @@ export const InCallView: FC<InCallViewProps> = ({
         key="fixed"
         className={styles.fixedGrid}
         style={{
-          insetBlockStart:
-            edgeToEdge || headerBounds.height === 0 ? 0 : headerBounds.bottom,
+          // If not edge-to-edge, consume the header insets right here.
+          insetBlockStart: edgeToEdge ? 0 : bounds.top + headerBounds.height,
           height: edgeToEdge ? "100%" : gridBounds.height,
           // If edge-to-edge, compute new safe area insets that account for the
-          // header and footer.
+          // header and footer, passing them down to the tiles.
           "--call-view-safe-area-inset-top":
             edgeToEdge && headerStyle !== HeaderStyle.None && showHeader
               ? // Header has two relevant cases: if it's an app bar, it lives

--- a/src/room/__snapshots__/InCallView.test.tsx.snap
+++ b/src/room/__snapshots__/InCallView.test.tsx.snap
@@ -104,6 +104,7 @@ exports[`InCallView > rendering > renders 1`] = `
     </div>
     <div
       class="fixedGrid grid"
+      style="inset-block-start: NaNpx;"
     >
       <div />
     </div>

--- a/src/state/CallViewModel/CallViewModel.ts
+++ b/src/state/CallViewModel/CallViewModel.ts
@@ -1070,10 +1070,12 @@ export function createCallViewModel$(
     }),
   );
 
-  const spotlightLandscapeLayoutMedia$: Observable<SpotlightLandscapeLayoutMedia> =
+  const spotlightLandscapeLayoutMedia$ = (
+    edgeToEdge: boolean,
+  ): Observable<SpotlightLandscapeLayoutMedia> =>
     combineLatest([grid$, spotlight$], (grid, spotlight) => ({
       type: "spotlight-landscape",
-      edgeToEdge: false,
+      edgeToEdge,
       spotlight,
       grid,
     }));
@@ -1208,7 +1210,7 @@ export function createCallViewModel$(
                       switchMap((expanded) =>
                         expanded
                           ? spotlightExpandedLayoutMedia$(false)
-                          : spotlightLandscapeLayoutMedia$,
+                          : spotlightLandscapeLayoutMedia$(false),
                       ),
                     );
                 }
@@ -1234,7 +1236,7 @@ export function createCallViewModel$(
                   case "grid":
                     // Yes, grid mode actually gets you a "spotlight" layout in
                     // this window mode.
-                    return spotlightLandscapeLayoutMedia$;
+                    return spotlightLandscapeLayoutMedia$(true);
                   case "spotlight":
                     return spotlightExpandedLayoutMedia$(true);
                 }

--- a/src/state/layout-types.ts
+++ b/src/state/layout-types.ts
@@ -26,7 +26,7 @@ export interface GridLayoutMedia {
 
 export interface SpotlightLandscapeLayoutMedia {
   type: "spotlight-landscape";
-  edgeToEdge: false;
+  edgeToEdge: boolean;
   spotlight: MediaViewModel[];
   grid: UserMediaViewModel[];
 }


### PR DESCRIPTION
8324ce2ce097d1ea2c52ac024ff6ba2daf75c2a3 fixes the following issue with the spotlight tile overlapping the app bar in mobile group calls:

<img width="380" height="844" alt="Screenshot_20260520-150153_Element X dbg" src="https://github.com/user-attachments/assets/8ef552b3-933d-4868-8e0b-c7152420f05c" />

8d07d552d79a53bf852dc196d0de060664f64935 fixes the fact that you could not tap to hide the footer anymore in the following landscape mobile layout:

<img width="627" height="317" alt="Screenshot From 2026-05-20 16-34-04" src="https://github.com/user-attachments/assets/1c51d398-f647-4ca0-a79b-3246da95b5a5" />