### PR TITLE
Fix corner radius on screenshare overlay in widget mode

### DIFF
--- a/src/grid/TileWrapper.module.css
+++ b/src/grid/TileWrapper.module.css
@@ -7,7 +7,7 @@ Please see LICENSE in the repository root for full details.
 
 .tile.draggable {
   cursor: grab;
-  box-shadow: var(--big-drop-shadow);
+  --draggable-shadow: var(--big-drop-shadow);
 }
 
 .tile.draggable:active {

--- a/src/tile/GridTile.module.css
+++ b/src/tile/GridTile.module.css
@@ -10,6 +10,7 @@ Please see LICENSE in the repository root for full details.
   --hover-space-margin: var(--cpd-space-1x);
   transition: outline-color ease 0.15s;
   outline: var(--cpd-border-width-2) solid rgb(0 0 0 / 0);
+  box-shadow: var(--draggable-shadow);
 }
 
 /* Use a pseudo-element to create the expressive speaking border, since CSS

--- a/src/tile/SpotlightTile.module.css
+++ b/src/tile/SpotlightTile.module.css
@@ -10,6 +10,7 @@ Please see LICENSE in the repository root for full details.
   inline-size: 100%;
   display: flex;
   border-radius: var(--cpd-space-6x);
+  box-shadow: var(--draggable-shadow);
   contain: strict;
   overflow-x: auto;
   overflow-y: hidden;


### PR DESCRIPTION
## Content

When in widget mode in Element Web and screensharing, the screenshare overlay appears to be missing the corner radius on its tile container which creates an odd box (I think possibly due to the shadow). This change applies the same corner radius to the tile.

I couldn't find any negative side effects of this but it's possible that I've missed something.

There's a separate issue with the corners and black spacing inside the screenshare overlay. This is not addressed in this change.

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

|Before|After|
|-|-|
|<img width="857" height="759" alt="Screenshot 2026-06-01 at 09 07 51" src="https://github.com/user-attachments/assets/f4a53507-d454-41b1-a37e-df50f828a49c" />|<img width="851" height="761" alt="Screenshot 2026-06-01 at 09 08 02" src="https://github.com/user-attachments/assets/91f2440a-1530-4eda-add0-dc8b91cecd96" />|

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...
-

## Checklist

- [ ] I have read through [CONTRIBUTING.md](https://github.com/element-hq/element-call/blob/livekit/CONTRIBUTING.md).
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Tests written for new code (and old code if feasible).
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-call)
