### PR TITLE
Fix missing text color for remote raised hand duration

### DIFF
--- a/src/reactions/ReactionIndicator.module.css
+++ b/src/reactions/ReactionIndicator.module.css
@@ -1,9 +1,9 @@
 .reactionIndicatorWidget {
   display: flex;
-  background-color: #00000030;
   border-radius: var(--cpd-radius-pill-effect);
   box-shadow: 0 0 var(--cpd-space-2x) #00000040;
-  background: "ffffff40";
+  color: var(--cpd-color-text-on-solid-primary);
+  background: var(--cpd-color-icon-secondary-alpha);
   backdrop-filter: blur(10px);
   outline: var(--cpd-border-width-1) solid var(--cpd-color-alpha-gray-400);
   outline-offset: calc(-1 * var(--cpd-border-width-1));
@@ -33,7 +33,6 @@
 
 .reaction {
   margin: var(--cpd-space-1x);
-  color: white;
   display: flex;
   align-items: center;
   border-radius: var(--cpd-radius-pill-effect);


### PR DESCRIPTION
Fixes: https://github.com/element-hq/voip-internal/issues/579

<!-- Thanks for submitting a PR! Please read CONTRIBUTING.md before you start. -->

> [!IMPORTANT]
> **Features and UI changes require a pre-approved issue.**
> Every PR must have a linked issue
> that a maintainer has reviewed and approved **before you started writing code**.
> PRs that don't meet this requirement will not be reviewed.
> See [CONTRIBUTING.md](https://github.com/element-hq/element-call/blob/livekit/CONTRIBUTING.md) for ElementCall decided for this approach.

## Content

The `color` property in the reaction indicator styles was moved from `.reaction` to `.reactionIndicatorWidget`.

## Motivation and context

`RaisedHandIndicator` adds the duration label as a child into `ReactionIndicator`. Inside `ReactionIndicator` the children are siblings to the reaction container. The latter already had `color: white` applied. Since there is nothing else in the indicator, moving the `color` property to the main class seemed acceptable.

Otherwise, the lack of a `color` property on the duration label means it is inherited from its parents. For your own raised hand indicator the closest colorful parent is the button. For remote indicators it seems to end up being the main `body`.

## Screenshots / GIFs

|Before|After|
|-|-|
|<img width="1096" height="653" alt="Screenshot 2026-06-03 at 15 32 20" src="https://github.com/user-attachments/assets/b80e7e1a-6f46-4591-9eab-241252d9c317" />|<img width="1095" height="653" alt="Screenshot 2026-06-03 at 15 32 03" src="https://github.com/user-attachments/assets/7f33f5de-98dd-456e-9199-fd53c1fa6c15" />|

## Tests

See issue.

## Checklist

- [x] A linked, pre-approved issue exists for this feature or UI change.
- [x] I have read [CONTRIBUTING.md](https://github.com/element-hq/element-call/blob/livekit/CONTRIBUTING.md) in full.
- [x] Pull request includes screenshots or videos for any UI changes.
- [x] Tests written for new code (and existing touched code where feasible).
- [ ] Linter and other CI checks pass.
- [x] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-call)
