### PR TITLE
fix: announce tab count and position in settings tab bar

### DIFF
--- a/src/tabs/Tabs.test.tsx
+++ b/src/tabs/Tabs.test.tsx
@@ -1,0 +1,124 @@
+/*
+Copyright 2026 New Vector Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE in the repository root for full details.
+*/
+
+import { expect, it, vi } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { type Tab, TabContainer } from "./Tabs";
+
+function renderTabs<K extends string>(tabs: Tab<K>[], tab: K): void {
+  render(
+    <TabContainer
+      label="Settings"
+      tab={tab}
+      onTabChange={vi.fn()}
+      tabs={tabs}
+    />,
+  );
+}
+
+function expectTabPositions(expectedNames: string[]): void {
+  const tabs = within(
+    screen.getByRole("tablist", { name: "Settings" }),
+  ).getAllByRole("tab");
+
+  expect(tabs).toHaveLength(expectedNames.length);
+  tabs.forEach((tab, index) => {
+    expect(tab).toHaveTextContent(expectedNames[index]);
+    expect(tab).toHaveAttribute(
+      "aria-setsize",
+      expectedNames.length.toString(),
+    );
+    expect(tab).toHaveAttribute("aria-posinset", (index + 1).toString());
+  });
+}
+
+it("sets tab collection size and positions for two tabs", () => {
+  renderTabs(
+    [
+      { key: "audio", name: "Audio", content: "Audio panel" },
+      { key: "video", name: "Video", content: "Video panel" },
+    ],
+    "audio",
+  );
+
+  expectTabPositions(["Audio", "Video"]);
+});
+
+it("sets tab collection size and positions for four tabs", () => {
+  renderTabs(
+    [
+      { key: "audio", name: "Audio", content: "Audio panel" },
+      { key: "video", name: "Video", content: "Video panel" },
+      { key: "profile", name: "Profile", content: "Profile panel" },
+      {
+        key: "preferences",
+        name: "Preferences",
+        content: "Preferences panel",
+      },
+    ],
+    "profile",
+  );
+
+  expectTabPositions(["Audio", "Video", "Profile", "Preferences"]);
+});
+
+it("fires tab changes and keeps the active tab selected", async () => {
+  const user = userEvent.setup();
+  const onTabChange = vi.fn();
+  const tabs = [
+    { key: "audio", name: "Audio", content: "Audio panel" },
+    { key: "video", name: "Video", content: "Video panel" },
+  ] satisfies Tab<string>[];
+
+  const { rerender } = render(
+    <TabContainer
+      label="Settings"
+      tab="audio"
+      onTabChange={onTabChange}
+      tabs={tabs}
+    />,
+  );
+
+  expect(screen.getByRole("tab", { name: "Audio" })).toHaveAttribute(
+    "aria-selected",
+    "true",
+  );
+
+  await user.click(screen.getByRole("tab", { name: "Video" }));
+  expect(onTabChange).toHaveBeenCalledWith("video");
+
+  rerender(
+    <TabContainer
+      label="Settings"
+      tab="video"
+      onTabChange={onTabChange}
+      tabs={tabs}
+    />,
+  );
+
+  expect(screen.getByRole("tab", { name: "Video" })).toHaveAttribute(
+    "aria-selected",
+    "true",
+  );
+});
+
+it("only shows the selected tab panel", () => {
+  renderTabs(
+    [
+      { key: "audio", name: "Audio", content: "Audio panel" },
+      { key: "video", name: "Video", content: "Video panel" },
+      { key: "profile", name: "Profile", content: "Profile panel" },
+    ],
+    "video",
+  );
+
+  expect(screen.getByText("Audio panel")).not.toBeVisible();
+  expect(screen.getByText("Video panel")).toBeVisible();
+  expect(screen.getByText("Profile panel")).not.toBeVisible();
+});

--- a/src/tabs/Tabs.tsx
+++ b/src/tabs/Tabs.tsx
@@ -34,10 +34,12 @@ export function TabContainer<K extends Key>({
   return (
     <div className={styles.tabContainer}>
       <NavBar role="tablist" aria-label={label} className={styles.tabList}>
-        {tabs.map(({ key, name }) => (
+        {tabs.map(({ key, name }, index) => (
           <NavItem
             key={key}
             aria-controls={`${idPrefix}[${key}]`}
+            aria-posinset={index + 1}
+            aria-setsize={tabs.length}
             onClick={() => onTabChange(key)}
             active={key === tab}
           >


### PR DESCRIPTION
## Content

The settings tab bar now announces each tab's count and position to assistive technology via `aria-setsize` and `aria-posinset`, so screen-reader users hear "tab 2 of 4" instead of an unpositioned list.

## Motivation and context

Closes #3915 (T-Defect): the settings tab bar rendered tabs without positional ARIA metadata, so screen readers could not convey how many tabs exist or which one is focused. This adds `aria-setsize` (total tab count) and `aria-posinset` (1-based index) to each rendered tab in `src/tabs/Tabs.tsx`.

## Screenshots / GIFs

No visual change. This is an accessibility-only change (ARIA attributes); there is nothing new to show on screen.

## Tests

- Added `src/tabs/Tabs.test.tsx` asserting each tab exposes the correct `aria-posinset`/`aria-setsize`, that selection state is reflected, and that the matching panel is visible.

## Checklist

- [x] A linked, pre-approved issue exists (T-Defect bug #3915; per CONTRIBUTING.md bug fixes carry implicit maintainer approval)
- [x] I have read CONTRIBUTING.md in full
- [x] Pull request includes screenshots or videos for any UI changes (n/a, accessibility-only change with no visual difference)
- [x] Tests written for new code
- [x] Linter and other CI checks pass
- [x] I have licensed the changes to Element by completing the Contributor License Agreement (CLA)

AI was used for assistance.
