### PR TITLE
Remove deprecated @types/content-type dependency

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -24,11 +24,6 @@ export default {
     "normalize.css",
     // Used for its global type declarations
     "@types/grecaptcha",
-    // Because we use matrix-js-sdk as a Git dependency rather than consuming
-    // the proper release artifacts, and also import directly from src/, we're
-    // forced to re-install some of the types that it depends on even though
-    // these look unused to Knip
-    "@types/content-type",
     "@types/sdp-transform",
     // We obviously use this, but if the package has been linked with pnpm link,
     // then Knip will flag it as a false positive

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.0.0",
     "@testing-library/user-event": "^14.5.1",
-    "@types/content-type": "^1.1.5",
     "@types/grecaptcha": "^3.0.9",
     "@types/jsdom": "^21.1.7",
     "@types/lodash-es": "^4.17.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,9 +105,6 @@ importers:
       '@testing-library/user-event':
         specifier: ^14.5.1
         version: 14.6.1(@testing-library/dom@10.4.1)
-      '@types/content-type':
-        specifier: ^1.1.5
-        version: 1.1.9
       '@types/grecaptcha':
         specifier: ^3.0.9
         version: 3.0.9
@@ -3697,9 +3694,6 @@ packages:
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
-
-  '@types/content-type@1.1.9':
-    resolution: {integrity: sha512-Hq9IMnfekuOCsEmYl4QX2HBrT+XsfXiupfrLLY8Dcf3Puf4BkBOxSbWYTITSOQAhJoYPBez+b4MJRpIYL65z8A==}
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
@@ -10857,8 +10851,6 @@ snapshots:
     dependencies:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
-
-  '@types/content-type@1.1.9': {}
 
   '@types/deep-eql@4.0.2': {}
 


### PR DESCRIPTION
`@types/content-type` is deprecated as per https://www.npmjs.com/package/@types/content-type. The types seem to now ship with `content-type` itself which we seem to inherit as a dependency from the JS SDK.