### PR TITLE
Fix Logging indexDB EC/EW collision

### DIFF
--- a/src/settings/rageshake.ts
+++ b/src/settings/rageshake.ts
@@ -149,7 +149,7 @@ class IndexedDBLogStore {
    * @return Resolves when the store is ready.
    */
   public async connect(): Promise<void> {
-    const req = this.indexedDB.open("logs");
+    const req = this.indexedDB.open("logs-element-call");
     return new Promise((resolve, reject) => {
       req.onsuccess = (): void => {
         this.db = req.result;


### PR DESCRIPTION
The issue with the logger is caused by EC using the same domain as EW (develop.element.io) so they end up using the same indexdb scope.
And they also (mistakingly) use the same logs db name.
This has not bothered us before since we were using call.element.io. But now with embedded mode we use the same DB which can lead to collisions with EWs logs.