### PR TITLE
Output the actual command for triggering prettier -w

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -17,6 +17,8 @@ export default {
     // installed binary. TODO We should switch to Compose v2:
     // https://docs.docker.com/compose/migrate/
     "docker-compose",
+    // Shell builtin, not a binary
+    "printf",
   ],
   ignoreFiles: ["scripts/.pnpmfile.cjs"],
   ignoreDependencies: [

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build:sdk": "pnpm build:full --config vite-sdk.config.js",
     "build:sdk:production": "pnpm build:sdk",
     "serve": "vite preview",
-    "prettier:check": "prettier -c .",
+    "prettier:check": "prettier -c .; EC=$?; [ $EC -ne 0 ] && printf '[\\033[33mwarn\\033[0m] To fix, run: pnpm run prettier:format\\n' >&2; exit $EC",
     "prettier:format": "prettier -w .",
     "lint": "pnpm lint:types && pnpm lint:eslint && pnpm lint:knip",
     "lint:eslint": "eslint --max-warnings 0 src playwright",


### PR DESCRIPTION
Maybe this is just me but I occasionally run into prettier errors and am then annoyed because it tells me to invoke prettier with `--write` but doesn't give me the pnpm command.

This change simply outputs our custom command if the check fails for convenience.