### PR TITLE
Show the subtitle of the app bar on small screens

### DIFF
--- a/src/AppBar.module.css
+++ b/src/AppBar.module.css
@@ -67,6 +67,27 @@
     "subtitle subtitle subtitle";
 }
 
+/* Hide everything but the subtitle in small windows */
+@media (max-height: 450px) {
+  .bar {
+    display: none;
+    .title,
+    .primaryButton,
+    .secondaryButton {
+      display: none;
+    }
+  }
+
+  .bar:has(.subtitle) {
+    display: initial;
+    > header {
+      grid-template-columns: 1fr;
+      grid-template-rows: var(--cpd-space-5x) minmax(var(--cpd-space-5x), auto);
+      grid-template-areas: "." "subtitle";
+    }
+  }
+}
+
 .primaryButton {
   grid-area: primaryButton;
   justify-self: start;
@@ -139,6 +160,28 @@ body[data-platform="ios"] {
 
     svg {
       display: none;
+    }
+  }
+
+  /* Hide everything but the subtitle in small windows */
+  @media (max-height: 450px) {
+    .bar {
+      display: none;
+    }
+
+    .bar:has(.subtitle) {
+      display: initial;
+      > header {
+        grid-template-rows: var(--cpd-space-4x) minmax(
+            var(--cpd-space-5x),
+            auto
+          );
+        grid-template-areas: "." "subtitle";
+      }
+    }
+
+    .subtitle {
+      color: var(--cpd-color-text-primary);
     }
   }
 }

--- a/src/AppBar.module.css
+++ b/src/AppBar.module.css
@@ -167,19 +167,9 @@ body[data-platform="ios"] {
 
   /* Hide everything but the subtitle in small windows */
   @media (max-height: 450px) {
-    .bar {
-      display: none;
-    }
-
-    .bar:has(.subtitle) {
-      display: initial;
-      > header {
-        grid-template-rows: var(--cpd-space-4x) minmax(
-            var(--cpd-space-5x),
-            auto
-          );
-        grid-template-areas: "." "subtitle";
-      }
+    .bar:has(.subtitle) > header {
+      grid-template-rows: var(--cpd-space-4x) minmax(var(--cpd-space-5x), auto);
+      grid-template-areas: "." "subtitle";
     }
 
     .subtitle {

--- a/src/AppBar.module.css
+++ b/src/AppBar.module.css
@@ -71,15 +71,17 @@
 @media (max-height: 450px) {
   .bar {
     display: none;
+  }
+
+  .bar:has(.subtitle) {
+    display: initial;
+
     .title,
     .primaryButton,
     .secondaryButton {
       display: none;
     }
-  }
 
-  .bar:has(.subtitle) {
-    display: initial;
     > header {
       grid-template-columns: 1fr;
       grid-template-rows: var(--cpd-space-5x) minmax(var(--cpd-space-5x), auto);

--- a/src/state/CallViewModel/CallViewModel.ts
+++ b/src/state/CallViewModel/CallViewModel.ts
@@ -1424,7 +1424,7 @@ export function createCallViewModel$(
     windowMode$.pipe(
       switchMap((mode) => {
         // In small windows the header would be too obstructive
-        if (mode === "pip" || mode === "flat") return of(false);
+        if (mode === "pip") return of(false);
         // In edge-to-edge layouts, couple the visibility of the header
         // to that of the footer
         return edgeToEdge$.pipe(


### PR DESCRIPTION
Previously we were hiding the entire app bar on mobile phones in landscape orientation. However now that the app bar supports a small 'subtitle' element, we should show only the subtitle in this case to match the designs.

||Before|After|
|-|-|-|
|Android|<img width="350" alt="Screen Shot 2026-06-22 at 18 19 00" src="https://github.com/user-attachments/assets/d7be9a65-5c4b-4715-bef3-585ddeb4eb03" />|<img width="350" alt="Screen Shot 2026-06-22 at 18 19 35" src="https://github.com/user-attachments/assets/1f2fc682-d1eb-4e7a-a4a6-41ca6cf85762" />|
|iOS|<img width="350" alt="Screen Shot 2026-06-22 at 18 18 34" src="https://github.com/user-attachments/assets/271f0fb4-91ad-4c3c-8d69-c2d8e693d62d" />|<img width="350" alt="Screen Shot 2026-06-22 at 18 18 08" src="https://github.com/user-attachments/assets/2e7eab6f-3526-40b9-aaa3-6ef75596cb93" />|

The subtitle still hides on tap, just like the footer.