### PR TITLE
Default to compatibilty mode (multi sfu) - non breaking, as multi-sfu is compatible with all versions younger 6 month

### DIFF
--- a/config/config.sample.json
+++ b/config/config.sample.json
@@ -12,7 +12,7 @@
     "feature_use_device_session_member_events": true
   },
   "ssla": "https://static.element.io/legal/element-software-and-services-license-agreement-uk-1.pdf",
-  "matrix_rtc_mode": "legacy",
+  "matrix_rtc_mode": "compatibility",
   "matrix_rtc_session": {
     "wait_for_key_rotation_ms": 3000,
     "membership_event_expiry_ms": 180000000,

--- a/playwright/sfu-reconnect-bug.spec.ts
+++ b/playwright/sfu-reconnect-bug.spec.ts
@@ -6,6 +6,7 @@ Please see LICENSE in the repository root for full details.
 */
 
 import { expect, test } from "@playwright/test";
+import { logger } from "matrix-js-sdk/lib/logger";
 
 test("When creator left, avoid reconnect to the same SFU", async ({
   browser,
@@ -88,15 +89,18 @@ test("When creator left, avoid reconnect to the same SFU", async ({
   await guestCPage.getByRole("radio", { name: "Spotlight" }).check();
 
   await guestCPage.waitForTimeout(1000);
-
+  if (wsConnectionCount === 2) {
+    logger.warn("wsConnectionCount is 2, expecting 1 after join")
+  }
+  const wsConnectionCountBeforeLeave = wsConnectionCount;
   // ========
   // the creator leaves the call
   await creatorPage.getByTestId("incall_leave").click();
 
   // https://github.com/element-hq/element-call/issues/3344
   // The app used to request a new jwt token then to reconnect to the SFU
-  expect(wsConnectionCount).toBe(1);
+  expect(wsConnectionCount).toBe(wsConnectionCountBeforeLeave);
   // Wait a bit to be sure that if there was a reconnect, it would have happened by now
   await guestCPage.waitForTimeout(6000);
-  expect(wsConnectionCount).toBe(1);
+  expect(wsConnectionCount).toBe(wsConnectionCountBeforeLeave);
 });

--- a/playwright/sfu-reconnect-bug.spec.ts
+++ b/playwright/sfu-reconnect-bug.spec.ts
@@ -90,7 +90,7 @@ test("When creator left, avoid reconnect to the same SFU", async ({
 
   await guestCPage.waitForTimeout(1000);
   if (wsConnectionCount === 2) {
-    logger.warn("wsConnectionCount is 2, expecting 1 after join")
+    logger.warn("wsConnectionCount is 2, expecting 1 after join");
   }
   const wsConnectionCountBeforeLeave = wsConnectionCount;
   // ========

--- a/playwright/sfu-reconnect-bug.spec.ts
+++ b/playwright/sfu-reconnect-bug.spec.ts
@@ -6,7 +6,6 @@ Please see LICENSE in the repository root for full details.
 */
 
 import { expect, test } from "@playwright/test";
-import { logger } from "matrix-js-sdk/lib/logger";
 
 test("When creator left, avoid reconnect to the same SFU", async ({
   browser,
@@ -90,7 +89,7 @@ test("When creator left, avoid reconnect to the same SFU", async ({
 
   await guestCPage.waitForTimeout(1000);
   if (wsConnectionCount === 2) {
-    logger.warn("wsConnectionCount is 2, expecting 1 after join");
+    console.warn("wsConnectionCount is 2, expecting 1 after join");
   }
   const wsConnectionCountBeforeLeave = wsConnectionCount;
   // ========

--- a/src/settings/__snapshots__/DeveloperSettingsTab.test.tsx.snap
+++ b/src/settings/__snapshots__/DeveloperSettingsTab.test.tsx.snap
@@ -274,7 +274,6 @@ exports[`DeveloperSettingsTab > renders and matches snapshot 1`] = `
         >
           <input
             aria-describedby="radix-_r_a_ radix-_r_c_ radix-_r_e_"
-            checked=""
             class="_input_1ug7n_18"
             id="radix-_r_9_"
             name="_r_0_"
@@ -315,6 +314,7 @@ exports[`DeveloperSettingsTab > renders and matches snapshot 1`] = `
         >
           <input
             aria-describedby="radix-_r_a_ radix-_r_c_ radix-_r_e_"
+            checked=""
             class="_input_1ug7n_18"
             id="radix-_r_b_"
             name="_r_0_"

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -137,7 +137,7 @@ export const enableExtendedLivekitLogs = new Setting<boolean>(
 
 export const matrixRTCMode = new Setting<MatrixRTCMode>(
   "matrix-rtc-mode",
-  MatrixRTCMode.Legacy,
+  MatrixRTCMode.Compatibility,
 );
 
 export const customLivekitUrl = new Setting<string | null>(


### PR DESCRIPTION
Fixes: https://github.com/element-hq/voip-internal/issues/619

Lets unleash all the SFU's.

This can only get merged once we have a TWIM post:
```
This week we do a small but significant change in Element Call.
From now on, we will be using the multi-sfu approach for our video and voice calls.
This is a noval approach introduced at one of Elements, "How Hard Can It Be" hackathon.
The big advantage is that is mitigates any negotiation on which SFU the users in a call "meet".
Instead everyone connects to the SFU associated with their Homeserver. No negotiation required.

If I want to subscribe to a stream from someone on a different homeserver Element Call will connect to that
SFU in an subscribe only mode.

With the next version of Element Call there will be no more SFU negotiations by default.
You still have the option to switch back to legacy mode using the developer settings tab.

EC is compatible with this mode since 6month already. So the whole ecosystem should be updated by now and this
should not lead to any incompatiblities.

Of course this requires every call participant to have an SFU associated with their homeserver if they want to participante in a session.
Since we already have checks in place so only usres with an SFU can join a call, this should not make a difference for anyone already on the latest versions.
```
