### PR TITLE
fix getChild before rageshake setup

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -34,6 +34,7 @@
       "/*\nCopyright %%CURRENT_YEAR%% Element Creations Ltd.\n\nSPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial\nPlease see LICENSE in the repository root for full details.\n*/\n\n"
     ],
     "element-call/no-observablescope-leak": "error",
+    "element-call/no-top-level-logger-get-child": "error",
     "jsdoc/empty-tags": "error",
     "jsdoc/check-property-names": "error",
     "jsdoc/require-param-description": "warn",

--- a/eslint/NoTopLevelLoggerGetChild.js
+++ b/eslint/NoTopLevelLoggerGetChild.js
@@ -1,0 +1,92 @@
+/*
+Copyright 2026 Element Creations Ltd.
+
+SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-Element-Commercial
+Please see LICENSE in the repository root for full details.
+*/
+
+import { ESLintUtils } from "@typescript-eslint/utils";
+
+/**
+ * Node types that introduce a new non-module scope. A getChild() call nested
+ * inside any of these is considered "not at the top level".
+ */
+const FUNCTION_OR_CLASS_TYPES = new Set([
+  "FunctionDeclaration",
+  "FunctionExpression",
+  "ArrowFunctionExpression",
+  "ClassBody",
+]);
+
+const rule = ESLintUtils.RuleCreator(
+  () => "https://github.com/element-hq/element-call",
+)({
+  name: "no-top-level-logger-get-child",
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+      "Disallow calling logger.getChild() at the top level of a module." +
+      "`getChild` has to be called after the rageshake logger `init()`." +
+      "If it is called at the top level the child logger will never be setup for rageshakes.",
+    },
+    messages: {
+      noTopLevelGetChild:
+        "Do not call logger.getChild() at the top level of a module; move it inside a function or class instead that gets called after rageshake logger `init()` is called.",
+    },
+    schema: [],
+  },
+  create(context) {
+    // Tracks the local binding names that refer to the logger imported from
+    // 'matrix-js-sdk/lib/logger', e.g. both `logger` and `rootLogger` in:
+    //   import { logger } from "matrix-js-sdk/lib/logger";
+    //   import { logger as rootLogger } from "matrix-js-sdk/lib/logger";
+    const loggerNames = new Set();
+
+    return {
+      ImportDeclaration(node) {
+        if (node.source.value !== "matrix-js-sdk/lib/logger") return;
+        for (const specifier of node.specifiers) {
+          if (
+            specifier.type === "ImportSpecifier" &&
+            specifier.imported.name === "logger"
+          ) {
+            loggerNames.add(specifier.local.name);
+          }
+        }
+      },
+
+      CallExpression(node) {
+        // Must be a non-computed member expression call: something.getChild(...)
+        if (
+          node.callee.type !== "MemberExpression" ||
+          node.callee.computed ||
+          node.callee.property.type !== "Identifier" ||
+          node.callee.property.name !== "getChild"
+        )
+          return;
+
+        // The receiver must be one of the tracked logger names.
+        const object = node.callee.object;
+        if (object.type !== "Identifier" || !loggerNames.has(object.name))
+          return;
+
+        // Flag the call only when it is at module top level — i.e. there is no
+        // enclosing function or class body anywhere in the ancestor chain.
+        const ancestors = context.sourceCode.getAncestors(node);
+        const isTopLevel = !ancestors.some((a) =>
+          FUNCTION_OR_CLASS_TYPES.has(a.type),
+        );
+
+        if (isTopLevel) {
+          context.report({
+            messageId: "noTopLevelGetChild",
+            node,
+          });
+        }
+      },
+    };
+  },
+});
+
+export default rule;

--- a/eslint/NoTopLevelLoggerGetChild.js
+++ b/eslint/NoTopLevelLoggerGetChild.js
@@ -26,9 +26,9 @@ const rule = ESLintUtils.RuleCreator(
     type: "problem",
     docs: {
       description:
-      "Disallow calling logger.getChild() at the top level of a module." +
-      "`getChild` has to be called after the rageshake logger `init()`." +
-      "If it is called at the top level the child logger will never be setup for rageshakes.",
+        "Disallow calling logger.getChild() at the top level of a module." +
+        "`getChild` has to be called after the rageshake logger `init()`." +
+        "If it is called at the top level the child logger will never be setup for rageshakes.",
     },
     messages: {
       noTopLevelGetChild:

--- a/eslint/index.js
+++ b/eslint/index.js
@@ -2,6 +2,7 @@ module.exports = {
   rules: {
     "copyright-header": require("./CopyrightHeader").default,
     "no-observablescope-leak": require("./NoObservableScopeLeak").default,
-    "no-top-level-logger-get-child": require("./NoTopLevelLoggerGetChild").default,
+    "no-top-level-logger-get-child": require("./NoTopLevelLoggerGetChild")
+      .default,
   },
 };

--- a/eslint/index.js
+++ b/eslint/index.js
@@ -2,5 +2,6 @@ module.exports = {
   rules: {
     "copyright-header": require("./CopyrightHeader").default,
     "no-observablescope-leak": require("./NoObservableScopeLeak").default,
+    "no-top-level-logger-get-child": require("./NoTopLevelLoggerGetChild").default,
   },
 };

--- a/sdk/helper.ts
+++ b/sdk/helper.ts
@@ -15,9 +15,9 @@ import { scan } from "rxjs";
 import { type WidgetHelpers } from "../src/widget";
 import { type LivekitRoomItem } from "../src/state/CallViewModel/CallViewModel";
 
-export const logger = rootLogger.getChild("[MatrixRTCSdk]");
 
 export const tryMakeSticky = (widget: WidgetHelpers): void => {
+  const logger = rootLogger.getChild("[MatrixRTCSdk]");
   logger.info("try making sticky MatrixRTCSdk");
   void widget.api
     .setAlwaysOnScreen(true)

--- a/sdk/helper.ts
+++ b/sdk/helper.ts
@@ -15,7 +15,6 @@ import { scan } from "rxjs";
 import { type WidgetHelpers } from "../src/widget";
 import { type LivekitRoomItem } from "../src/state/CallViewModel/CallViewModel";
 
-
 export const tryMakeSticky = (widget: WidgetHelpers): void => {
   const logger = rootLogger.getChild("[MatrixRTCSdk]");
   logger.info("try making sticky MatrixRTCSdk");

--- a/sdk/main.ts
+++ b/sdk/main.ts
@@ -53,7 +53,7 @@ import { MuteStates } from "../src/state/MuteStates";
 import { MediaDevices } from "../src/state/MediaDevices";
 import { E2eeType } from "../src/e2ee/e2eeType";
 import { currentAndPrev, TEXT_LK_TOPIC, tryMakeSticky } from "./helper";
-import {logger as rootLogger} from "matrix-js-sdk/lib/logger"
+import { logger as rootLogger } from "matrix-js-sdk/lib/logger";
 import {
   ElementWidgetActions,
   widget as _widget,

--- a/sdk/main.ts
+++ b/sdk/main.ts
@@ -52,7 +52,8 @@ import { getUrlParams } from "../src/UrlParams";
 import { MuteStates } from "../src/state/MuteStates";
 import { MediaDevices } from "../src/state/MediaDevices";
 import { E2eeType } from "../src/e2ee/e2eeType";
-import { currentAndPrev, logger, TEXT_LK_TOPIC, tryMakeSticky } from "./helper";
+import { currentAndPrev, TEXT_LK_TOPIC, tryMakeSticky } from "./helper";
+import {logger as rootLogger} from "matrix-js-sdk/lib/logger"
 import {
   ElementWidgetActions,
   widget as _widget,
@@ -104,6 +105,7 @@ export async function createMatrixRTCSdk(
   id: string = "",
   sticky: boolean = false,
 ): Promise<MatrixRTCSdk> {
+  const logger = rootLogger.getChild("[MatrixRTCSdk]");
   const scope = new ObservableScope();
 
   // widget client

--- a/src/e2ee/matrixKeyProvider.ts
+++ b/src/e2ee/matrixKeyProvider.ts
@@ -10,15 +10,15 @@ import {
   type MatrixRTCSession,
   MatrixRTCSessionEvent,
 } from "matrix-js-sdk/lib/matrixrtc";
-import { logger as rootLogger } from "matrix-js-sdk/lib/logger";
+import { logger as rootLogger, type Logger } from "matrix-js-sdk/lib/logger";
 import { type CallMembershipIdentityParts } from "matrix-js-sdk/lib/matrixrtc/EncryptionManager";
-const logger = rootLogger.getChild("[MatrixKeyProvider]");
 
 export class MatrixKeyProvider extends BaseKeyProvider {
   private rtcSession?: MatrixRTCSession;
-
+  private logger: Logger;
   public constructor() {
     super({ ratchetWindowSize: 10, keyringSize: 256 });
+    this.logger = rootLogger.getChild("[MatrixKeyProvider]");
   }
 
   public setRTCSession(rtcSession: MatrixRTCSession): void {
@@ -60,12 +60,12 @@ export class MatrixKeyProvider extends BaseKeyProvider {
             encryptionKeyIndex,
           );
 
-          logger.debug(
+          this.logger.debug(
             `Sent new key to livekit room=${this.rtcSession?.room.roomId} participantId=${rtcBackendIdentity} (before hash: ${membershipParts.userId}:${membershipParts.deviceId}) encryptionKeyIndex=${encryptionKeyIndex}`,
           );
         },
         (e) => {
-          logger.error(
+          this.logger.error(
             `Failed to create key material from buffer for livekit room=${this.rtcSession?.room.roomId} participantId before hash=${membershipParts.userId}:${membershipParts.deviceId} encryptionKeyIndex=${encryptionKeyIndex}`,
             e,
           );

--- a/src/livekit/MatrixAudioRenderer.tsx
+++ b/src/livekit/MatrixAudioRenderer.tsx
@@ -14,7 +14,7 @@ import {
   AudioTrack,
   type AudioTrackProps,
 } from "@livekit/components-react";
-import { logger } from "matrix-js-sdk/lib/logger";
+import { logger as rootLogger } from "matrix-js-sdk/lib/logger";
 
 import { useEarpieceAudioConfig } from "../MediaDevicesContext";
 import { useReactiveState } from "../useReactiveState";
@@ -59,7 +59,7 @@ export function LivekitRoomAudioRenderer({
   validIdentities,
   muted,
 }: MatrixAudioRendererProps): ReactNode {
-  const prefixedLogger = logger.getChild("[MatrixAudioRenderer]");
+  const logger = rootLogger.getChild("[MatrixAudioRenderer]");
   const tracks = useTracks(
     [
       Track.Source.Microphone,
@@ -80,7 +80,7 @@ export function LivekitRoomAudioRenderer({
       if (!isValid) {
         // TODO make sure to also skip the warn logging for the local identity
         // Log that there is an invalid identity, that means that someone is publishing audio that is not expected to be in the call.
-        prefixedLogger.warn(
+        logger.warn(
           `Audio track ${ref.participant.identity} from ${url} has no matching matrix call member`,
           `current members: ${validIdentities.join()}`,
           `track will not get rendered`,

--- a/src/livekit/MatrixAudioRenderer.tsx
+++ b/src/livekit/MatrixAudioRenderer.tsx
@@ -40,7 +40,6 @@ export interface MatrixAudioRendererProps {
   muted?: boolean;
 }
 
-const prefixedLogger = logger.getChild("[MatrixAudioRenderer]");
 /**
  * Takes care of handling remote participants’ audio tracks and makes sure that microphones and screen share are audible.
  *
@@ -60,6 +59,7 @@ export function LivekitRoomAudioRenderer({
   validIdentities,
   muted,
 }: MatrixAudioRendererProps): ReactNode {
+  const prefixedLogger = logger.getChild("[MatrixAudioRenderer]");
   const tracks = useTracks(
     [
       Track.Source.Microphone,

--- a/src/room/InCallView.tsx
+++ b/src/room/InCallView.tsx
@@ -94,7 +94,7 @@ declare module "react" {
   }
 }
 
-const logger = rootLogger.getChild("[InCallView]");
+
 
 export interface ActiveCallProps extends Omit<
   InCallViewProps,
@@ -116,7 +116,7 @@ export const ActiveCall: FC<ActiveCallProps> = (props) => {
   const mediaDevices = useMediaDevices();
   const trackProcessorState$ = useTrackProcessorObservable$();
   useEffect(() => {
-    logger.info("START CALL VIEW SCOPE");
+    rootLogger.info("START CALL VIEW SCOPE");
     const scope = new ObservableScope();
     const reactionsReader = new ReactionsReader(scope, props.rtcSession);
     const { autoLeaveWhenOthersLeft, waitForCallPickup, sendNotificationType } =
@@ -218,6 +218,7 @@ export const InCallView: FC<InCallViewProps> = ({
   muteStates,
   onShareClick,
 }) => {
+  const logger = rootLogger.getChild("[InCallView]");
   const { t } = useTranslation();
   const { sendReaction, toggleRaisedHand } = useReactionsSender();
 

--- a/src/room/InCallView.tsx
+++ b/src/room/InCallView.tsx
@@ -94,8 +94,6 @@ declare module "react" {
   }
 }
 
-
-
 export interface ActiveCallProps extends Omit<
   InCallViewProps,
   "vm" | "livekitRoom" | "connState" | "footerVm"

--- a/src/settings/rageshake.ts
+++ b/src/settings/rageshake.ts
@@ -467,7 +467,7 @@ declare global {
   // eslint-disable-next-line no-var, camelcase
   var mx_rage_initStoragePromise: Promise<void> | undefined;
 }
-
+export let rageshakeLogger: Logger;
 /**
  * Configure rage shaking support for sending bug reports.
  * Modifies globals.
@@ -477,7 +477,8 @@ export async function init(): Promise<void> {
   global.mx_rage_logger = new ConsoleLogger();
 
   // configure loglevel based loggers:
-  setLogExtension(logger, global.mx_rage_logger.log);
+  rageshakeLogger = logger;
+  setLogExtension(rageshakeLogger, global.mx_rage_logger.log);
 
   // intercept console logging so that we can get matrix_sdk logs:
   // this is nasty, but no logging hooks are provided

--- a/src/state/CallViewModel/CallNotificationLifecycle.ts
+++ b/src/state/CallViewModel/CallNotificationLifecycle.ts
@@ -39,8 +39,6 @@ import { type Behavior } from "../Behavior";
 import { type Epoch, type ObservableScope } from "../ObservableScope";
 import { type RoomMemberMap } from "./remoteMembers/MatrixMemberMetadata";
 
-const logger = rootLogger.getChild("[CallNotificationLifecycle]");
-
 export type AutoLeaveReason = "allOthersLeft" | "timeout" | "decline";
 
 export interface RingAttempt {
@@ -114,6 +112,7 @@ export function createCallNotificationLifecycle$({
    */
   autoLeave$: Observable<AutoLeaveReason>;
 } {
+  const logger = rootLogger.getChild("[CallNotificationLifecycle]");
   let ringAttempts$: Observable<RingAttempt> = NEVER;
   if (options.waitForCallPickup)
     ringAttempts$ = sentCallNotification$.pipe(

--- a/src/state/CallViewModel/CallViewModel.ts
+++ b/src/state/CallViewModel/CallViewModel.ts
@@ -157,7 +157,7 @@ import {
 } from "../media/RingingMediaViewModel.ts";
 import { type GridTileViewModel } from "../TileViewModel.ts";
 
-const logger = rootLogger.getChild("[CallViewModel]");
+
 //TODO
 // Larger rename
 // member,membership -> rtcMember
@@ -411,6 +411,7 @@ export function createCallViewModel$(
   reactionsSubject$: Observable<Record<string, ReactionInfo>>,
   trackProcessorState$: Behavior<ProcessorState>,
 ): CallViewModel {
+  const logger = rootLogger.getChild("[CallViewModel]");
   const client = matrixRoom.client;
   const userId = client.getUserId();
   const deviceId = client.getDeviceId();

--- a/src/state/CallViewModel/CallViewModel.ts
+++ b/src/state/CallViewModel/CallViewModel.ts
@@ -40,7 +40,7 @@ import {
   timer,
   takeUntil,
 } from "rxjs";
-import { logger as rootLogger } from "matrix-js-sdk/lib/logger";
+import { type Logger, logger as rootLogger } from "matrix-js-sdk/lib/logger";
 import {
   MembershipManagerEvent,
   type LivekitTransportConfig,
@@ -156,7 +156,6 @@ import {
   type RingingMediaViewModel,
 } from "../media/RingingMediaViewModel.ts";
 import { type GridTileViewModel } from "../TileViewModel.ts";
-
 
 //TODO
 // Larger rename
@@ -421,6 +420,7 @@ export function createCallViewModel$(
   const livekitKeyProvider = getE2eeKeyProvider(
     options.encryptionSystem,
     matrixRTCSession,
+    logger,
   );
   // matrix_rtc_mode in config.json overrides the user's Developer Settings choice.
   // It is validated at config load (src/config/Config.ts) so the cast is safe.
@@ -1798,6 +1798,7 @@ export function createCallViewModel$(
 function getE2eeKeyProvider(
   e2eeSystem: EncryptionSystem,
   rtcSession: MatrixRTCSession,
+  logger: Logger,
 ): BaseKeyProvider | undefined {
   if (e2eeSystem.kind === E2eeType.NONE) return undefined;
 

--- a/src/state/CallViewModel/localMember/HomeserverConnected.ts
+++ b/src/state/CallViewModel/localMember/HomeserverConnected.ts
@@ -31,11 +31,6 @@ import { type ObservableScope } from "../../ObservableScope";
 import { type Behavior } from "../../Behavior";
 import { type NodeStyleEventEmitter } from "../../../utils/test";
 
-/**
- * Logger instance (scoped child) for homeserver connection updates.
- */
-const logger = rootLogger.getChild("[HomeserverConnected]");
-
 export type HomeserverDisconnectReason = "sync" | "membership" | "probablyLeft";
 
 export interface HomeserverConnected {
@@ -70,6 +65,7 @@ export function createHomeserverConnected$(
     Pick<MatrixRTCSession, "membershipStatus" | "probablyLeft">,
   gracePeriodMs?: number,
 ): HomeserverConnected {
+  const logger = rootLogger.getChild("[HomeserverConnected]");
   // Get grace period from parameter or config (default 10000ms)
   const graceMs = gracePeriodMs ?? Config.get().sync_disconnect_grace_period_ms;
 

--- a/src/state/CallViewModel/localMember/LocalTransport.ts
+++ b/src/state/CallViewModel/localMember/LocalTransport.ts
@@ -193,6 +193,7 @@ export const createLocalTransport$ = ({
           roomId,
           client,
           delayId ?? undefined,
+          logger,
         );
       } catch (e) {
         logger.error(
@@ -312,7 +313,7 @@ async function doOpenIdAndJWTFromUrl(
   > &
     OpenIDClientParts,
   delayId?: string,
-  logger: Logger,
+  logger?: Logger,
 ): Promise<LocalTransportWithSFUConfig> {
   const sfuConfig = await getSFUConfigWithOpenID(
     client,

--- a/src/state/CallViewModel/localMember/LocalTransport.ts
+++ b/src/state/CallViewModel/localMember/LocalTransport.ts
@@ -25,7 +25,7 @@ import {
   switchMap,
   tap,
 } from "rxjs";
-import { logger as rootLogger } from "matrix-js-sdk/lib/logger";
+import { logger as rootLogger, type Logger } from "matrix-js-sdk/lib/logger";
 import { AutoDiscovery } from "matrix-js-sdk/lib/autodiscovery";
 import { type CallMembershipIdentityParts } from "matrix-js-sdk/lib/matrixrtc/EncryptionManager";
 
@@ -45,8 +45,6 @@ import {
 import { areLivekitTransportsEqual } from "../remoteMembers/MatrixLivekitMembers.ts";
 import { customLivekitUrl } from "../../../settings/settings.ts";
 import { RtcTransportAutoDiscovery } from "./RtcTransportAutoDiscovery.ts";
-
-const logger = rootLogger.getChild("[LocalTransport]");
 
 /*
  * It figures out “which LiveKit focus URL/alias the local user should use,”
@@ -140,9 +138,14 @@ export const createLocalTransport$ = ({
   forceJwtEndpoint,
   delayId$,
 }: Props): LocalTransport => {
+  const logger = rootLogger.getChild("[LocalTransport]");
   // The LiveKit transport in use by the oldest RTC membership. `null` when the
   // oldest member has no such transport.
-  const oldestMemberTransport$ = observerOldestMembership$(scope, memberships$);
+  const oldestMemberTransport$ = observerOldestMembership$(
+    scope,
+    memberships$,
+    logger,
+  );
 
   const transportDiscovery = new RtcTransportAutoDiscovery({
     client: client,
@@ -209,6 +212,7 @@ export const createLocalTransport$ = ({
       client,
       ownMembershipIdentity,
       roomId,
+      logger,
     );
   }
 
@@ -248,6 +252,7 @@ export const createLocalTransport$ = ({
 function observerOldestMembership$(
   scope: ObservableScope,
   memberships$: Behavior<Epoch<CallMembership[]>>,
+  logger: Logger,
 ): Behavior<LivekitTransportConfig | null> {
   return scope.behavior<LivekitTransportConfig | null>(
     memberships$.pipe(
@@ -307,6 +312,7 @@ async function doOpenIdAndJWTFromUrl(
   > &
     OpenIDClientParts,
   delayId?: string,
+  logger: Logger,
 ): Promise<LocalTransportWithSFUConfig> {
   const sfuConfig = await getSFUConfigWithOpenID(
     client,
@@ -337,6 +343,7 @@ function observeLocalTransportForOldestMembership(
     OpenIDClientParts,
   ownMembershipIdentity: CallMembershipIdentityParts,
   roomId: string,
+  logger: Logger,
 ): LocalTransport {
   // Ensure we can authenticate with the SFU.
   const authenticatedOldestMemberTransport$ = oldestMemberTransport$.pipe(
@@ -355,6 +362,7 @@ function observeLocalTransportForOldestMembership(
           roomId,
           client,
           undefined,
+          logger,
         ),
       ).pipe(
         catchError((e: unknown) => {

--- a/src/state/CallViewModel/remoteMembers/MatrixMemberMetadata.ts
+++ b/src/state/CallViewModel/remoteMembers/MatrixMemberMetadata.ts
@@ -22,8 +22,6 @@ import {
 } from "../../../utils/displayname";
 import { type Behavior } from "../../Behavior";
 
-const logger = rootLogger.getChild("[MatrixMemberMetadata]");
-
 export type RoomMemberMap = Map<
   string,
   Pick<RoomMember, "userId" | "getMxcAvatarUrl" | "rawDisplayName">
@@ -67,6 +65,7 @@ export const memberDisplaynames$ = (
   memberships$: Behavior<Pick<CallMembership, "userId">[]>,
   roomMembers$: Behavior<RoomMemberMap>,
 ): Behavior<Map<string, string>> => {
+  const logger = rootLogger.getChild("[MatrixMemberMetadata]");
   // This map tracks userIds that at some point needed disambiguation.
   // This is a memory leak bound to the number of participants.
   // A call application will always increase the memory if there have been more members in a call.


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please read CONTRIBUTING.md before you start. -->

## Content

Fix missing logs in rageshakes. (yes there was another issue, the first one was using the same rageshake db as EW)
The issue:
 - rageshake loggers are setup on the root logger via the rageshakes file `init()` method.
 - files that used `const logger = rootLogger.getChild("[childscopename]");` often executed before the init call.
 - so the `logger` would be created before the parent logger got configured to use the rageshake log extension.
 - we ended up missing a large amount of logs

## Motivation and context

We need those logs. This Issue revealed the missing logs:
https://github.com/element-hq/element-call/pull/4087
(we first got locally recorded logs from android via logcat and then a rageshake.)

## Tests
uploaded logs before this change:
https://github.com/element-hq/element-call-rageshakes/issues/16750
 - `[CallViewModel]` is missing `[CallViewModel localTransport$] Creating item with keys compatibility ...` does exisint but that is from the `item with keys` logging... not the `getChild` one

after changing some (first commit):
https://github.com/element-hq/element-call-rageshakes/issues/16754

 - `[CallViewModel][1783444309670]` exists!!
 -  but `[InCallView]` is missing

after updating all logs:
https://github.com/element-hq/element-call-rageshakes/issues/16755
 -  we should have all logs now. including `[InCallView]` (only gets logged on fatal errors so not visible in rageshake)
## Checklist

- [ ] A linked, pre-approved issue exists for this feature or UI change.
- [ ] I have read [CONTRIBUTING.md](https://github.com/element-hq/element-call/blob/livekit/CONTRIBUTING.md) in full.
- [ ] Pull request includes screenshots or videos for any UI changes.
- [ ] Tests written for new code (and existing touched code where feasible).
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-call)
