### PR TITLE
fix: Safari preview tile no video is 16px wide only

### DIFF
--- a/src/room/VideoPreview.module.css
+++ b/src/room/VideoPreview.module.css
@@ -10,6 +10,7 @@ Please see LICENSE in the repository root for full details.
   margin-right: var(--content-inset-right);
   min-block-size: 0;
   block-size: 50vh;
+  aspect-ratio: 16 / 9;
   border-radius: var(--cpd-space-4x);
   position: relative;
   overflow: hidden;
@@ -64,12 +65,6 @@ video.mirror {
     rgba(0, 0, 0, 0) 0%,
     var(--cpd-color-bg-canvas-default) 100%
   );
-}
-
-@media (min-aspect-ratio: 1 / 1) {
-  .preview > video {
-    aspect-ratio: 16 / 9;
-  }
 }
 
 @media (max-width: 550px) {

--- a/src/room/VideoPreview.module.css
+++ b/src/room/VideoPreview.module.css
@@ -11,6 +11,7 @@ Please see LICENSE in the repository root for full details.
   min-block-size: 0;
   block-size: 50vh;
   aspect-ratio: 16 / 9;
+  max-width: 100%;
   border-radius: var(--cpd-space-4x);
   position: relative;
   overflow: hidden;


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please read CONTRIBUTING.md before you start. -->

fixes https://github.com/element-hq/element-call/issues/4124

There is a behavior change when the screen with get smaller, just before switching to mobile layout

<img width="739" height="341" alt="image" src="https://github.com/user-attachments/assets/81699cc0-15c7-488b-82da-b24d7e1de5d2" />

The right/left margin are gone.
the max-width: 100% ensures that the tile is not cropped (breaking the ratio on smaller width), but cannot maintain the margins

## Content

<!-- Describe shortly what has been changed -->

## Motivation and context

<!-- Provide a link to the pre-approved issue, or explain the context for a bug fix -->

## Screenshots / GIFs

<!--

You can use a table like this to show a before/after comparison.
Uncomment the markdown table below and fill in the last line:

|Before|After|
|-|-|
|||

-->

## Tests

<!-- Explain how you tested your changes -->

- Step 1
- Step 2
- Step ...

## Checklist

- [ ] A linked, pre-approved issue exists for this feature or UI change.
- [ ] I have read [CONTRIBUTING.md](https://github.com/element-hq/element-call/blob/livekit/CONTRIBUTING.md) in full.
- [ ] Pull request includes screenshots or videos for any UI changes.
- [ ] Tests written for new code (and existing touched code where feasible).
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-call)
