### PR TITLE
[backport] fix: FF mirrored self video lose rounding

### DIFF
--- a/src/tile/MediaView.module.css
+++ b/src/tile/MediaView.module.css
@@ -33,6 +33,9 @@ Please see LICENSE in the repository root for full details.
 
 .media.mirror video {
   transform: scaleX(-1);
+  /* In FF if you add a transform: scale/translate/matrix filter on an element,
+  it'll ignore the parents' border-radius, so force back the radius to avoid UI glitch*/
+  border-radius: inherit;
 }
 
 .media[data-video-fit="cover"] video {


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please read CONTRIBUTING.md before you start. -->

Backport of #4136

> [!IMPORTANT]
> **Features and UI changes require a pre-approved issue.**
> Every PR must have a linked issue
> that a maintainer has reviewed and approved **before you started writing code**.
> PRs that don't meet this requirement will not be reviewed.
> See [CONTRIBUTING.md](https://github.com/element-hq/element-call/blob/livekit/CONTRIBUTING.md) for ElementCall decided for this approach.

## Content

<!-- Describe shortly what has been changed -->

## Motivation and context

<!-- Provide a link to the pre-approved issue, or explain the context for a bug fix -->

## Screenshots / GIFs

<!--

You can use a table like this to show a before/after comparison.
Uncomment the markdown table below and fill in the last line:

|Before|After|
|-|-|
|||

-->

## Tests

<!-- Explain how you tested your changes -->

- Step 1
- Step 2
- Step ...

## Checklist

- [ ] A linked, pre-approved issue exists for this feature or UI change.
- [ ] I have read [CONTRIBUTING.md](https://github.com/element-hq/element-call/blob/livekit/CONTRIBUTING.md) in full.
- [ ] Pull request includes screenshots or videos for any UI changes.
- [ ] Tests written for new code (and existing touched code where feasible).
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-call)
